### PR TITLE
fix(eval): trigger lazy MCP tool build before the runtime readiness guard

### DIFF
--- a/src/evaluation/qa/runtime.py
+++ b/src/evaluation/qa/runtime.py
@@ -382,10 +382,17 @@ class ArchiAgentRuntime:
             default_provider=chat["default_provider"],
             default_model=chat["default_model"],
         )
-        if "mcp" in self._selected_tool_names and not pipeline.loaded_mcp_tools:
-            raise RuntimeError(
-                "agent spec selected 'mcp', but no MCP tools were loaded"
-            )
+        if "mcp" in self._selected_tool_names:
+            # A pipeline may bind its MCP sessions lazily, on the first agent
+            # refresh. Trigger that build before the guard reads the result, or
+            # every lazily-loading pipeline fails here on tools that would have
+            # loaded.
+            if hasattr(pipeline, "refresh_agent"):
+                pipeline.refresh_agent(force=True)
+            if not pipeline.loaded_mcp_tools:
+                raise RuntimeError(
+                    "agent spec selected 'mcp', but no MCP tools were loaded"
+                )
 
         # Cache only a completely initialized runtime. A failed initialization
         # remains retryable by the next independently accounted attempt.

--- a/tests/unit/evaluation/qa/test_runtime.py
+++ b/tests/unit/evaluation/qa/test_runtime.py
@@ -522,3 +522,46 @@ def test_archi_runtime_rejects_empty_answer():
         ArchiAgentRuntime(_config(), SimpleNamespace(tools=[]), Pipeline).run(
             "question"
         )
+
+
+def test_archi_runtime_triggers_lazy_mcp_tool_build_before_the_guard():
+    """A pipeline that binds MCP sessions on its first refresh must pass the guard.
+
+    The readiness check runs right after construction, so without a forced
+    refresh it reads "not loaded yet" as "failed to load" and rejects a
+    pipeline whose tools would have loaded.
+    """
+
+    class Pipeline:
+        def __init__(self, **kwargs):
+            self.loaded_mcp_tools = []
+
+        def refresh_agent(self, force=False):
+            assert force is True
+            self.loaded_mcp_tools = ["current_capacity"]
+
+        def invoke(self, **kwargs):
+            return _Output("final answer")
+
+    agent = ArchiAgentRuntime(_config(), SimpleNamespace(tools=["mcp"]), Pipeline)
+
+    assert agent.run("question") == "final answer"
+
+
+def test_archi_runtime_still_rejects_mcp_spec_when_no_tool_loads():
+    """The guard keeps failing attempts whose refresh loads nothing."""
+
+    class Pipeline:
+        def __init__(self, **kwargs):
+            self.loaded_mcp_tools = []
+
+        def refresh_agent(self, force=False):
+            pass
+
+        def invoke(self, **kwargs):  # pragma: no cover - the guard fires first
+            return _Output("unreachable")
+
+    agent = ArchiAgentRuntime(_config(), SimpleNamespace(tools=["mcp"]), Pipeline)
+
+    with pytest.raises(RuntimeError, match="no MCP tools were loaded"):
+        agent.run("question")


### PR DESCRIPTION
Found while porting `feat/live-eval` (at bebfbe56) into the fasrc fork and running it against an agent pipeline that binds its MCP sessions lazily — full context in the defect report on #608.

**Defect.** `ArchiAgentRuntime._runtime_for_attempt` checks `pipeline.loaded_mcp_tools` immediately after constructing the pipeline. A pipeline that defers MCP session setup past `__init__` (to its first refresh/invoke) is rejected on every attempt with `agent spec selected 'mcp', but no MCP tools were loaded` — the guard reads "not loaded yet" as "failed to load".

**Fix.** Trigger the pipeline's tool build (`refresh_agent(force=True)` when the pipeline exposes it) before the guard reads the result. The guard still fails attempts whose refresh loads nothing — a second test pins that.

**Tests.** `test_archi_runtime_triggers_lazy_mcp_tool_build_before_the_guard` (red before the fix) and `test_archi_runtime_still_rejects_mcp_spec_when_no_tool_loads`. Full `tests/unit/evaluation` suite: 289 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)