### PR TITLE
fix(eval): name the generate-atoms draft in the live-row review save error

### DIFF
--- a/src/evaluation/qa/catalog.py
+++ b/src/evaluation/qa/catalog.py
@@ -200,6 +200,19 @@ class _ReviewedChildPublisher:
     ) -> Dict[str, Any]:
         if self._is_v2:
             if draft_row.get("status") != "prepared" or supplied_atoms is None:
+                if draft_row.get("status") == "skipped_time_sensitive":
+                    # A review-atoms draft skips live rows at creation, so no
+                    # hand-supplied atom can make one resolve here. Name the way
+                    # out, or the operator dead-ends on the generic message.
+                    raise ValueError(
+                        "live item "
+                        f"'{draft_row.get('item_id')}' cannot resolve in this "
+                        "draft: review-atoms drafts skip live rows. Live rows "
+                        "are materialized only in a generate-atoms draft — save "
+                        "that draft instead (its id is the generating job "
+                        "result's draft_id), or omit the live item from "
+                        "reviewed_items."
+                    )
                 raise ValueError(
                     "included draft items must resolve and contain valid atoms"
                 )

--- a/tests/unit/evaluation/qa/test_live_catalog.py
+++ b/tests/unit/evaluation/qa/test_live_catalog.py
@@ -255,3 +255,76 @@ class TestLiveCatalog:
         assert catalog.dataset_items(sibling["id"])[1].answer == {
             "lookup": {"value": 8}
         }
+
+
+def test_review_draft_save_error_points_live_items_at_the_generating_draft(tmp_path):
+    """Including a live row from a review-atoms draft must name the way out.
+
+    A review-atoms draft skips live rows at creation, so saving one can never
+    resolve. The generic "must resolve" error gives the operator no pointer to
+    the draft that does work — the generate-atoms job's own draft, whose id the
+    job result carries as ``draft_id``.
+    """
+    catalog = EvaluationCatalog(tmp_path / "catalog")
+    blob = (
+        json.dumps(
+            {
+                "schema_version": "qa-dataset-v2",
+                "items": [
+                    {
+                        "id": "static",
+                        "question": "Fixed?",
+                        "answer": "fixed",
+                        "time_sensitive": False,
+                        "expected_atoms": [
+                            {"id": "a1", "text": "The answer is fixed.", "required": True}
+                        ],
+                    },
+                    {
+                        "id": "live",
+                        "question": "Current?",
+                        "time_sensitive": True,
+                        "oracle": {
+                            "kind": "mcp",
+                            "calls": [
+                                {
+                                    "id": "lookup",
+                                    "server": "read-model",
+                                    "tool": "current",
+                                    "arguments": {},
+                                    "answer_fields": {"value": "/value"},
+                                }
+                            ],
+                        },
+                    },
+                ],
+            }
+        )
+        + "\n"
+    ).encode()
+    parent, _ = catalog.import_dataset("Parent", "parent.json", blob)
+    draft = catalog.create_atom_review_draft(parent["id"])
+    statuses = {row["item_id"]: row["status"] for row in draft["items"]}
+    assert statuses == {"static": "prepared", "live": "skipped_time_sensitive"}
+
+    # The operator answers the "at least one atom" rejection by hand-writing an
+    # atom for the skipped live row — and then hits the opaque wall this fix
+    # replaces.
+    reviewed = [
+        {
+            "item_id": row["item_id"],
+            "atoms": row["atoms"]
+            or [{"id": "hand", "text": "Hand-written for a live row.", "required": True}],
+        }
+        for row in draft["items"]
+    ]
+    with pytest.raises(ValueError, match="generate-atoms") as caught:
+        catalog.save_reviewed_dataset(
+            draft["id"],
+            "Reviewed",
+            reviewed,
+            approval_actor="manager@example.test",
+        )
+
+    assert "live" in str(caught.value)
+    assert "draft_id" in str(caught.value)


### PR DESCRIPTION
Found while running the console trial for the fasrc fork port of `feat/live-eval` (at bebfbe56) — full context in the defect report on #608. UX repair only; no behavior change for resolvable rows.

**Dead-end.** On a live (V2) dataset, `POST review-atoms` creates a draft whose live rows are silently `skipped_time_sensitive`. Trying to save one first fails with `reviewed_items[N].atoms must contain at least one atom`; hand-writing an atom for the live row then fails with the generic `included draft items must resolve and contain valid atoms` — which never says why the row cannot resolve or where the working path is. The draft that *does* work is the generate-atoms job's own draft (its id is the job result's `draft_id`), but nothing points there. This cost an operator who knows the code three failed saves; a UI-only user is walled. (`refresh-live` as a first move also fails — "requires an approved child".)

**Fix.** The publisher's save error differentiates the `skipped_time_sensitive` case and names the way out: the generating job's draft (`draft_id`), or omitting the live item from `reviewed_items`. The generic message stays for every other unresolvable case.

**Test.** `test_review_draft_save_error_points_live_items_at_the_generating_draft` — reproduces the exact operator path (V2 dataset with inline atoms on the static row, review-atoms draft, hand-written atom on the skipped live row). Full `tests/unit/evaluation` suite: 288 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)