### PR TITLE
fix(eval): continue re-runs the run-frozen agent inputs, not the live files

### DIFF
--- a/src/evaluation/qa/console.py
+++ b/src/evaluation/qa/console.py
@@ -519,14 +519,17 @@ class EvaluationConsoleService:
             raise ValueError("no static or matching live question can continue")
         dataset_id = context["dataset_id"]
         profile_id = context["profile_id"]
-        agent_filename = context["agent_spec"]
+        # The run's own frozen snapshot, not the live config and agent file. An
+        # edit between the pause and the continue would otherwise swap the system
+        # under test inside one run id, with no hash change to show it. The retry
+        # path reads these same two artifacts.
         return self.job_manager.continue_process(
             job_id,
             {
                 "operation": "continue",
                 "output_dir": str(run_dir),
-                "agent_config": str(self.agent_config_path),
-                "agent_spec": str(self._agent_path(agent_filename)),
+                "agent_config": str(run_dir / "agent_config.resolved.yaml"),
+                "agent_spec": str(run_dir / "agent_spec.resolved.md"),
                 "attempts": context["attempts"],
                 "run_workers": context["run_workers"],
                 "score_workers": context["score_workers"],

--- a/tests/unit/evaluation/qa/test_jobs_history.py
+++ b/tests/unit/evaluation/qa/test_jobs_history.py
@@ -1837,3 +1837,85 @@ def test_history_does_not_follow_run_directory_symlinks(tmp_path):
     (tmp_path / "linked").symlink_to(external, target_is_directory=True)
 
     assert EvaluationHistory(tmp_path).list_runs() == []
+
+
+def test_continue_re_runs_the_frozen_agent_inputs_of_the_paused_run(
+    monkeypatch, tmp_path
+):
+    """A continue must re-run the inputs the paused run froze, not the live files.
+
+    The continue path passes the live ``agent_config_path`` and re-resolves the
+    spec from ``agents_dir``, so an edit between the pause and the continue
+    swaps the system under test inside one run id, with no new run and no hash
+    change to show it. The run directory already holds the snapshot the retry
+    path reads, so continue must read it too.
+    """
+    live_config = tmp_path / "config.yaml"
+    live_spec = tmp_path / "tested.md"
+    live_config.write_text("source: live-at-pause\n", encoding="utf-8")
+    live_spec.write_text("live spec at pause\n", encoding="utf-8")
+    service = EvaluationConsoleService(
+        tmp_path,
+        agent_config_path=live_config,
+        agents_dir=tmp_path,
+    )
+    run_dir = service.catalog.runs_dir / "workspace-frozen"
+    run_dir.mkdir(parents=True)
+    (run_dir / "agent_config.resolved.yaml").write_text(
+        "source: frozen-in-run\n", encoding="utf-8"
+    )
+    (run_dir / "agent_spec.resolved.md").write_text(
+        "frozen spec in run\n", encoding="utf-8"
+    )
+    write_json(
+        run_dir / "manifest.json",
+        {
+            "phases": {"prepare": {"prepared_items": 2}},
+            "attention_required": {"affected_item_count": 1},
+        },
+    )
+    monkeypatch.setattr(
+        service.job_manager,
+        "get",
+        lambda job_id: {
+            "id": job_id,
+            "kind": "evaluation",
+            "status": "attention_required",
+            "context": {
+                "workspace_id": "workspace-frozen",
+                "dataset_id": "approved-live",
+                "profile_id": "builtin",
+                "agent_spec": "tested.md",
+                "attempts": 2,
+                "run_workers": 1,
+                "score_workers": 1,
+            },
+        },
+    )
+    requests = []
+    monkeypatch.setattr(
+        service.job_manager,
+        "continue_process",
+        lambda job_id, request: requests.append((job_id, request))
+        or {"id": job_id, "status": "queued"},
+    )
+
+    # The operator edits both live inputs while the run sits paused.
+    live_config.write_text("source: edited-after-pause\n", encoding="utf-8")
+    live_spec.write_text("edited spec after pause\n", encoding="utf-8")
+
+    service.continue_evaluation("paused-job")
+
+    [(job_id, request)] = requests
+    assert job_id == "paused-job"
+    assert request["agent_config"] == str(run_dir / "agent_config.resolved.yaml")
+    assert request["agent_spec"] == str(run_dir / "agent_spec.resolved.md")
+    assert (
+        Path(request["agent_config"]).read_text(encoding="utf-8")
+        == "source: frozen-in-run\n"
+    )
+    assert (
+        Path(request["agent_spec"]).read_text(encoding="utf-8")
+        == "frozen spec in run\n"
+    )
+    service.job_manager.close()


### PR DESCRIPTION
Found while porting `feat/live-eval` (at bebfbe56) into the fasrc fork — full context in the defect report on #608.

**Defect.** `EvaluationConsoleService.continue_evaluation` hands the workflow the console's **live** `agent_config_path` and re-resolves the agent file from `agents_dir`. An edit to either file between the pause (`attention_required`) and the continue swaps the system under test inside one run id — same workspace, no new run, and the report's hashes still describe the original inputs.

**Fix.** Continue reads the run's own frozen snapshot — `agent_config.resolved.yaml` / `agent_spec.resolved.md` — the same two artifacts the retry path already reads.

**Repro.** Start a run with live rows → pre-run live check pauses it → edit the console's agent config → continue → the run finishes under the edited config with no visible trace.

**Test.** `test_continue_re_runs_the_frozen_agent_inputs_of_the_paused_run` (red before the fix: the request carried the live paths and the post-pause edits). Full `tests/unit/evaluation` suite: 288 passed.

Note: this composes with #614-style workspace verification — even with this fix, a direct workspace edit during the pause needs the digest check in the companion PR (resume digest verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)