### PR TITLE
Circle-back review fixes: false completed-scope claims, anonymizer PII leaks, hygiene

### DIFF
--- a/bundles/cern-team/source-defaults/cmssw_releases.yaml
+++ b/bundles/cern-team/source-defaults/cmssw_releases.yaml
@@ -27,11 +27,11 @@ cmssw_releases:
       edges:
         - cmssw_release supersedes cmssw_release
   source_class: reference_catalog
-  # NOTE: the archi/sources/cmssw.py docstring template says
-  # `remote_id`, but the substrate's reference_catalog profile only
-  # admits `domain_key` (deployment lint blocker
-  # deployment.source_registry.profile_invalid otherwise). The
-  # w1-scratch proven registry already used domain_key.
+  # NOTE: the substrate's reference_catalog profile only admits
+  # `domain_key` (deployment lint blocker
+  # deployment.source_registry.profile_invalid otherwise); the
+  # cmssw.py docstring template and the w1-scratch proven registry
+  # both use it.
   record_identity_kind: domain_key
   record_identity_fields: [release]
   source_revision_kind: content_hash

--- a/bundles/cern-team/source-defaults/cmssw_releases.yaml
+++ b/bundles/cern-team/source-defaults/cmssw_releases.yaml
@@ -42,7 +42,13 @@ cmssw_releases:
     map_cache_path: ${archi_data_root}/cmssw-releases/releases.map
     releases_map_url: https://raw.githubusercontent.com/cms-sw/cms-bot/master/releases.map
     fetch: true
-    limit: 300
+    # No `limit` here on purpose: the real releases.map has far more
+    # than any reasonable cap, and a cap that actually truncates makes
+    # every run forfeit its completed-scope claim (circleback-fixes
+    # finding 7) — completed_scope stays False forever, so
+    # missing_from_completed_scope deletion semantics never fire. The
+    # live demo ingested the full map fine; only set `limit` for
+    # debugging, accepting that retraction is disabled while it is set.
   sync:
     triggers: [manual, reconcile]
     default_event_mode: scope_complete

--- a/bundles/cern-team/source-defaults/indico.yaml.example
+++ b/bundles/cern-team/source-defaults/indico.yaml.example
@@ -7,9 +7,16 @@
 # To enable on an instance: rename to indico.yaml BEFORE install (or
 # paste the block into the instance's source_registry.yaml after
 # install, replacing ${...} by hand). Requires the meeting_minutes /
-# document subtypes and their narrowings — ship in the archi wheel
-# slices (operations.yaml + bridges/operations.yaml) already copied by
-# the install runbook.
+# document subtypes (in the copied operations.yaml slice) AND the
+# `meeting_minutes_contains_document` narrowing from the wheel's
+# bridges/operations.yaml — NOTE: the install runbook's pruned bridge
+# copy does NOT include it (the default prune keeps only
+# cmssw_release_supersedes_release). When enabling this connector,
+# also copy that narrowing into the instance's
+# schemas/bridges/operations.yaml, or the catalog composes green and
+# the first ingest of an event with attachments fails at ingest time
+# (ProducerPolicyViolation — narrowings outside schemas/bridges/ are
+# silently ignored, okg#1282).
 indico:
   module: archi.sources.indico
   class: IndicoSource

--- a/docs/okg-alignment.md
+++ b/docs/okg-alignment.md
@@ -64,6 +64,24 @@ for cutover. New PACT v4 note from the re-pin: `change.tier` is now mandatory
 removed from the archi_v3 line (W10 teardown pulled forward, 2026-08-21); v2
 lives on `main` until instance cutover.
 
+**Circle-back adversarial review + fixes (2026-08-24, PACT change
+`circleback-fixes`):** a four-domain adversarial review of `archi_v3` @
+`728739e6` (your pinned external-consumer baseline) found 3 blockers / 15
+majors, dominated by connectors claiming `completed_scope` after silently
+losing input — a mass-retraction hazard under `missing_from_completed_scope`.
+All confirmed blocker/major findings are fixed with per-finding regression
+tests (suite 254 → 320); ~85% of the bugs exist identically in the frozen
+canonical `okg-deployments/cms` copies (deviations recorded in the change
+dir's notes files). Two items are routed to this channel instead of patched
+locally: (1) **likely root cause for the deletion-semantics finding you are
+triaging** — no adapter ever provides `SourceRun.record_set`, and the runner
+then silently skips retraction synthesis rather than failing loudly; (2) the
+enricher derived-edge lifecycle (attrs-independent dedupe keys block
+re-derivation after any transient retraction; no evidence-based retraction) —
+both substrate-contract questions. Also relevant to the sealed-artifact
+design: bundle playbooks are symlinks escaping `bundles/`, so packaging must
+dereference (your "materialized payload" wording already covers this).
+
 ## The exact substrate surface Archi consumes today
 
 This is the de-facto interface #1181 (public connector/enricher SDK) will replace.

--- a/pact/changes/circleback-fixes/notes-catalogs.md
+++ b/pact/changes/circleback-fixes/notes-catalogs.md
@@ -1,0 +1,214 @@
+# circleback-fixes — catalog/feed connector deviations (notes-catalogs)
+
+Fixes for the confirmed adversarial-review findings in the catalog/feed
+connectors (hypernews, siteconf, cric, cmssw, conddb, dbs, dqm, gocdb,
+wmstats, indico). Each entry documents the finding, the fix, the
+behavior change, and whether the bug is shared with the frozen canonical
+okg-deployments/cms copy (`main@f33a9c4`) — where it is, the fix is a
+deliberate deviation from canonical behavior.
+
+Guiding rule for every fix: the substrate retracts records missing from
+a completed scope (`missing_from_completed_scope`), so a false
+`completed_scope` claim mass-retracts good records. Partial data with
+`completed_scope=False` is fine; claiming completeness is not.
+
+Vocabulary note: the review prescribed a "degraded" health status, but
+`okg.substrate.library.sources.base.PREFLIGHT_STATUSES` has no such
+status (closed set: ok / skipped_optional / missing_credential /
+auth_failed / tls_failed / endpoint_failed / cache_missing /
+not_applicable / acquire_stale / acquire_failed). Partial failures
+therefore follow the repo's existing docs.py/twiki.py partial-crawl
+idiom: emit the surviving records, `status="endpoint_failed"`,
+`completed_scope=False`, details in `reason`. Benign degradations
+(item skips with survivors, cap truncation) keep `status="ok"` but
+forfeit the scope claim.
+
+## 1. BLOCKER — hypernews: per-forum listing failure swallowed
+
+- **Finding:** `_fetch` caught per-forum listing errors with
+  `except Exception: continue` while `run()` reported ok +
+  `completed_scope=True`; the failed forum's threads were then
+  retracted.
+- **Fix:** `_fetch` returns a `_FetchOutcome` recording
+  `failed_forums`; any forum failure → `completed_scope=False`,
+  `status="endpoint_failed"`, failed forums named in `health.reason`
+  (endpoint_failed for all-fail too — see vocabulary note). Surviving
+  forums' threads are still emitted.
+- **Behavior change:** partial crawls no longer look healthy/complete
+  and are not persisted to the records cache (see #2).
+- **Shared with canonical:** yes — deliberate deviation.
+- **Test:** `test_hypernews.py::test_forum_listing_failure_degrades_and_never_claims_scope`
+
+## 2. BLOCKER — hypernews: total fetch failure persisted an empty cache
+
+- **Finding:** `_fetch_and_cache` wrote `records.json` even when the
+  fetch produced zero records, claiming ok/complete over zero records;
+  later runs replayed the poisoned empty cache forever.
+- **Fix:** cache writing split out (`_write_cache`) and performed only
+  after a fully successful, untruncated crawl. Total failure (all
+  forums failed, cookie unreadable, or zero threads parsed across all
+  configured forums) → `endpoint_failed`, no facts, no scope claim, no
+  cache write. A pre-existing empty/unusable cache is also refused at
+  read time (`endpoint_failed`, reason says to delete the cache to
+  force a re-fetch) instead of replaying as an empty complete scope.
+- **Behavior change:** zero-record crawls are failures, not empty
+  successes; empty caches no longer replay. A dict-shaped cache without
+  a `records` key now raises `ValueError` (was: silently read as zero
+  threads). Configuring `max_threads` now means the cache is never
+  written (a truncated snapshot must not replay as complete), so every
+  run re-fetches.
+- **Shared with canonical:** yes — deliberate deviation.
+- **Tests:** `test_hypernews.py::test_total_fetch_failure_writes_no_cache_and_fails_loud`,
+  `::test_zero_threads_across_forums_is_failure_not_empty_success`,
+  `::test_empty_cache_refuses_complete_scope`
+
+## 3. MAJOR — hypernews: failed hydration emitted a blanked record
+
+- **Finding:** `_hydrate` returned the un-hydrated listing stub on
+  fetch failure, blanking body/author and dropping chunks under a
+  complete scope.
+- **Fix:** failed hydrations return `None`, are dropped from the
+  emission, counted in `_FetchOutcome.failed_hydrations`, and force
+  `completed_scope=False` + `endpoint_failed` with the drop count in
+  `health.reason`; the partial result is not cached.
+- **Behavior change:** a transient thread-fetch failure leaves the
+  previous good record in place (no scope claim → no retraction)
+  instead of overwriting it with a blank.
+- **Shared with canonical:** yes — deliberate deviation.
+- **Test:** `test_hypernews.py::test_failed_hydration_drops_record_instead_of_blanking_it`
+
+## 4. MAJOR — siteconf: HTTP-200 empty project list → retract-all
+
+- **Finding:** preflight validated only `/api/v4/user`; a token
+  without group visibility yields an HTTP-200 *empty* project list,
+  which became ok/complete over 0 records.
+- **Fix:** (a) in `run()`, a live fetch that produces no records
+  (empty project list, or projects listed but zero SITECONF records
+  parsed) → `endpoint_failed`, no facts, no scope claim; (b) preflight
+  now also probes `/api/v4/groups/<id>/projects?per_page=1` —
+  401/403 → `auth_failed`, empty/non-list/HTTP>=400 →
+  `endpoint_failed`.
+- **Behavior change:** a token that can log in but cannot see the
+  SITECONF group now fails preflight and can never produce an empty
+  completed scope.
+- **Shared with canonical:** yes — deliberate deviation.
+- **Tests:** `test_siteconf.py::test_empty_project_list_fails_loud_instead_of_empty_scope`,
+  `::test_zero_parsed_records_from_projects_fails_loud`,
+  `::test_preflight_group_probe_flags_invisible_group`
+
+## 5. MAJOR — cric: error-shaped responsibilities cache read as empty
+
+- **Finding:** the responsibilities payload was read as
+  `.get("result", [])`, so an error-shaped/drifted cache silently meant
+  "no responsibilities" under ok/complete (retracting all operators).
+- **Fix:** `_responsibilities_result` requires a dict with a `result`
+  list and raises `ValueError` otherwise (run fails loudly; the
+  matching top-level-shape checks in the sibling sources also raise).
+  `CRICSource.preflight` catches the drift and reports
+  `endpoint_failed` instead of raising.
+- **Behavior change:** a drifted responsibilities cache aborts the run
+  instead of emptying the operator set.
+- **Shared with canonical:** yes — deliberate deviation.
+- **Test:** `test_cric.py::test_drifted_responsibilities_payload_fails_loud`
+
+## 6. MAJOR systemic — item-level parse loops silently skipped records
+
+- **Finding:** cmssw, conddb, dbs, dqm, gocdb, wmstats, indico, and
+  hypernews (cache path) skipped non-dict/missing-key items with
+  `continue`; schema drift could turn a full cache into zero records
+  under a healthy completed-scope run.
+- **Fix:** each `_records()` loop now counts skips
+  (`_records_with_skips` / `_records_with_details`); a new shared
+  policy helper `archi/sources/_cache_report.py::skipped_items_status`
+  (plus a `skipped_count` parameter on `cache_source_health`)
+  implements: any skipped item → `completed_scope=False` with the skip
+  count in `health.reason` (status stays ok when survivors exist);
+  zero parsed records from a non-empty payload →
+  `status="endpoint_failed"`. Per-item tolerance is kept — one bad
+  record still never fails the run. Indico's duplicate-event dedup is
+  deliberately *not* counted as a skip (the record is still
+  represented). GoCDB additionally counts (rather than crashes on)
+  non-numeric `downtime_id` values.
+- **Behavior change:** drifted caches degrade loudly instead of
+  silently retracting; `skipped_items_status` is a new helper absent
+  from the canonical `_cache.py`.
+- **Shared with canonical:** yes — deliberate deviation.
+- **Tests:** `test_{cmssw,conddb,dbs,dqm,gocdb,wmstats,indico,hypernews}.py::test_skipped_cache_items_never_claim_scope`
+  (hypernews: `test_cache_skips_unparseable_items_without_scope_claim`)
+  and `::test_all_items_unparseable_is_endpoint_failed` per family.
+
+## 7. MINOR — caps truncate while claiming complete scope
+
+- **Finding:** cmssw `limit`, hypernews `max_threads`, siteconf
+  `max_projects` truncate to the newest/first N while claiming
+  complete scope — a sliding retention window where each upstream
+  append retracts the oldest in-window record.
+- **Fix:** each source now detects when its cap actually truncated
+  (`_records_from_map` compares against the full parse;
+  `_parse_threads`/`_list_projects` report a truncation flag) and
+  forfeits the scope claim with the cap named in `health.reason`.
+  A cap that does not truncate keeps the claim.
+- **Behavior change:** capped runs are cursor-style updates, never
+  scope authorities; hypernews additionally stops caching truncated
+  crawls (see #2).
+- **Shared with canonical:** yes — deliberate deviation
+  (cmssw `limit` is archi-W1-only; the truncation-forfeits-scope rule
+  itself is the deviation for hypernews/siteconf).
+- **Tests:** `test_cmssw.py::test_limit_truncation_never_claims_scope`,
+  `test_hypernews.py::test_max_threads_truncation_never_claims_scope`,
+  `test_siteconf.py::test_max_projects_truncation_never_claims_scope`
+
+## 8. MINOR — conddb: change probe missed cmssw_records_path
+
+- **Finding:** the change probe covered only `records_path`, but
+  `run()` also reads `cmssw_records_path` (release-target gating); a
+  cmssw-cache update changed emitted facts without firing the probe.
+- **Fix:** the probe's path set and config now include
+  `cmssw_records_path` (the probe tolerates a missing file). The
+  `cache_paths` property is deliberately unchanged: it defines this
+  source's own record authority for preflight and `content_hash`,
+  and the cmssw cache is optional (a missing file would make
+  `content_hash` raise and preflight report `cache_missing`).
+- **Behavior change:** editing the cmssw cache now busts the conddb
+  probe token.
+- **Shared with canonical:** yes — deliberate deviation.
+- **Test:** `test_conddb.py::test_change_probe_covers_cmssw_cache`
+
+## 9. MINOR — gocdb: scheme-prefixed endpoint host parse
+
+- **Finding:** `endpoint.split("/", 1)[0].split(":", 1)[0]` turned
+  `https://host.cern.ch:8443/path` into `https:`, silently breaking
+  hostname → service `affects` matching.
+- **Fix:** new `_endpoint_host` uses `urllib.parse.urlparse(...)
+  .hostname` when a scheme is present; bare `host[:port][/path]`
+  endpoints keep the original split (canonical behavior preserved for
+  the schemeless case).
+- **Behavior change:** scheme-prefixed endpoints now produce
+  `affects` edges; a `https:` key no longer pollutes the lookup.
+- **Shared with canonical:** yes — deliberate deviation.
+- **Test:** `test_gocdb.py::test_scheme_prefixed_endpoint_maps_hostname_to_service`
+
+## 10. MINOR — indico: chunk node_id collisions across events
+
+- **Finding:** chunk `node_id` was a content hash of the chunk text
+  alone, so identical boilerplate in different events collided onto
+  one node with contradictory parents.
+- **Fix:** chunk ids are salted with the parent document node id +
+  chunk index (`chunk:sha256(f"{doc_id}\0{index}\0{text}")[:16]`,
+  hypernews-pattern literal backslash-zero separator).
+  `content_sha256` still hashes the text alone.
+- **Behavior change:** **all indico chunk node ids change — expect a
+  one-time churn (retract old ids / insert new ids) on the next
+  re-ingest of any deployment carrying indico chunks.** Cross-event
+  dedup of identical boilerplate is intentionally given up in favor of
+  parent-correct provenance.
+- **Shared with canonical:** yes — deliberate deviation.
+- **Test:** `test_indico.py::test_identical_pdf_text_in_different_events_gets_distinct_chunks`
+
+## Explicitly not attempted
+
+- `SourceRun.record_set` plumbing (review finding "C3") — substrate-side
+  coordination, out of scope for this change.
+- No files outside the catalog/feed domain were touched (no docs.py /
+  monit.py / jira.py / twiki.py, no enrichment/, no
+  docs/okg-alignment.md — the okg import surface is unchanged).

--- a/pact/changes/circleback-fixes/notes-catalogs.md
+++ b/pact/changes/circleback-fixes/notes-catalogs.md
@@ -205,10 +205,69 @@ forfeit the scope claim.
 - **Shared with canonical:** yes — deliberate deviation.
 - **Test:** `test_indico.py::test_identical_pdf_text_in_different_events_gets_distinct_chunks`
 
+## Round-2 review deltas (same discipline, same branch)
+
+An independent adversarial review of the merged wave confirmed the
+fixes hold and surfaced these deltas, fixed here:
+
+- **MAJOR — cmssw releases.map zero-parse (extends finding 6):**
+  `parse_releases_map` filtered unparseable lines uncounted, so a
+  non-empty map whose every line failed the label pattern (e.g. a
+  `label=` key rename) still claimed ok + `completed_scope=True` over
+  zero records — in the exact mode the shipped cern-team bundle uses.
+  The map parser now counts filtered lines as skips
+  (`_parse_map_with_skips`): survivors forfeit the scope claim, and
+  zero parsed from a non-empty map is `endpoint_failed`.
+  Shared with canonical: no (the releases.map mode is archi-W1-only).
+  Tests: `test_cmssw.py::test_map_skipped_lines_never_claim_scope`,
+  `::test_map_zero_parse_from_nonempty_map_is_endpoint_failed`.
+- **MINOR — cern-team bundle default `limit: 300` removed
+  (consequence of finding 7):** the real releases.map has far more
+  than 300 releases, so the default install would truncate every run,
+  leaving `completed_scope` permanently False and deletion semantics
+  permanently disabled. The bundle now ships without a limit (the live
+  demo ingested the full map fine); the yaml comments why.
+  File: `bundles/cern-team/source-defaults/cmssw_releases.yaml`.
+- **MINOR — siteconf group probe missed `include_subgroups=true`
+  (extends finding 4):** the new preflight group probe listed only
+  direct group projects while the crawl includes subgroups, so a group
+  whose projects live only in subgroups got a false-negative preflight
+  that permanently blocked `run()`. The probe now mirrors the crawl's
+  listing parameters. Test:
+  `test_siteconf.py::test_preflight_group_probe_includes_subgroups_like_the_crawl`.
+- **LOW — hypernews preflight vs run() on an empty cache (extends
+  finding 2):** preflight reported ok/record_count=0 for an empty
+  well-formed cache that run() then refused with `endpoint_failed`.
+  Preflight now returns the same `endpoint_failed` refusal (shared
+  `_empty_cache_reason`). Test:
+  `test_hypernews.py::test_preflight_empty_cache_matches_run_refusal`.
+- **Coverage — hypernews live happy path:** added the missing test
+  that a clean multi-forum crawl reports ok + `completed_scope=True`,
+  persists the records cache, and a second run replays that cache and
+  still claims scope.
+  Test: `test_hypernews.py::test_clean_live_crawl_claims_scope_writes_cache_and_replays`.
+
+### Empty-cache asymmetry (recorded rationale, no code change)
+
+The reviewer flagged that dbs/conddb/wmstats/dqm/gocdb/indico still
+claim a complete *empty* scope when their cache is an explicitly-empty
+(`[]`) file, unlike hypernews's new refusal. This asymmetry is
+intentional: those catalog caches are operator/fetcher-authored inputs
+— the authority over "this catalog is currently empty" lies outside
+the connector, so an explicitly-empty file is a legitimate statement
+of scope (and preflight already surfaces it as `skipped_optional`
+where the cache is optional). HyperNews, by contrast, writes its own
+cache from its own crawl, so an empty file there is by construction a
+crawl failure artifact (self-poisoning risk), never an operator
+statement — hence the stricter refusal rule applies only there.
+
 ## Explicitly not attempted
 
 - `SourceRun.record_set` plumbing (review finding "C3") — substrate-side
   coordination, out of scope for this change.
 - No files outside the catalog/feed domain were touched (no docs.py /
   monit.py / jira.py / twiki.py, no enrichment/, no
-  docs/okg-alignment.md — the okg import surface is unchanged).
+  docs/okg-alignment.md — the okg import surface is unchanged). The
+  round-2 deltas additionally touched
+  `bundles/cern-team/source-defaults/cmssw_releases.yaml` (the cmssw
+  connector's shipped default), per the reviewer's direction.

--- a/pact/changes/circleback-fixes/notes-enrichment.md
+++ b/pact/changes/circleback-fixes/notes-enrichment.md
@@ -10,7 +10,9 @@ coordination there too.
 
 Verification for every entry:
 `/work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests/enrichment/ -q`
-(35 passed).
+(36 passed). A second independent adversarial review confirmed findings
+1-6 hold and produced the deltas recorded in "Second-review deltas"
+below.
 
 ## 1. Email redaction left local-part fragments (MAJOR)
 
@@ -45,7 +47,9 @@ Verification for every entry:
   named entities `&amp; &apos; &quot; &commat;`. References that would
   decode to `<` or `>` are left encoded, so the markup pass sees
   unchanged tag structure and the author-element regexes keep their
-  offsets/behavior.
+  offsets/behavior. Normalization iterates to a fixpoint (bounded at 3
+  passes) so double-encoded forms (`jdoe&amp;#64;cern.ch`,
+  `John&amp;nbsp;Doe`) are fully decoded too (second-review delta 1).
 - **Behavior change:** encoded occurrences of names/emails are redacted
   like their plain forms. Output text now carries decoded entities
   (`R&amp;D` → `R&D`, NBSP → space) — a visible normalization of the
@@ -84,19 +88,25 @@ Verification for every entry:
   CMSCOMPPR-1.").
 - **Fix:** greetings now require an actual greeting word
   (`hi|hello|hey|greetings|dear|ciao|salut|hiya|howdy|good morning/…`;
-  v2-compatible prefix semantics for those words, the bare `^\w+,` rule
-  is gone). Sign-offs must be the entire line: the phrase, optional
-  punctuation, and at most a short (≤4-word) trailing name introduced
-  by punctuation.
+  the bare `^\w+,` rule is gone) AND the line must be short — greeting
+  word plus at most four trailing words (second-review delta 2a, which
+  found the pure word-list rule still deleted greeting-prefixed
+  operational sentences like "Good morning update: transfers to
+  T2_US_MIT stuck"). Sign-offs must be the entire line: the phrase,
+  optional punctuation, and at most a short (≤4-word) trailing name
+  introduced by punctuation.
 - **Behavior change:** operational lines that merely start with a
-  comma'd word or a sign-off word survive; real greeting/sign-off lines
-  (including new phrases: `thanks in advance`, `take care`, `hth`, …)
-  are still stripped. Lines like a bare salutation name ("John,") are
-  no longer caught by the greeting filter — names are the
-  known_names/NER layer's job. Callers passing custom
-  `greeting_patterns`/`signoff_patterns` are unaffected.
+  comma'd word, a greeting word, or a sign-off word survive; real
+  greeting/sign-off lines (including new phrases: `thanks in advance`,
+  `take care`, `hth`, …) are still stripped. Greeting deletion is now
+  stricter than v2 even for the original greeting words: a long
+  greeting-prefixed sentence survives where v2 deleted it. Lines like a
+  bare salutation name ("John,") are no longer caught by the greeting
+  filter — names are the known_names/NER layer's job. Callers passing
+  custom `greeting_patterns`/`signoff_patterns` are unaffected.
 - **Tests:**
-  `test_anonymizer.py::test_operational_lines_survive_greeting_signoff_filters`
+  `test_anonymizer.py::test_operational_lines_survive_greeting_signoff_filters`,
+  `test_anonymizer.py::test_greeting_prefixed_operational_lines_survive`,
   and `test_anonymizer.py::test_real_greetings_and_signoffs_still_stripped`
 - **shared_with_canonical:** yes — both default pattern sets came from
   the v2 base-config template; v2 deployments destroy the same
@@ -169,6 +179,33 @@ Verification for every entry:
   catalog change, coordinated with its consumers.
 - **shared_with_canonical:** yes — the pattern is the canonical
   okg-deployments catalog entry; the fix belongs upstream.
+
+## Second-review deltas
+
+An independent adversarial review of the fixes above confirmed they
+hold (the leak tests fail on pre-fix code) and raised three deltas:
+
+1. **FIXED — double-encoded PII survived one normalization pass**
+   (MINOR): `jdoe&amp;#64;cern.ch` peeled to `jdoe&#64;cern.ch` and
+   leaked; likewise `John&amp;nbsp;Doe`. `_normalize_encodings` now
+   iterates to a fixpoint, bounded at 3 passes (folded into entry 2
+   above). Tests: double-encoded cases in
+   `test_anonymizer.py::test_encoded_and_nbsp_variants_redacted`.
+2. **FIXED — greeting word-list deleted content-bearing lines**
+   (MINOR): "Good morning update: transfers to T2_US_MIT stuck" was
+   deleted whole. The greeting rule now only deletes short greeting
+   lines — greeting word + at most four trailing words (folded into
+   entry 4 above). Test:
+   `test_anonymizer.py::test_greeting_prefixed_operational_lines_survive`.
+3. **ACCEPTED privacy-over-recall tradeoffs (no behavior change):**
+   - "Thanks, fixed." is deleted by the sign-off rule's ≤4-word tail:
+     without NER the tail cannot be reliably told apart from a trailing
+     name ("Thanks, Fabio."), so the deterministic filter keeps erring
+     toward redaction.
+   - mailto anchors are removed whole even when the anchor text is
+     non-PII ("cms-comp-ops list archive"): the anchor text of a mailto
+     link may itself be a person's name, and without NER there is no
+     reliable way to distinguish, so the whole element goes.
 
 ## Residual (out of the reviewed findings' scope)
 

--- a/pact/changes/circleback-fixes/notes-enrichment.md
+++ b/pact/changes/circleback-fixes/notes-enrichment.md
@@ -1,0 +1,180 @@
+# circleback-fixes: enrichment stack behavior changes
+
+Fixes for the confirmed adversarial-review findings in
+`python/archi/enrichment/` (branch `cb-fix-enrichment`, base
+`728739e6`). Each entry: the finding, the fix, the resulting behavior
+change, and whether the changed behavior is shared with v2/canonical
+(`shared_with_canonical`) — i.e. whether the same defect exists in the
+v2 anonymizer defaults or the okg-deployments port source and needs
+coordination there too.
+
+Verification for every entry:
+`/work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests/enrichment/ -q`
+(35 passed).
+
+## 1. Email redaction left local-part fragments (MAJOR)
+
+- **Finding:** `anonymizer.py` default email pattern
+  (`[\w\.-]+@[\w\.-]+\.\w+`) covered only the RFC-simple core:
+  `john.doe+ops@cern.ch` left `john.doe+` behind (the name),
+  `o'brien@cern.ch` left `o'`, and percent-encoded addresses in URLs
+  (`mail=john.doe%40cern.ch`) were untouched.
+- **Fix:** `_DEFAULT_EMAIL_PATTERN` now matches quoted local parts and
+  RFC-5322 atext (`+` tags, apostrophes, `%`-encoded octets) and
+  accepts `%40` as the separator. URL-structural characters (`/ = ?`)
+  are deliberately excluded from the local-part class so a surrounding
+  URL path/query is not swallowed.
+- **Behavior change:** addresses that previously left local-part
+  fragments are now removed whole; `%40`-form addresses inside URLs are
+  now redacted (the rest of the URL survives). Callers passing a custom
+  `email_pattern` are unaffected.
+- **Test:** `test_anonymizer.py::test_email_local_part_never_leaks_fragments`
+- **shared_with_canonical:** yes — the default pattern was lifted
+  verbatim from the v2 base-config template (`dev@28b977d1`); v2
+  deployments leak the same fragments.
+
+## 2. Encoded/NBSP variants bypassed discovery-vs-replacement (MAJOR)
+
+- **Finding:** name discovery ran on unescaped text while replacement
+  ran on the raw input, so `John&nbsp;Doe`, `John\xa0Doe`, and
+  `jdoe&#64;cern.ch` survived both the name and email passes.
+- **Fix:** new `_normalize_encodings()` runs at the top of both
+  `anonymize()` and `anonymize_markup()`, before discovery and every
+  redaction pass: decodes NBSP (U+00A0, `&nbsp;`, `&#160;`), numeric
+  character references (`&#64;`/`&#x40;` → `@`, ...), and the safe
+  named entities `&amp; &apos; &quot; &commat;`. References that would
+  decode to `<` or `>` are left encoded, so the markup pass sees
+  unchanged tag structure and the author-element regexes keep their
+  offsets/behavior.
+- **Behavior change:** encoded occurrences of names/emails are redacted
+  like their plain forms. Output text now carries decoded entities
+  (`R&amp;D` → `R&D`, NBSP → space) — a visible normalization of the
+  emitted text surface. `&lt;`/`&gt;` remain encoded.
+- **Test:** `test_anonymizer.py::test_encoded_and_nbsp_variants_redacted`
+- **shared_with_canonical:** yes for the text pass (v2's `anonymize`
+  has the same discovery/replacement mismatch via its NER path); the
+  markup-pass plumbing it also protects is v3-new.
+
+## 3. NER-off author formats outside four markup shapes leaked (MAJOR)
+
+- **Finding:** in NER-disabled mode (the deterministic connector mode),
+  only four hardcoded markup shapes were stripped. Leaked: non-CDATA
+  `<dc:creator>Name</dc:creator>`, `<a href="mailto:...">John Doe</a>`
+  anchor text, and TWiki signatures `-- Main.JohnDoe - 2024-01-15`.
+- **Fix:** three new patterns — `_DC_CREATOR_PLAIN_RE` (dc:creator with
+  or without CDATA, applied after the verbatim CDATA rule),
+  `_DEFAULT_MARKUP_MAILTO_LINK_RE` (removes the whole mailto anchor,
+  whose href the email pass has already emptied), and
+  `_TWIKI_SIGNATURE_RE` (`-- Main.WikiWord [- date]` lines, also
+  `TWiki.WikiWord`), the last applied in both the text and markup
+  passes since TWiki signatures appear in plain topic text.
+- **Behavior change:** those three author formats are now redacted with
+  NER off (and on). dc:creator elements are emptied, mailto anchors
+  removed entirely, signature lines dropped.
+- **Test:** `test_anonymizer.py::test_ner_off_author_shapes_redacted`
+- **shared_with_canonical:** no — the markup/NER-off/known_names
+  machinery is v3-new (v2 always ran spaCy NER).
+
+## 4. Greeting/sign-off filters destroyed operational content (MAJOR)
+
+- **Finding:** the default greeting rule `^\w+,` deleted any line whose
+  first word had a trailing comma ("However, run 381000 was affected
+  badly."), and the sign-off rule prefix-matched content lines
+  ("Regards to whoever fixed run 381000", "Thank you note was filed as
+  CMSCOMPPR-1.").
+- **Fix:** greetings now require an actual greeting word
+  (`hi|hello|hey|greetings|dear|ciao|salut|hiya|howdy|good morning/…`;
+  v2-compatible prefix semantics for those words, the bare `^\w+,` rule
+  is gone). Sign-offs must be the entire line: the phrase, optional
+  punctuation, and at most a short (≤4-word) trailing name introduced
+  by punctuation.
+- **Behavior change:** operational lines that merely start with a
+  comma'd word or a sign-off word survive; real greeting/sign-off lines
+  (including new phrases: `thanks in advance`, `take care`, `hth`, …)
+  are still stripped. Lines like a bare salutation name ("John,") are
+  no longer caught by the greeting filter — names are the
+  known_names/NER layer's job. Callers passing custom
+  `greeting_patterns`/`signoff_patterns` are unaffected.
+- **Tests:**
+  `test_anonymizer.py::test_operational_lines_survive_greeting_signoff_filters`
+  and `test_anonymizer.py::test_real_greetings_and_signoffs_still_stripped`
+- **shared_with_canonical:** yes — both default pattern sets came from
+  the v2 base-config template; v2 deployments destroy the same
+  operational lines.
+
+## 5. `rules_files=None/[]` suppressed the packaged rule (MINOR)
+
+- **Finding:** `declarative.py` used a key-presence check, so
+  `GlobalTagReleaseLinker(rules_files=None)` (or `[]`) suppressed the
+  packaged default and silently loaded all 104 substrate ontology rules
+  under the cms linker name.
+- **Fix:** None/empty `rules`/`rules_files`/`rules_dir` are treated as
+  absent: the falsy keys are dropped and the packaged
+  `global_tag_release.yaml` is used. Non-empty caller sources still
+  win.
+- **Behavior change:** deployment configs that render optional keys as
+  null/empty now get the one packaged rule instead of the full
+  substrate rule set.
+- **Tests:**
+  `test_defaults.py::test_global_tag_release_linker_treats_empty_rule_sources_as_absent`
+  and `test_defaults.py::test_global_tag_release_linker_honors_explicit_rule_sources`
+- **shared_with_canonical:** no — the packaged-default fallback is
+  v3-new (the okg-deployments original hardcoded a deployment-relative
+  path and had no such guard).
+
+## 6. Dataset alias case-folding + unbounded negative cache (MINOR)
+
+- **Finding:** `alias.py` `_norm()` lowercased dataset keys, so
+  case-distinct canonical ids (`/A/B/RAW` vs `/a/b/raw`) collapsed to
+  whichever loaded last; and `_resolve_dataset` cached every miss
+  forever (a cache that memoized nothing — its fallback lookup hit the
+  same index).
+- **Fix:** dataset matching is exact-case; misses are no longer cached
+  (`_dataset_by_value` holds only live nodes, so it is bounded by the
+  live dataset population). Per-type case policy:
+  - `cms_dataset` — **case-sensitive**: DBS dataset paths are
+    case-sensitive identifiers; folding merges distinct datasets.
+  - `cms_site`, `cmssw_release`, `cms_jira_key`, `global_tag`,
+    `cms_run_number`, `cms_workflow`, `cms_hostname`/endpoints —
+    **case-insensitive**: canonical forms are unique up to case and
+    human transcription varies it (`t2_us_mit`, `cmssw_15_0_15`,
+    `EOSCMS.cern.ch`), so case is noise, not identity.
+- **Behavior change:** case-mismatched dataset mentions no longer
+  resolve (previously they resolved, sometimes to the wrong node);
+  memory no longer grows with unresolved dataset mentions.
+- **Tests:** `test_alias.py::test_dataset_alias_is_case_sensitive`,
+  `test_alias.py::test_non_dataset_matching_stays_case_insensitive`,
+  `test_alias.py::test_dataset_misses_are_not_cached`
+- **shared_with_canonical:** yes — both defects are verbatim from the
+  port source (`cms/cms_sources/alias.py`, okg-deployments
+  `main@f33a9c4`); the fix should be coordinated upstream.
+
+## 7. Catalog `cms_run_number` pattern is context-free (NOTE-ONLY)
+
+- **Finding:** `defaults/identifier_patterns.yaml` carries
+  `\b[1-9][0-9]{5,6}\b` for `cms_run_number` — any bare 6/7-digit
+  number matches. The packaged extraction rule kept a `run` context
+  anchor (`\b(?:run|Run|RUN)\s*#?\s*([1-9][0-9]{5,6})\b`); the catalog
+  pattern dropped it.
+- **Decision: not fixed here.** The file is documented verbatim from
+  okg-deployments `main@f33a9c4` and is loaded by
+  `okg catalog load --apply` into `okg.identifier_patterns`, consumed
+  by okg-side extractor/MCP tools whose regex-flavor and
+  match-extraction conventions this repo does not control. The other
+  catalog patterns match the identifier itself as the whole match (no
+  capture groups); a `run`-prefixed pattern would change the matched
+  identifier text unless the consumer honors capture groups, and a
+  lookbehind workaround may not survive a non-Python regex engine
+  (e.g. Postgres POSIX). Restoring the anchor is an okg-deployments
+  catalog change, coordinated with its consumers.
+- **shared_with_canonical:** yes — the pattern is the canonical
+  okg-deployments catalog entry; the fix belongs upstream.
+
+## Residual (out of the reviewed findings' scope)
+
+- Reviewer repro G — a known name split across a line wrap
+  (`John\nDoe`) is not matched by the word-bounded single-line name
+  regex. Not in the confirmed findings list; unchanged.
+- SQL enrichers' dedupe-key re-derivation and evidence-based
+  derived-edge retraction (E5/E6) are okg-side contract items;
+  untouched per scope.

--- a/pact/changes/circleback-fixes/notes-hygiene.md
+++ b/pact/changes/circleback-fixes/notes-hygiene.md
@@ -1,0 +1,48 @@
+# Circle-back fixes — hygiene notes (schemas/bundle/playbooks reviewer)
+
+Fixed directly (no behavioral risk):
+
+1. `skills/indico.md` rewritten for the v3 runtime. The old file was v2-only:
+   it directed agents to `INDICO_*` MCP sidecar tools, `ingest_indico_event`,
+   `search_metadata_index`, the "data-manager", the "vectorstore", and a
+   hardcoded `/shared/indico-downloads/<event_id>/` volume — none of which
+   exist on a v3 OKG instance (Archi ships no MCP servers). The rewrite
+   describes what the `archi.sources.indico` connector projects into the
+   graph and how to answer Indico questions from OKG reads, including the
+   snapshot-freshness caveat. shared_with_canonical: true (the canonical
+   deployment shipped the same v2 playbook).
+
+2. `skills/source_document_exploration.md` — de-site-ification artifact
+   "`inspect`, `inspect`" corrected to "`inspect`, `aggregate`" (the
+   schema/source-shape pairing; `expand` is covered separately below it).
+
+3. `bundles/cern-team/source-defaults/cmssw_releases.yaml` — stale NOTE
+   claimed the cmssw.py docstring template says `remote_id`; the template
+   says `domain_key`. Comment corrected, substrate-constraint explanation
+   kept.
+
+4. `bundles/cern-team/source-defaults/indico.yaml.example` — the header
+   claimed its required narrowings were "already copied by the install
+   runbook"; the runbook's pruned bridge copy excludes
+   `meeting_minutes_contains_document`. The comment now states exactly
+   which narrowing must be copied additionally when enabling the
+   connector, and names the ingest-time failure otherwise (okg#1282
+   trap). The structural fix (prune list vs per-connector bridge
+   fragments) belongs to the sealed-artifact packaging wave.
+
+5. `python/archi/schemas/bridges/sources.yaml` — added the LinkML header
+   block (id/name/prefixes/imports) its sibling `bridges/operations.yaml`
+   carries; the catalog composer reads only `classes.EdgeNarrowings`, so this
+   is consistency-only (verified: parses, guard tests pass).
+
+Deliberately NOT changed (recorded for the ledger):
+
+- `bundles/cern-team/deployment-defaults.yaml` placeholder contact — a
+  documented post-install edit; making it an init question is #1179-adjacent
+  bundle work, not a bug fix.
+- Five `dataset`-subtype skill triggers with no dataset module in the
+  cern-team composition — dead-but-harmless routing; the dataset module is
+  expected with later bundles.
+- Playbook symlinks escaping the bundle dir (S3) — works in-repo; the fix
+  belongs in the sealed-artifact materialization contract (okg#1178 told:
+  materialization must dereference).

--- a/pact/changes/circleback-fixes/notes-live.md
+++ b/pact/changes/circleback-fixes/notes-live.md
@@ -1,0 +1,294 @@
+# circleback-fixes — live connectors & live tools (cb-fix-live)
+
+Fixes for the confirmed adversarial-review findings in the live-proven
+connectors (`python/archi/sources/monit.py`, `docs.py`, `jira.py`) and
+live tools (`python/archi/tools/monit.py`). Branch `cb-fix-live` off
+`728739e6`.
+
+Core discipline applied throughout: the substrate retracts records
+missing from a completed scope (`missing_from_completed_scope`), so a
+false completed-scope claim causes mass retraction. Every fix moves in
+the safe direction — **never claim `completed_scope` when any input
+failed, was truncated, capped, or is indistinguishable from an upstream
+outage**. Partial data with `completed_scope=False` is fine.
+`SourceHealth.status` values come from okg's closed vocabulary
+(`okg.substrate.library.sources.base.PREFLIGHT_STATUSES`); there is no
+`degraded`/`partial`, so degraded-but-emitting runs report
+`endpoint_failed` (the same mapping docs.py's partial-crawl path already
+used).
+
+Most fixes are deliberate deviations from the frozen canonical
+`okg-deployments/cms` copies (`cms/cms_sources/monit.py`,
+`cms/cms_sources/docs.py`, `cms/cms_sources/jira.py`,
+`cms/cms_tools/monit_live.py` at `main@f33a9c4`) — noted per finding as
+`shared_with_canonical`.
+
+---
+
+## 1. BLOCKER — rucio-dataset live page cache replays stale days forever
+
+- **Finding**: `monit.py` `_load_live_page`/`_query_fingerprint` keyed
+  the live page cache on a date-free fingerprint (hashing the literal
+  `"now-24h"`/`"now"` strings) and never invalidated entries. After one
+  successful live run, every later run replayed the cached pages with
+  zero HTTP and still claimed a completed scope: day 2 emitted day 1's
+  datasets stamped with day 2's date.
+- **Fix**: the fingerprint now includes the resolved snapshot date
+  (`_today()`), with `query_version` bumped to
+  `rucio_dataset_composite_v3` so all date-free v2 entries are
+  invalidated. Additionally each entry's stored `cached_at` is honored:
+  it must be parseable, on the same UTC day as the run's snapshot date,
+  and younger than the new `page_cache_ttl_hours` constructor/registry
+  param (default 24.0). Entries without/with corrupt `cached_at`
+  (legacy caches) never satisfy a run. Partial pages are never written
+  to the cache (see finding 2).
+- **`cache_live_pages: true` default — decision**: kept `true`,
+  documented in the module docstring and registry template. With
+  date-scoped keys + same-day TTL, the cache can only replay the
+  current snapshot day's pages, which is exactly its intended role
+  (crash/resume within a day without re-querying MONIT). Flipping the
+  default to `false` would drop that resume capability without any
+  additional safety, since cross-day replay is now impossible.
+- **Behavior change**: a new day's run always issues fresh HTTP;
+  same-day reruns still replay (resume) within the TTL; existing v2
+  cache directories become dead weight (never read) and are refetched
+  once.
+- **Tests**: `test_rucio_dataset_page_cache_is_day_scoped`,
+  `test_rucio_dataset_page_cache_honors_ttl`,
+  `test_rucio_dataset_page_cache_entry_without_cached_at_is_stale`.
+- **shared_with_canonical**: yes (`cms_sources/monit.py` has the same
+  date-free fingerprint and no `cached_at` check).
+
+## 2. MAJOR — partial OpenSearch responses accepted as complete
+
+- **Finding**: `_monit_msearch` consumers never checked
+  `timed_out: true` or `_shards.failed > 0`; an HTTP-200 partial
+  response fed a run that claimed a completed scope (all four sources:
+  SAM/Condor/Transfer/Dataset).
+- **Fix**: new `_ResponseQuality` assessment
+  (`timed_out`/`_shards.failed`/terms truncation, see finding 3) is
+  computed for every live response and for cached raw `_msearch`
+  payloads (a cached partial response is equally partial). A degraded
+  response still emits the records it carries but reports
+  `endpoint_failed` (closed vocabulary has no `degraded`) with details
+  in `reason`, and `completed_scope=False`. The dataset overlay's
+  *streaming* path cannot retroactively downgrade its already-returned
+  health/scope claim, so it raises on any partial page — degraded first
+  page becomes an `endpoint_failed` run before any facts are produced;
+  a degraded later page raises mid-stream so the runner fails the run —
+  and never caches partial pages.
+- **Behavior change**: timed-out/shard-degraded snapshots no longer
+  become retraction baselines; the emitted data is still available for
+  cursor-style consumption.
+- **Tests**: `test_sam_live_timed_out_response_degrades_scope`,
+  `test_condor_live_shard_failures_degrade_scope`,
+  `test_cached_raw_response_with_partial_markers_degrades_scope`,
+  `test_rucio_dataset_live_partial_first_page_fails_run`,
+  `test_rucio_dataset_live_partial_later_page_raises_midstream`.
+- **shared_with_canonical**: yes.
+
+## 3. MAJOR — terms-aggregation caps silently truncate
+
+- **Finding**: `sum_other_doc_count` / `doc_count_error_upper_bound`
+  were never read; a bucket-limited terms aggregation (`max_sites`,
+  `max_src_sites`, `max_replica_rses`, ...) that dropped buckets still
+  claimed a completed scope.
+- **Fix**: `_ResponseQuality` recursively walks the aggregation tree
+  (nested aggregations live inside each bucket) and flags any
+  `buckets` aggregation with positive `sum_other_doc_count` or
+  `doc_count_error_upper_bound`, naming the aggregation path and both
+  counters in the health reason. Truncation ⇒ `completed_scope=False`
+  (same degraded handling as finding 2; in the dataset streaming path
+  it raises).
+- **Behavior change**: capped snapshots are marked partial instead of
+  silently retracting everything beyond the cap.
+- **Tests**: `test_transfer_live_terms_truncation_degrades_scope`,
+  `test_nested_terms_truncation_is_detected`.
+- **shared_with_canonical**: yes.
+
+## 4. MAJOR — zero-bucket result claimed a complete empty scope
+
+- **Finding**: with `ignore_unavailable: true` wildcard-index queries,
+  a renamed index or stalled ingestion pipeline returns zero buckets —
+  indistinguishable from a genuinely empty window — and `_source_run`
+  still claimed the mode's scope: a retract-everything hazard.
+- **Fix**: zero records ⇒ `skipped_optional` **with**
+  `completed_scope=False` in `_source_run` (live and cache paths). The
+  dataset streaming path now prefetches page 0 and returns the same
+  `skipped_optional`/`completed_scope=False` run on a zero-bucket first
+  page instead of claiming a completed empty stream. The module
+  docstring bullet that allowed "may still claim the mode's scope (the
+  scope is genuinely empty)" is rewritten accordingly.
+- **Behavior change**: a genuinely empty window no longer triggers
+  retraction of previously ingested records; it reports
+  `skipped_optional` and leaves the prior generation in place.
+- **Tests**: `test_sam_live_zero_buckets_never_claims_empty_scope`,
+  `test_sam_empty_cache_never_claims_scope`,
+  `test_rucio_dataset_live_zero_buckets_never_claims_empty_scope`.
+- **shared_with_canonical**: yes.
+
+## 5. MAJOR — docs SSO crawl: max_pages truncation claimed complete scope
+
+- **Finding**: `SSOCookieDocsSource._crawl` truncated the sitemap
+  frontier *before* crawling and computed `total_urls` post-truncation,
+  so a clean truncated crawl looked complete and claimed the scope —
+  retracting every un-crawled page.
+- **Fix**: `_CrawlOutcome` now carries `sitemap_total` (pre-truncation)
+  and `truncated`; when `max_pages` actually truncates, the run emits
+  what it crawled, surfaces `sitemap frontier truncated by
+  max_pages=N (crawled/total)` in health, and never claims
+  `completed_scope` (status stays `ok` — the crawl itself succeeded;
+  the scope claim is what changes). The partial-crawl
+  (`endpoint_failed`) branch also carries the truncation note.
+- **Behavior change**: capped crawls become partial by configuration;
+  a cap that does not truncate changes nothing.
+- **Tests**: `test_sso_max_pages_truncation_never_claims_scope`.
+- **shared_with_canonical**: yes (same pre-crawl slice in
+  `cms_sources/docs.py`, which claimed `ok`/complete).
+
+## 6. MAJOR — jira run() never cross-checked meta.json's record_count
+
+- **Finding**: `meta.json` was read only in the cache-missing preflight
+  branch; a truncated-but-valid records cache (meta reports 72000, file
+  parses 2) claimed a complete scope in `run()`.
+- **Fix**: `run()` now compares the parsed record count against
+  `meta.json`'s `record_count` (via the existing `_expected_count`,
+  which tolerates absent/corrupt meta and a missing key by returning
+  `None` — no cross-check, clean run). On a mismatch: facts still
+  emitted, `endpoint_failed` with both counts in the reason,
+  `completed_scope=False`.
+- **Test-fixture note**: `python/tests/sources/test_jira.py`'s
+  `_write_caches` used to write `record_count: 72000` beside 1–2
+  records; fixtures that want a clean run now carry a matching count
+  (the cache-missing preflight fixtures keep 72000, which their
+  assertions report on).
+- **Behavior change**: truncated caches degrade instead of silently
+  retracting the dropped issues.
+- **Tests**: `test_meta_record_count_mismatch_never_claims_scope`,
+  `test_meta_without_record_count_stays_clean`,
+  `test_meta_record_count_match_claims_scope`.
+- **shared_with_canonical**: yes.
+
+## 7. MINOR — live tools: ConnectionError / non-JSON 200 escape uncaught
+
+- **Finding**: `monit_search`/`monit_aggregate` caught only
+  `Timeout` and `HTTPError`; `requests.ConnectionError` and a non-JSON
+  200 body (Grafana HTML error page) escaped as raw exceptions.
+- **Fix**: both cores also catch
+  `(requests.exceptions.RequestException, json.JSONDecodeError)` and
+  return the same structured error payload as the timeout path
+  (`MONIT OpenSearch request failed: <ExceptionType>` /
+  `MONIT OpenSearch returned a non-JSON response body`). Messages are
+  built from the exception type only, never its text (which can embed
+  URLs). A missing token still raises `RuntimeError` (harness
+  `requires_env` gating, unchanged).
+- **Tests**: `test_search_connection_error_is_structured`,
+  `test_aggregate_connection_error_is_structured`,
+  `test_search_non_json_200_body_is_structured`,
+  `test_aggregate_non_json_200_body_is_structured`.
+- **shared_with_canonical**: yes.
+
+## 8. MINOR — keyword-then-raw terms retry conflated zero matches with wrong field
+
+- **Finding**: a legitimate zero-bucket `.keyword` result (zero
+  matching documents) triggered the raw-field retry, whose fielddata
+  error was surfaced as the result.
+- **Fix**: zero matches ⇒ valid empty result, returned as-is, no retry.
+  The raw-field retry fires only when (a) the `.keyword` attempt failed
+  with a *field-related* error (`_looks_like_field_error`: mentions the
+  field, or markers like `no mapping found`/`fielddata`/`not
+  aggregatable`), or (b) documents matched (`hits.total > 0`) yet the
+  `.keyword` aggregation produced zero buckets — the unmapped-`.keyword`
+  case (numeric fields such as `data.ExitCode`). A failing raw retry
+  never replaces a valid empty `.keyword` result.
+- **Deliberate refinement of the finding's letter** (which said "only
+  retry on a field-related error, not on empty buckets"): an unmapped
+  `.keyword` sub-field on a numeric group_by returns empty buckets
+  *without any error*, so an error-only rule would permanently break
+  terms aggregation over numeric fields — a real regression for e.g.
+  `group_by=data.ExitCode`. The matched-but-bucketless condition keeps
+  that path working while fully fixing the reported conflation: a
+  zero-match window can never trigger the retry, and a retry error can
+  never clobber a valid empty result.
+- **Tests**: `test_aggregate_zero_match_empty_buckets_is_valid_result`,
+  `test_aggregate_field_error_triggers_raw_retry`,
+  `test_aggregate_failing_raw_retry_keeps_valid_empty_result`, updated
+  `test_aggregate_keyword_retry_falls_back_to_raw_field`.
+- **shared_with_canonical**: yes.
+
+## 9. MINOR — echoed time_window drifted from the actual query body
+
+- **Finding**: `_time_window` applied defaulting/stripping the query
+  body did not: blank inputs queried raw `""`/`"  "` while echoing
+  `now-24h`/`now` (or an empty string), so the payload claimed a window
+  the query never used.
+- **Fix**: `_sanitize_time` (strip, then default) runs once at the top
+  of both cores and the exact same values feed the query body and the
+  echoed `time_window`; `_time_window` no longer defaults or strips.
+- **Behavior change**: blank/padded window inputs now query the
+  defaults they always echoed; well-formed inputs are unchanged.
+- **Tests**: `test_time_window_echo_matches_query_body`.
+- **shared_with_canonical**: yes.
+
+## 10. MINOR — docs SSO crawl regex-stripped PDFs/binaries into mojibake pages
+
+- **Finding**: the crawl never checked `Content-Type`; binary sitemap
+  entries were tag-stripped into mojibake `documentation_page` records.
+- **Fix**: responses whose `Content-Type` media type does not contain
+  `html` are skipped and counted (`skipped_non_html` in
+  `_CrawlOutcome`, surfaced in health). A missing header is treated as
+  HTML (conservative; real `requests` responses always carry one).
+- **Scope decision, documented**: skipped non-HTML entries are
+  **excluded from the source's scope by design** — they are not crawl
+  failures and do not block the `completed_scope` claim. Consequence:
+  a previously mis-ingested binary page is retracted on the next clean
+  completed-scope run, which is the correct outcome (it never was a
+  documentation page).
+- **Tests**: `test_sso_non_html_sitemap_entries_skipped_not_ingested`.
+- **shared_with_canonical**: yes.
+
+## 11. MAJOR (template hygiene) — docs.py docstring registry templates violated their own prerequisites
+
+- **Finding**: the file's prerequisites (lines 52–53) require
+  `output_scope_summary` alongside `output_signature` and a standard
+  `sync:` block, yet the `gitlab_docs` and `cmsweb_docs` templates
+  omitted `output_signature` + `output_scope_summary` (`gitlab_docs`
+  also omitted `sync`), and the `docsite` template omitted `sync` —
+  copies of these templates fail strict admission
+  (`admission_policy_block_drift`) after a green-looking start.
+- **Fix**: all three docstring templates now carry the full
+  ingest-proven strict shape, mirroring
+  `bundles/cern-team/source-defaults/docsite.yaml`:
+  - `docsite`: added the missing `sync:` block, and the
+    `jira_records_path` param its (already-uncommented)
+    `document_chunk references jira_issue` edge requires — the bundle
+    carries both.
+  - `gitlab_docs`: added `output_signature` + `output_scope_summary`
+    (documentation_page / software_repository / document_chunk with the
+    two `contains` edges; reference edges kept in the commented
+    optional pattern to match its params) and the `sync:` block.
+  - `cmsweb_docs`: added `output_signature` + `output_scope_summary`
+    (documentation_page / document_chunk and `documentation_page
+    contains document_chunk` only — the SSO crawl emits no
+    `software_repository` nodes; reference edges commented, matching
+    its params).
+  `output_scope_summary` duplicates `output_signature` per the okg#1283
+  requirement in every template.
+- **Behavior change**: docstring-only (templates operators copy); no
+  runtime change.
+- **Tests**: none (docstring templates are not executed); covered by
+  review.
+- **shared_with_canonical**: no — the templates are archi-v3 docstring
+  additions; the canonical cms module has no such templates.
+
+---
+
+## Status mapping note (applies to findings 2, 3, 6)
+
+The review asked for "status degraded". `PREFLIGHT_STATUSES` is a
+closed vocabulary without `degraded`/`partial`; the chosen mapping is
+`endpoint_failed` with the degradation detailed in `reason` and
+`record_count` carrying the emitted count — the same mapping the
+already-reviewed `SSOCookieDocsSource` partial-crawl path uses for
+"data emitted, scope not claimed". What the substrate keys retraction
+on — `completed_scope=False` — is exact in every degraded path.

--- a/pact/changes/circleback-fixes/pact.yaml
+++ b/pact/changes/circleback-fixes/pact.yaml
@@ -75,4 +75,25 @@ test_plan:
   - pytest
 formal: []
 waivers: []
-evidence: []
+evidence:
+- id: ev.executed-test.req-circleback-fixes.20260824T141031575824Z
+  kind: executed_test
+  status: pass
+  refs:
+  - req.circleback-fixes
+  artifact: python/tests
+  command: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests -q
+  summary: Full suite 320 passed (254 baseline + 66 new regression tests across catalogs/live/enrichment/hygiene
+    waves); junit report ingested.
+  data:
+    attached_at: '2026-08-24T14:10:31.575851+00:00'
+- id: ev.executed-test.acc-circleback-fixes.20260824T141033150775Z
+  kind: executed_test
+  status: pass
+  refs:
+  - acc.circleback-fixes
+  artifact: python/tests
+  summary: 'Acceptance: suite green incl. leak-corpus, scope-claim, and tools-error
+    regression tests; notes files present for catalogs/live/enrichment/hygiene.'
+  data:
+    attached_at: '2026-08-24T14:10:33.150802+00:00'

--- a/pact/changes/circleback-fixes/pact.yaml
+++ b/pact/changes/circleback-fixes/pact.yaml
@@ -97,3 +97,16 @@ evidence:
     regression tests; notes files present for catalogs/live/enrichment/hygiene.'
   data:
     attached_at: '2026-08-24T14:10:33.150802+00:00'
+- id: ev.executed-test.req-circleback-fixes.20260824T143454559459Z
+  kind: executed_test
+  status: pass
+  refs:
+  - req.circleback-fixes
+  artifact: python/tests
+  command: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests -q
+  summary: 'Final suite after adversarial-review deltas: 326 passed (72 new regression
+    tests over the 254 baseline). Independent adversarial diff review: branch holds;
+    its one major escape (cmssw map-path zero-parse) and all prescriptions fixed or
+    documented.'
+  data:
+    attached_at: '2026-08-24T14:34:54.559492+00:00'

--- a/pact/changes/circleback-fixes/pact.yaml
+++ b/pact/changes/circleback-fixes/pact.yaml
@@ -59,7 +59,7 @@ requirements:
 tasks:
 - id: task.circleback-fixes
   title: 'Circle-back review fixes: scope-claim, anonymizer, and hygiene waves'
-  status: todo
+  status: done
   verification: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests -q
     (full suite, zero failures; includes new regression tests per fixed finding)
   requirements:

--- a/pact/changes/circleback-fixes/pact.yaml
+++ b/pact/changes/circleback-fixes/pact.yaml
@@ -4,17 +4,15 @@ change:
   id: circleback-fixes
   title: 'Circle-back review fixes: scope-claim, anonymizer, and hygiene waves'
   status: proposal
-  rationale: >-
-    The deferred whole-package adversarial review (4 domain reviewers on
-    archi_v3@728739e6) confirmed 3 blockers / 15 majors, dominated by one
-    class: connectors claiming completed_scope after silently losing input,
-    which under missing_from_completed_scope means mass retraction of good
-    records; plus PII leak paths in the anonymizer (the v2 anonymize_data
-    cutover gate). Fixes are deliberate deviations from the frozen canonical
-    okg-deployments/cms copies (~85% of findings are shared), recorded in
-    per-domain notes files in this change dir. Out of scope by design:
-    enricher dedupe/retraction lifecycle and SourceRun.record_set plumbing
-    (substrate-side contracts, routed to okg#1178).
+  rationale: 'The deferred whole-package adversarial review (4 domain reviewers on
+    archi_v3@728739e6) confirmed 3 blockers / 15 majors, dominated by one class: connectors
+    claiming completed_scope after silently losing input, which under missing_from_completed_scope
+    means mass retraction of good records; plus PII leak paths in the anonymizer (the
+    v2 anonymize_data cutover gate). Fixes are deliberate deviations from the frozen
+    canonical okg-deployments/cms copies (~85% of findings are shared), recorded in
+    per-domain notes files in this change dir. Out of scope by design: enricher dedupe/retraction
+    lifecycle and SourceRun.record_set plumbing (substrate-side contracts, routed
+    to okg#1178).'
   root_cause: Small nontrivial change whose intent, task, acceptance, and proof fit
     the PACT fast path.
   tier: 1
@@ -22,20 +20,22 @@ change:
     pact_shape: fast_path
     fast_path: Compact PACT for small nontrivial work. Upgrade when scope, risk, hierarchy,
       formal proof, graph evidence, or review complexity increases.
-  affected_areas: [python/archi/sources, python/archi/tools, python/archi/enrichment, skills]
+  affected_areas:
+  - python/archi/sources
+  - python/archi/tools
+  - python/archi/enrichment
+  - skills
   affected_code: []
 requirements:
 - id: req.circleback-fixes
   title: 'Circle-back review fixes: scope-claim, anonymizer, and hygiene waves'
-  statement: >-
-    Every confirmed blocker/major finding from the circle-back review is
-    either fixed with a regression test reproducing its failure scenario, or
-    explicitly routed upstream (okg#1178) with the reason recorded. No
-    connector claims completed_scope when any enumerated input failed, was
-    truncated, or parsed to nothing from non-empty input; no anonymizer leak
-    case in the review corpus survives; the full v3 suite passes with zero
-    regressions; every behavioral deviation from canonical cms code is
-    recorded in notes-{catalogs,live,enrichment}.md in this change dir.
+  statement: Every confirmed blocker/major finding from the circle-back review is
+    either fixed with a regression test reproducing its failure scenario, or explicitly
+    routed upstream (okg#1178) with the reason recorded. No connector claims completed_scope
+    when any enumerated input failed, was truncated, or parsed to nothing from non-empty
+    input; no anonymizer leak case in the review corpus survives; the full v3 suite
+    passes with zero regressions; every behavioral deviation from canonical cms code
+    is recorded in notes-{catalogs,live,enrichment}.md in this change dir.
   evidence_policy:
     required:
     - executed_test
@@ -51,17 +51,17 @@ requirements:
     and: []
   acceptance:
   - id: acc.circleback-fixes
-    description: >-
-      Full suite green including new regression tests for each fixed finding
-      (scope-claim class, anonymizer leak corpus, tools error contract);
-      notes files present for all three domains.
+    description: Full suite green including new regression tests for each fixed finding
+      (scope-claim class, anonymizer leak corpus, tools error contract); notes files
+      present for all three domains.
     evidence:
     - executed_test
 tasks:
 - id: task.circleback-fixes
   title: 'Circle-back review fixes: scope-claim, anonymizer, and hygiene waves'
   status: todo
-  verification: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests -q (full suite, zero failures; includes new regression tests per fixed finding)
+  verification: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests -q
+    (full suite, zero failures; includes new regression tests per fixed finding)
   requirements:
   - req.circleback-fixes
   evidence: []

--- a/pact/changes/circleback-fixes/pact.yaml
+++ b/pact/changes/circleback-fixes/pact.yaml
@@ -1,0 +1,78 @@
+pact_version: 4
+target_pact_version: 4
+change:
+  id: circleback-fixes
+  title: 'Circle-back review fixes: scope-claim, anonymizer, and hygiene waves'
+  status: proposal
+  rationale: >-
+    The deferred whole-package adversarial review (4 domain reviewers on
+    archi_v3@728739e6) confirmed 3 blockers / 15 majors, dominated by one
+    class: connectors claiming completed_scope after silently losing input,
+    which under missing_from_completed_scope means mass retraction of good
+    records; plus PII leak paths in the anonymizer (the v2 anonymize_data
+    cutover gate). Fixes are deliberate deviations from the frozen canonical
+    okg-deployments/cms copies (~85% of findings are shared), recorded in
+    per-domain notes files in this change dir. Out of scope by design:
+    enricher dedupe/retraction lifecycle and SourceRun.record_set plumbing
+    (substrate-side contracts, routed to okg#1178).
+  root_cause: Small nontrivial change whose intent, task, acceptance, and proof fit
+    the PACT fast path.
+  tier: 1
+  method_metadata:
+    pact_shape: fast_path
+    fast_path: Compact PACT for small nontrivial work. Upgrade when scope, risk, hierarchy,
+      formal proof, graph evidence, or review complexity increases.
+  affected_areas: [python/archi/sources, python/archi/tools, python/archi/enrichment, skills]
+  affected_code: []
+requirements:
+- id: req.circleback-fixes
+  title: 'Circle-back review fixes: scope-claim, anonymizer, and hygiene waves'
+  statement: >-
+    Every confirmed blocker/major finding from the circle-back review is
+    either fixed with a regression test reproducing its failure scenario, or
+    explicitly routed upstream (okg#1178) with the reason recorded. No
+    connector claims completed_scope when any enumerated input failed, was
+    truncated, or parsed to nothing from non-empty input; no anonymizer leak
+    case in the review corpus survives; the full v3 suite passes with zero
+    regressions; every behavioral deviation from canonical cms code is
+    recorded in notes-{catalogs,live,enrichment}.md in this change dir.
+  evidence_policy:
+    required:
+    - executed_test
+  scenarios:
+  - id: scn.circleback-fixes.fast-path
+    title: Fast-path work is verified
+    given:
+    - a small nontrivial change fits one requirement
+    when:
+    - the declared verification runs
+    then:
+    - the requirement has executed proof before completion
+    and: []
+  acceptance:
+  - id: acc.circleback-fixes
+    description: >-
+      Full suite green including new regression tests for each fixed finding
+      (scope-claim class, anonymizer leak corpus, tools error contract);
+      notes files present for all three domains.
+    evidence:
+    - executed_test
+tasks:
+- id: task.circleback-fixes
+  title: 'Circle-back review fixes: scope-claim, anonymizer, and hygiene waves'
+  status: todo
+  verification: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests -q (full suite, zero failures; includes new regression tests per fixed finding)
+  requirements:
+  - req.circleback-fixes
+  evidence: []
+  environment: []
+dependencies: []
+test_plan:
+- id: test.req-circleback-fixes.full-suite
+  requirement: req.circleback-fixes
+  test_id: python/tests
+  evidence:
+  - pytest
+formal: []
+waivers: []
+evidence: []

--- a/python/archi/enrichment/alias.py
+++ b/python/archi/enrichment/alias.py
@@ -3,10 +3,21 @@
 Provenance: ported from ``cms/cms_sources/alias.py`` (192 LOC,
 okg-deployments ``main@f33a9c4``). Changes: class de-CMS-ified
 (``CMSProjectionAliasBackend`` -> :class:`ProjectionAliasBackend`);
-everything else — the entity-type/prefix tables (which mirror the
-packaged extraction rules' ``cms_*`` id types), the backend ``name``
-(``cms_projection``, kept for cutover parity with the comp-ops
-instance's alias-resolver config), matching, and SQL — is unchanged.
+the entity-type/prefix tables (which mirror the packaged extraction
+rules' ``cms_*`` id types), the backend ``name`` (``cms_projection``,
+kept for cutover parity with the comp-ops instance's alias-resolver
+config), and SQL are unchanged. Matching differs from the port source
+in two ways (circleback review, see
+``pact/changes/circleback-fixes/notes-enrichment.md``):
+
+- Dataset alias matching is case-sensitive: DBS dataset paths are
+  case-sensitive identifiers, and case-folding collapsed case-distinct
+  canonical ids (``/A/B/RAW`` vs ``/a/b/raw``) into whichever loaded
+  last. Sites, releases, JIRA keys, hostnames, and endpoints stay
+  case-insensitive — for those types case is transcription noise.
+- Dataset misses are no longer cached: the old negative cache grew
+  unboundedly with every unresolved mention, and memoized nothing (the
+  fallback lookup hit the same index).
 
 Deployment wiring (alias_resolver block)::
 
@@ -71,7 +82,9 @@ class ProjectionAliasBackend:
             for entity_type in self._ENTITY_PREFIXES
         }
         self._service_by_endpoint: dict[str, str] = {}
-        self._dataset_by_value: dict[str, str | None] = {}
+        # Case-sensitive dataset-path -> node id index (DBS paths are
+        # case-sensitive). Holds only live nodes; misses are not cached.
+        self._dataset_by_value: dict[str, str] = {}
         self._dataset_index_loaded = False
         self._load()
 
@@ -148,14 +161,12 @@ class ProjectionAliasBackend:
 
     def _resolve_dataset(self, value: str) -> str | None:
         self._load_dataset_index()
-        key = _norm(value)
-        canonical = self._dataset_by_value.get(key)
-        if canonical is not None or key in self._dataset_by_value:
+        # Exact-case lookup: DBS dataset paths are case-sensitive, so
+        # /A/B/RAW and /a/b/raw are distinct canonical ids.
+        canonical = self._dataset_by_value.get(value)
+        if canonical is not None:
             return canonical
-        node_id = value if value.startswith("dataset:") else f"dataset:{value}"
-        canonical = self._dataset_by_value.get(_norm(node_id.removeprefix("dataset:")))
-        self._dataset_by_value[key] = canonical
-        return canonical
+        return self._dataset_by_value.get(value.removeprefix("dataset:"))
 
     def _load_dataset_index(self) -> None:
         if self._dataset_index_loaded:
@@ -173,7 +184,7 @@ class ProjectionAliasBackend:
             node_id = str(row["node_id"])
             prefix, _, value = node_id.partition(":")
             if prefix == "dataset" and value:
-                self._dataset_by_value[_norm(value)] = node_id
+                self._dataset_by_value[value.strip()] = node_id
         self._dataset_index_loaded = True
 
     def _index_service_endpoint(

--- a/python/archi/enrichment/anonymizer.py
+++ b/python/archi/enrichment/anonymizer.py
@@ -26,8 +26,26 @@ Changes from the v2 original:
   download-on-missing behavior) can be set False to fail fast instead
   of downloading a model mid-ingest.
 
-Everything else — the markup regexes, greeting/sign-off stripping,
-name replacement, and text extraction for NER — is kept verbatim.
+Hardening on top of the v2 behavior (circleback adversarial review,
+see ``pact/changes/circleback-fixes/notes-enrichment.md``):
+
+- Email redaction covers RFC-5322 local parts (``+`` tags, apostrophes,
+  quoted local parts) and the percent-encoded ``%40`` form seen in
+  URLs, so no fragment of the local part survives.
+- NBSP (U+00A0 / ``&nbsp;``) and text-level HTML character references
+  (``&#64;``, ``&amp;``, ...) are normalized before both discovery and
+  replacement, so encoded occurrences of names/emails are redacted too.
+  ``&lt;``/``&gt;`` are deliberately left encoded so markup structure
+  is unchanged for the markup pass.
+- NER-disabled mode additionally strips non-CDATA ``<dc:creator>``,
+  ``mailto:`` anchor text, and TWiki ``-- Main.WikiWord`` signature
+  lines.
+- The greeting/sign-off line filters are tightened: greetings need an
+  actual greeting word (the v2 ``^\\w+,`` rule deleted operational
+  lines like "However, run 381000 ..."), and sign-offs must be the
+  whole line (optionally followed by a short name), not a prefix.
+
+Name replacement and text extraction for NER are kept verbatim.
 """
 from __future__ import annotations
 
@@ -41,6 +59,26 @@ _CDATA_RE = re.compile(r"<!\[CDATA\[|\]\]>")
 _DC_CREATOR_RE = re.compile(
     r'(<dc:creator><!\[CDATA\[)[^\]]*(\]\]></dc:creator>)',
     re.IGNORECASE,
+)
+# <dc:creator>Name</dc:creator> without a CDATA wrapper. Disjoint from
+# _DC_CREATOR_RE: CDATA content starts with "<", which [^<]* rejects.
+_DC_CREATOR_PLAIN_RE = re.compile(
+    r'(<dc:creator(?:\s[^>]*)?>)[^<]*(</dc:creator>)',
+    re.IGNORECASE,
+)
+# <a href="mailto:jdoe@cern.ch">John Doe</a> → (removed): the email
+# pass empties the href, but the anchor text is a name and must go too.
+_DEFAULT_MARKUP_MAILTO_LINK_RE = re.compile(
+    r'<a[^>]*href=["\']mailto:[^"\']*["\'][^>]*>.*?</a>',
+    re.IGNORECASE | re.DOTALL,
+)
+# TWiki signature lines: "-- Main.JohnDoe - 2024-01-15" (also plain
+# "-- Main.JohnDoe" and "-- TWiki.JohnDoe - 15 Jan 2024"). Applied in
+# both the text and markup passes; the emptied line is dropped by the
+# final blank-line filter.
+_TWIKI_SIGNATURE_RE = re.compile(
+    r'^[ \t]*-{2,}[ \t]*(?:Main|TWiki)\.[A-Z]\w*(?:[ \t]*-[ \t]*[^\n]*)?[ \t]*$',
+    re.MULTILINE,
 )
 _ATTR_TEXT_RE = re.compile(r'(?:title|alt|creator|author)=["\']([^"\']+)["\']', re.IGNORECASE)
 _CONTENT_TAG_RE = re.compile(
@@ -86,19 +124,77 @@ _DEFAULT_MARKUP_TRAILING_SIGNOFF_TAG_RE = re.compile(
 )
 
 # Defaults lifted from the v2 base-config template
-# (src/cli/templates/base-config.yaml, dev@28b977d1).
+# (src/cli/templates/base-config.yaml, dev@28b977d1), tightened per the
+# circleback review: the v2 greeting rule ``^\w+,`` and the prefix-match
+# sign-off rule deleted operational lines whole ("However, run 381000
+# was affected badly.", "Regards to whoever fixed run 381000").
 _DEFAULT_NLP_MODEL = "en_core_web_sm"
 _DEFAULT_EXCLUDED_WORDS = ("John", "Jane", "Doe")
+# Greeting lines must start with an actual greeting word (v2-compatible
+# prefix semantics for those words; the bare ``^\w+,`` rule is gone).
 _DEFAULT_GREETING_PATTERNS = (
-    r"^(hi|hello|hey|greetings|dear)\b",
-    r"^\w+,\s*",
+    r"^(hi|hello|hey|greetings|dear|ciao|salut|hiya|howdy"
+    r"|good\s+(?:morning|afternoon|evening|day))\b",
 )
+# Sign-off lines must be ONLY the sign-off phrase, optionally followed
+# by punctuation and a short (<= 4 word) trailing name. A phrase that
+# runs straight into more words ("Thank you note was filed as ...",
+# "Best effort reprocessing ...") is content and survives.
 _DEFAULT_SIGNOFF_PATTERNS = (
-    r"\b(regards|sincerely|best regards|cheers|thank you)\b",
+    r"^(?:yours\s+(?:sincerely|truly|faithfully)|sincerely(?:\s+yours)?"
+    r"|(?:best|kind|warm)\s+regards|regards|best\s+wishes|best|cheers"
+    r"|many\s+thanks|thanks(?:\s+(?:a\s+lot|in\s+advance|again))?"
+    r"|thank\s+you|thx|hth|take\s+care|all\s+the\s+best)"
+    r"(?:\s*[,.!;:-]+\s*(?:[A-Za-z][\w'.-]*(?:[ \t]+[A-Za-z][\w'.-]*){0,3})?)?"
+    r"\s*[,.!]*\s*$",
     r"^\s*[-~]+\s*$",
 )
-_DEFAULT_EMAIL_PATTERN = r"[\w\.-]+@[\w\.-]+\.\w+"
+# Local part: quoted form ("john doe"@...) or RFC-5322 atext plus dots
+# and %-encoded octets — but not the URL-structural chars ``/ = ?`` so
+# a surrounding URL's path/query is not swallowed. The separator also
+# accepts the percent-encoded ``%40`` form (mail=john.doe%40cern.ch).
+_DEFAULT_EMAIL_PATTERN = (
+    r"(?:\"[^\"\n]+\"|[A-Za-z0-9.!#$%&'*+^_`{|}~-]+)(?:@|%40)[\w.-]+\.\w+"
+)
 _DEFAULT_USERNAME_PATTERN = r"\[~[^\]]+\]"
+
+# Text-level HTML character references decoded before redaction. The
+# numeric-reference decoder below deliberately keeps &lt;/&gt; (and any
+# reference that would decode to "<" or ">") encoded, so decoding never
+# creates or breaks markup structure for the markup pass.
+_NUMERIC_ENTITY_RE = re.compile(r"&#(x[0-9a-fA-F]{1,6}|[0-9]{1,7});")
+_SAFE_NAMED_ENTITIES = {
+    "&nbsp;": "\u00a0",
+    "&amp;": "&",
+    "&apos;": "'",
+    "&quot;": '"',
+    "&commat;": "@",
+}
+
+
+def _normalize_encodings(text: str) -> str:
+    """Decode NBSP and text-level entities so encoded PII is caught.
+
+    ``John&nbsp;Doe`` / ``John\\xa0Doe`` become ``John Doe`` and
+    ``jdoe&#64;cern.ch`` becomes ``jdoe@cern.ch`` before the discovery,
+    email, and replacement passes — which then all see the same string.
+    """
+
+    def _decode(match: re.Match) -> str:
+        ref = match.group(1)
+        code = int(ref[1:], 16) if ref[0] in "xX" else int(ref)
+        try:
+            char = chr(code)
+        except (ValueError, OverflowError):
+            return match.group(0)
+        if char in "<>":
+            return match.group(0)
+        return char
+
+    text = _NUMERIC_ENTITY_RE.sub(_decode, text)
+    for entity, char in _SAFE_NAMED_ENTITIES.items():
+        text = text.replace(entity, char)
+    return text.replace("\u00a0", " ")
 
 
 class Anonymizer:
@@ -171,12 +267,16 @@ class Anonymizer:
         """
         Anonymize names, emails, usernames, greetings, and sign-offs from the text.
         """
+        # Normalize NBSP/entity encodings first so discovery, the email
+        # pass, and replacement all see the same decoded string.
+        text = _normalize_encodings(text)
         names_to_replace = self._discover_names(text)
 
         # Remove email addresses and usernames
         text = self.EMAIL_PATTERN.sub("", text)
         text = self.USERNAME_PATTERN.sub("", text)
 
+        text = _TWIKI_SIGNATURE_RE.sub("", text)
         text = self._strip_greetings_signoffs(text)
         return self._replace_names(text, names_to_replace)
 
@@ -185,16 +285,24 @@ class Anonymizer:
         Anonymize names, emails, usernames, greetings, and sign-offs from the markup.
         including html, rss, and other markup formats. (especially twiki and discourse markup)
         """
+        # Normalize NBSP/entity encodings first so discovery and every
+        # sub below see the same decoded string ("John&nbsp;Doe" and
+        # "jdoe&#64;cern.ch" are redacted like their plain forms).
+        # &lt;/&gt; stay encoded, so tag structure is unchanged.
+        markup = _normalize_encodings(markup)
         names_to_replace = self._discover_names_markup(markup)
         # Remove email addresses and usernames
         markup = self.EMAIL_PATTERN.sub("", markup)
         markup = self.USERNAME_PATTERN.sub("", markup)
         markup = _DC_CREATOR_RE.sub(r'\1\2', markup)
+        markup = _DC_CREATOR_PLAIN_RE.sub(r'\1\2', markup)
+        markup = _DEFAULT_MARKUP_MAILTO_LINK_RE.sub("", markup)
         markup = _DEFAULT_GENERIC_MARKUP_AUTHOR_ELEMENT_RE.sub("", markup)
         markup = _DEFAULT_GENERIC_MARKUP_USER_LINK_RE.sub("", markup)
         markup = _DEFAULT_MARKUP_SIGNOFF_TAG_RE.sub("", markup)
         markup = _DEFAULT_MARKUP_TRAILING_SIGNOFF_TAG_RE.sub("", markup)
         markup = _DEFAULT_MARKUP_TWIKI_USER_LINK_RE.sub("", markup)
+        markup = _TWIKI_SIGNATURE_RE.sub("", markup)
         markup = self._strip_greetings_signoffs(markup)
         return self._replace_names(markup, names_to_replace)
 

--- a/python/archi/enrichment/anonymizer.py
+++ b/python/archi/enrichment/anonymizer.py
@@ -42,8 +42,10 @@ see ``pact/changes/circleback-fixes/notes-enrichment.md``):
   lines.
 - The greeting/sign-off line filters are tightened: greetings need an
   actual greeting word (the v2 ``^\\w+,`` rule deleted operational
-  lines like "However, run 381000 ..."), and sign-offs must be the
-  whole line (optionally followed by a short name), not a prefix.
+  lines like "However, run 381000 ...") and must be short greeting
+  lines (greeting word + at most four trailing words), and sign-offs
+  must be the whole line (optionally followed by a short name), not a
+  prefix.
 
 Name replacement and text extraction for NER are kept verbatim.
 """
@@ -130,11 +132,15 @@ _DEFAULT_MARKUP_TRAILING_SIGNOFF_TAG_RE = re.compile(
 # was affected badly.", "Regards to whoever fixed run 381000").
 _DEFAULT_NLP_MODEL = "en_core_web_sm"
 _DEFAULT_EXCLUDED_WORDS = ("John", "Jane", "Doe")
-# Greeting lines must start with an actual greeting word (v2-compatible
-# prefix semantics for those words; the bare ``^\w+,`` rule is gone).
+# Greeting lines must start with an actual greeting word (the bare
+# ``^\w+,`` rule is gone) AND be short: greeting word plus at most four
+# trailing words (mirroring the sign-off tail bound), so
+# greeting-prefixed operational sentences ("Good morning update:
+# transfers to T2_US_MIT stuck") survive.
 _DEFAULT_GREETING_PATTERNS = (
-    r"^(hi|hello|hey|greetings|dear|ciao|salut|hiya|howdy"
-    r"|good\s+(?:morning|afternoon|evening|day))\b",
+    r"^(?:hi|hello|hey|greetings|dear|ciao|salut|hiya|howdy"
+    r"|good\s+(?:morning|afternoon|evening|day))"
+    r"(?:[\s,!]+[A-Za-z][\w'.-]*){0,4}[\s,.!]*$",
 )
 # Sign-off lines must be ONLY the sign-off phrase, optionally followed
 # by punctuation and a short (<= 4 word) trailing name. A phrase that
@@ -178,6 +184,12 @@ def _normalize_encodings(text: str) -> str:
     ``John&nbsp;Doe`` / ``John\\xa0Doe`` become ``John Doe`` and
     ``jdoe&#64;cern.ch`` becomes ``jdoe@cern.ch`` before the discovery,
     email, and replacement passes — which then all see the same string.
+
+    Normalization iterates to a fixpoint (bounded at 3 passes) so
+    double-encoded forms like ``jdoe&amp;#64;cern.ch`` — which a single
+    pass only peels to ``jdoe&#64;cern.ch`` — are fully decoded too.
+    References that would decode to ``<`` or ``>`` stay encoded on
+    every pass, so markup structure is never created or broken.
     """
 
     def _decode(match: re.Match) -> str:
@@ -191,10 +203,15 @@ def _normalize_encodings(text: str) -> str:
             return match.group(0)
         return char
 
-    text = _NUMERIC_ENTITY_RE.sub(_decode, text)
-    for entity, char in _SAFE_NAMED_ENTITIES.items():
-        text = text.replace(entity, char)
-    return text.replace("\u00a0", " ")
+    for _ in range(3):
+        previous = text
+        text = _NUMERIC_ENTITY_RE.sub(_decode, text)
+        for entity, char in _SAFE_NAMED_ENTITIES.items():
+            text = text.replace(entity, char)
+        text = text.replace("\u00a0", " ")
+        if text == previous:
+            break
+    return text
 
 
 class Anonymizer:

--- a/python/archi/enrichment/declarative.py
+++ b/python/archi/enrichment/declarative.py
@@ -31,7 +31,13 @@ class GlobalTagReleaseLinker(DeclarativeLinker):
 
     def __init__(self, **kwargs) -> None:
         kwargs.setdefault("name", "cms_declarative_global_tag_release")
-        if not any(k in kwargs for k in ("rules", "rules_files", "rules_dir")):
+        # None/empty rule sources mean "not provided". A bare key-presence
+        # check treated rules_files=None/[] as a caller override, which
+        # suppressed the packaged default and let DeclarativeLinker load
+        # its entire substrate rule set under this linker's name.
+        if not any(kwargs.get(k) for k in ("rules", "rules_files", "rules_dir")):
+            for key in ("rules", "rules_files", "rules_dir"):
+                kwargs.pop(key, None)
             kwargs["rules_files"] = [
                 str(cross_link_rules_file("global_tag_release.yaml"))
             ]

--- a/python/archi/schemas/bridges/sources.yaml
+++ b/python/archi/schemas/bridges/sources.yaml
@@ -7,6 +7,20 @@
 # deployment as <deployment>/schemas/bridges/sources.yaml, alongside
 # archi/schemas/sources.yaml -> <deployment>/schemas/sources.yaml
 # (the catalog composer only honors narrowings under schemas/bridges/).
+id: https://archi-physics.org/okg/archi/bridges/sources
+name: archi_sources_narrowings
+title: Archi W2 — sources bridge narrowings
+description: Narrowings for the ported jira/docs source emissions.
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+  archi: https://archi-physics.org/okg/archi/
+
+default_range: string
+
+imports:
+  - linkml:types
+
 classes:
   EdgeNarrowings:
     description: Narrowings for the ported jira/docs source emissions.

--- a/python/archi/sources/_cache_report.py
+++ b/python/archi/sources/_cache_report.py
@@ -9,6 +9,15 @@ Consumed by :mod:`archi.sources.dbs`, :mod:`archi.sources.conddb`, and
 resolution takes the explicit ``base`` argument of
 :func:`archi.auth.cache.resolve_repo_path` instead of assuming a
 deployments-repo checkout.
+
+Archi deviation (circleback-fixes): :func:`skipped_items_status` is new
+— it is the shared policy for item-level parse tolerance. Sources that
+skip unparseable cached items must not claim a completed scope over the
+survivors (``missing_from_completed_scope`` would retract every record
+the drifted items used to produce), and zero parsed records from a
+non-empty payload is an endpoint failure rather than an empty success.
+Also consumed by the inline-health catalog sources (cmssw, dqm, gocdb,
+indico, hypernews).
 """
 from __future__ import annotations
 
@@ -65,15 +74,54 @@ def cache_source_health(
     description: str,
     cache_paths: Iterable[str | Path],
     record_count: int,
+    skipped_count: int = 0,
     base: str | None = None,
 ) -> SourceHealth:
-    return SourceHealth(
+    status, reason = skipped_items_status(
         status=_cache_status(record_count),
+        reason=_cache_reason(description, record_count, observed=False),
+        record_count=record_count,
+        skipped_count=skipped_count,
+    )
+    return SourceHealth(
+        status=status,
         mode="cache",
         record_count=record_count,
         content_hash=content_hash(cache_paths, base=base),
-        reason=_cache_reason(description, record_count, observed=False),
+        reason=reason,
         checked_at=_checked_at(),
+    )
+
+
+def skipped_items_status(
+    *,
+    status: str,
+    reason: str,
+    record_count: int,
+    skipped_count: int,
+) -> tuple[str, str]:
+    """Degrade a health claim when item-level parsing skipped records.
+
+    Per-item tolerance stays (one bad record must not fail the whole
+    run), but the run must stop claiming completeness: callers gate
+    ``completed_scope`` on ``skipped_count == 0`` so schema drift never
+    turns into a healthy completed-scope run that retracts the skipped
+    records. Zero parsed records from a non-empty payload becomes
+    ``endpoint_failed`` instead of an empty success.
+    """
+    if not skipped_count:
+        return status, reason
+    if not record_count:
+        return (
+            "endpoint_failed",
+            f"{reason}; all {skipped_count} cached item(s) failed to "
+            "parse (possible schema drift); no records emitted and no "
+            "complete scope claimed",
+        )
+    return (
+        status,
+        f"{reason}; skipped {skipped_count} unparseable cached item(s); "
+        "no complete scope claimed",
     )
 
 

--- a/python/archi/sources/cmssw.py
+++ b/python/archi/sources/cmssw.py
@@ -89,6 +89,7 @@ from archi.auth.cache import (
     load_json,
     resolve_repo_path,
 )
+from archi.sources._cache_report import skipped_items_status
 
 RELEASES_MAP_URL = (
     "https://raw.githubusercontent.com/cms-sw/cms-bot/master/releases.map"
@@ -205,7 +206,7 @@ class CMSSWReleaseSource:
         )
 
     def run(self, run_id: str, *, mode: str = "cursor") -> SourceRun:
-        records = self._records()
+        records, skipped, truncated = self._records_with_details()
         revision = {
             "run_id": run_id,
             "content_hash": content_hash(self.cache_paths, base=self.base),
@@ -220,24 +221,48 @@ class CMSSWReleaseSource:
                 yield _node_fact(record, revision)
             yield from _supersedes_edges(records, revision)
 
+        status, reason = skipped_items_status(
+            status="ok",
+            reason=(
+                "local CMSSW release cache used"
+                if self.map_cache_path is None
+                else "cms-bot releases.map used"
+            ),
+            record_count=len(records),
+            skipped_count=skipped,
+        )
+        if truncated:
+            # A truncated newest-N window must not claim a complete
+            # scope: every upstream append would retract the oldest
+            # in-window release (sliding retention window).
+            reason += (
+                f"; limit={self.limit} truncated the release list; "
+                "no complete scope claimed"
+            )
         return SourceRun(
             facts=_facts(),
-            completed_scope=(mode in {"scope_complete", "reconcile"}),
+            completed_scope=(
+                mode in {"scope_complete", "reconcile"}
+                and not skipped
+                and not truncated
+            ),
             run_mode=mode,
             health=SourceHealth(
-                status="ok",
+                status=status,
                 mode="cache",
                 record_count=len(records),
                 content_hash=revision["content_hash"],
-                reason=(
-                    "local CMSSW release cache used"
-                    if self.map_cache_path is None
-                    else "cms-bot releases.map used"
-                ),
+                reason=reason,
             ),
         )
 
     def _records(self) -> list[CMSSWReleaseRecord]:
+        return self._records_with_details()[0]
+
+    def _records_with_details(
+        self,
+    ) -> tuple[list[CMSSWReleaseRecord], int, bool]:
+        """Records plus (skipped_item_count, limit_truncated)."""
         if self.map_cache_path is not None:
             return self._records_from_map()
         payload = load_json(self.records_path, base=self.base)
@@ -246,11 +271,14 @@ class CMSSWReleaseSource:
                 f"{self.records_path}: expected a JSON list of releases"
             )
         records: list[CMSSWReleaseRecord] = []
+        skipped = 0
         for item in payload:
             if not isinstance(item, dict):
+                skipped += 1
                 continue
             label = str(item.get("label") or "").strip()
             if not label:
+                skipped += 1
                 continue
             architecture_raw = item.get("architecture") or ()
             if isinstance(architecture_raw, str):
@@ -265,9 +293,11 @@ class CMSSWReleaseSource:
                 release_notes=str(item.get("release_notes") or ""),
                 release_date=str(item.get("release_date") or ""),
             ))
-        return records
+        return records, skipped, False
 
-    def _records_from_map(self) -> list[CMSSWReleaseRecord]:
+    def _records_from_map(
+        self,
+    ) -> tuple[list[CMSSWReleaseRecord], int, bool]:
         """W1 path: build records from the cms-bot ``releases.map`` cache."""
         path = resolve_repo_path(self.map_cache_path, base=self.base)
         if self.fetch or not path.is_file():
@@ -277,7 +307,9 @@ class CMSSWReleaseSource:
             ) as resp:
                 path.write_bytes(resp.read())
         raw = path.read_text(encoding="utf-8", errors="replace")
-        return parse_releases_map(raw, self.limit)
+        full = parse_releases_map(raw)
+        records = full[-self.limit:] if self.limit > 0 else full
+        return records, 0, len(records) < len(full)
 
 
 def parse_releases_map(raw: str, limit: int = 0) -> list[CMSSWReleaseRecord]:

--- a/python/archi/sources/cmssw.py
+++ b/python/archi/sources/cmssw.py
@@ -307,14 +307,31 @@ class CMSSWReleaseSource:
             ) as resp:
                 path.write_bytes(resp.read())
         raw = path.read_text(encoding="utf-8", errors="replace")
-        full = parse_releases_map(raw)
+        full, skipped = _parse_map_with_skips(raw)
         records = full[-self.limit:] if self.limit > 0 else full
-        return records, 0, len(records) < len(full)
+        return records, skipped, len(records) < len(full)
 
 
 def parse_releases_map(raw: str, limit: int = 0) -> list[CMSSWReleaseRecord]:
     """Parse cms-bot ``releases.map`` lines into release records (W1 path)."""
+    records, _skipped = _parse_map_with_skips(raw)
+    if limit > 0:
+        return records[-limit:]
+    return records
+
+
+def _parse_map_with_skips(
+    raw: str,
+) -> tuple[list[CMSSWReleaseRecord], int]:
+    """Parse map lines, counting the ones that yield no release.
+
+    A non-empty line without a ``label`` matching the CMSSW version
+    pattern is a skip: format drift (e.g. a renamed key) must degrade
+    the run's scope claim instead of silently emptying the record set
+    under a healthy completed scope.
+    """
     by_label: dict[str, dict[str, Any]] = {}
+    skipped = 0
     for line in raw.splitlines():
         line = line.strip()
         if not line:
@@ -324,6 +341,7 @@ def parse_releases_map(raw: str, limit: int = 0) -> list[CMSSWReleaseRecord]:
         )
         label = fields.get("label", "")
         if not _VERSION_RE.match(label):
+            skipped += 1
             continue
         rec = by_label.setdefault(
             label,
@@ -341,8 +359,6 @@ def parse_releases_map(raw: str, limit: int = 0) -> list[CMSSWReleaseRecord]:
         by_label.values(),
         key=lambda r: _sort_key(r["label"]),
     )
-    if limit > 0:
-        ordered = ordered[-limit:]
     return [
         CMSSWReleaseRecord(
             label=rec["label"],
@@ -351,7 +367,7 @@ def parse_releases_map(raw: str, limit: int = 0) -> list[CMSSWReleaseRecord]:
             architecture=tuple(sorted(rec["architecture"])),
         )
         for rec in ordered
-    ]
+    ], skipped
 
 
 def _sort_key(label: str) -> tuple[int, int, int, str]:

--- a/python/archi/sources/conddb.py
+++ b/python/archi/sources/conddb.py
@@ -118,9 +118,18 @@ class CondDBGlobalTagSource:
         self.records_path = records_path
         self.cmssw_records_path = cmssw_records_path
         self.base = base
+        # The probe must cover every cache run() reads: run() also
+        # consults cmssw_records_path (release-target gating), so a
+        # cmssw-cache update changes emitted facts and must fire the
+        # probe. `cache_paths` stays records-only — it defines this
+        # source's own record authority (preflight/content_hash), and
+        # the cmssw cache is optional.
         self.change_probe = content_hash_change_probe(
-            cache_paths=self.cache_paths,
-            config={"records_path": self.records_path},
+            cache_paths=(self.records_path, self.cmssw_records_path),
+            config={
+                "records_path": self.records_path,
+                "cmssw_records_path": self.cmssw_records_path,
+            },
             emit_targets=CondDBGlobalTagSource,
             base=base,
         )
@@ -144,7 +153,7 @@ class CondDBGlobalTagSource:
         )
 
     def run(self, run_id: str, *, mode: str = "cursor") -> SourceRun:
-        records = self._records()
+        records, skipped = self._records_with_skips()
         revision = {
             "run_id": run_id,
             "content_hash": content_hash(self.cache_paths, base=self.base),
@@ -173,28 +182,37 @@ class CondDBGlobalTagSource:
 
         return SourceRun(
             facts=_facts(),
-            completed_scope=(mode in {"scope_complete", "reconcile"}),
+            completed_scope=(
+                mode in {"scope_complete", "reconcile"} and not skipped
+            ),
             run_mode=mode,
             health=cache_source_health(
                 description="CondDB global tag",
                 cache_paths=self.cache_paths,
                 record_count=len(records),
+                skipped_count=skipped,
                 base=self.base,
             ),
         )
 
     def _records(self) -> list[GlobalTagRecord]:
+        return self._records_with_skips()[0]
+
+    def _records_with_skips(self) -> tuple[list[GlobalTagRecord], int]:
         payload = load_json(self.records_path, base=self.base)
         if not isinstance(payload, list):
             raise ValueError(
                 f"{self.records_path}: expected a JSON list of global tags"
             )
         records: list[GlobalTagRecord] = []
+        skipped = 0
         for item in payload:
             if not isinstance(item, dict):
+                skipped += 1
                 continue
             name = str(item.get("name") or item.get("tag_name") or "").strip()
             if not name:
+                skipped += 1
                 continue
             records.append(GlobalTagRecord(
                 name=name,
@@ -207,7 +225,7 @@ class CondDBGlobalTagSource:
                     or ""
                 ),
             ))
-        return records
+        return records, skipped
 
 
 def _node_fact(

--- a/python/archi/sources/cric.py
+++ b/python/archi/sources/cric.py
@@ -220,7 +220,17 @@ class CRICSource:
                 reason="one or more CRIC cache files are missing",
                 checked_at=_checked_at(),
             )
-        records = self._records()
+        try:
+            records = self._records()
+        except ValueError as exc:
+            return SourcePreflightResult(
+                source_name=self.name,
+                status="endpoint_failed",
+                mode="cache",
+                required=True,
+                reason=str(exc),
+                checked_at=_checked_at(),
+            )
         return SourcePreflightResult(
             source_name=self.name,
             status="ok",
@@ -265,14 +275,38 @@ class CRICSource:
             storage_units=load_json(self.storage_units_path, base=self.base),
             compute_units=load_json(self.compute_units_path, base=self.base),
             facilities=load_json(self.facilities_path, base=self.base),
-            responsibilities=load_json(
-                self.responsibilities_path, base=self.base
-            ).get("result", []),
+            responsibilities=_responsibilities_result(
+                load_json(self.responsibilities_path, base=self.base),
+                self.responsibilities_path,
+            ),
         )
 
 
 def _checked_at() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def _responsibilities_result(payload: Any, path: str) -> list[list[Any]]:
+    """Extract the ``result`` rows, failing loudly on schema drift.
+
+    The former ``.get("result", [])`` default silently read an
+    error-shaped or drifted payload as "no responsibilities", which a
+    completed-scope run would then commit by retracting every operator
+    record. A payload without a ``result`` list must abort the run
+    instead of emptying it.
+    """
+    if not isinstance(payload, dict) or "result" not in payload:
+        raise ValueError(
+            f"{path}: expected a dict with a 'result' list of "
+            "responsibility rows; refusing to treat a drifted or "
+            "error-shaped payload as zero responsibilities"
+        )
+    result = payload["result"]
+    if not isinstance(result, list):
+        raise ValueError(
+            f"{path}: 'result' must be a list of responsibility rows"
+        )
+    return result
 
 
 def _build_records(

--- a/python/archi/sources/dbs.py
+++ b/python/archi/sources/dbs.py
@@ -140,7 +140,7 @@ class DBSDatasetSource:
         )
 
     def run(self, run_id: str, *, mode: str = "cursor") -> SourceRun:
-        records = self._records()
+        records, skipped = self._records_with_skips()
         revision = {
             "run_id": run_id,
             "content_hash": content_hash(self.cache_paths, base=self.base),
@@ -154,30 +154,39 @@ class DBSDatasetSource:
 
         return SourceRun(
             facts=_facts(),
-            completed_scope=(mode in {"scope_complete", "reconcile"}),
+            completed_scope=(
+                mode in {"scope_complete", "reconcile"} and not skipped
+            ),
             run_mode=mode,
             health=cache_source_health(
                 description="DBS dataset",
                 cache_paths=self.cache_paths,
                 record_count=len(records),
+                skipped_count=skipped,
                 base=self.base,
             ),
         )
 
     def _records(self) -> list[DBSDatasetRecord]:
+        return self._records_with_skips()[0]
+
+    def _records_with_skips(self) -> tuple[list[DBSDatasetRecord], int]:
         payload = load_json(self.records_path, base=self.base)
         if not isinstance(payload, list):
             raise ValueError(
                 f"{self.records_path}: expected a JSON list of datasets"
             )
         records: list[DBSDatasetRecord] = []
+        skipped = 0
         for item in payload:
             if not isinstance(item, dict):
+                skipped += 1
                 continue
             dataset_name = str(
                 item.get("dataset_name") or item.get("dataset") or ""
             ).strip()
             if not dataset_name:
+                skipped += 1
                 continue
             records.append(DBSDatasetRecord(
                 dataset_name=dataset_name,
@@ -217,7 +226,7 @@ class DBSDatasetSource:
                     item.get("total_events") or item.get("nevents") or 0
                 ),
             ))
-        return records
+        return records, skipped
 
 
 def _node_fact(

--- a/python/archi/sources/docs.py
+++ b/python/archi/sources/docs.py
@@ -29,6 +29,16 @@ Changes from the original:
   previously ingested pages. A bounce means landing on an SSO host (or
   a redirect to a login-looking body), never just ``/login`` in a
   page's own path or ``auth.cern.ch`` in its text.
+- 2026-08 adversarial review (see
+  ``pact/changes/circleback-fixes/notes-live.md``): a ``max_pages`` cap
+  that actually truncates the sitemap frontier is surfaced in health
+  and never claims ``completed_scope`` (the un-crawled pages would be
+  retracted under ``missing_from_completed_scope``); non-HTML sitemap
+  entries (PDFs/binaries, decided by response ``Content-Type``) are
+  skipped and counted instead of being regex-stripped into mojibake
+  pages — they are excluded from the source's scope *by design*, so a
+  clean crawl that skipped them may still claim the scope (a
+  previously mis-ingested binary is then correctly retracted).
 - ``DocumentationSource.run`` reports ``cache_missing`` health when the
   records cache is absent instead of raising from ``load_json``.
 - The reference-target caches (sites / releases / jira / services) are
@@ -99,6 +109,10 @@ ingest); (2) ``output_scope_summary`` must accompany
         source_name: docsite
         required: true
         records_path: data/docsite/records.json
+        # Enables the document_chunk references jira_issue edges
+        # declared above (as in bundles/cern-team/source-defaults/
+        # docsite.yaml); drop it together with those edge lines.
+        jira_records_path: data/jira/records.json
         # Optional reference-target caches — commented out on purpose.
         # WARNING: enabling any of them requires (a) uncommenting the
         # matching document_chunk references edges in output_signature
@@ -111,6 +125,10 @@ ingest); (2) ``output_scope_summary`` must accompany
         # sites_path: data/cric/sites.json
         # releases_path: data/cmssw-releases/records.json
         # services_path: data/cric-core/services.json
+      sync:
+        triggers: [manual, reconcile]
+        default_event_mode: scope_complete
+        reconcile_mode: scope_complete
 
     gitlab_docs:
       module: archi.sources.docs
@@ -124,6 +142,31 @@ ingest); (2) ``output_scope_summary`` must accompany
         authority_scope:
           source_family: <family>
           source_name: gitlab_docs
+        output_signature:
+          nodes:
+            - {subtype: documentation_page}
+            - {subtype: software_repository}
+            - {subtype: document_chunk}
+          edges:
+            - {src_subtype: software_repository, edge_type: contains, dst_subtype: documentation_page}
+            - {src_subtype: documentation_page, edge_type: contains, dst_subtype: document_chunk}
+            # Uncomment together with the matching reference-cache
+            # params (same warning as the docsite entry above):
+            # - {src_subtype: document_chunk, edge_type: references, dst_subtype: jira_issue}
+            # - {src_subtype: document_chunk, edge_type: references, dst_subtype: cmssw_release}
+            # - {src_subtype: document_chunk, edge_type: references, dst_subtype: site}
+            # - {src_subtype: document_chunk, edge_type: references, dst_subtype: infrastructure_service}
+        output_scope_summary:
+          summary: GitLab-exported documentation pages, their repos, and text chunks from the records cache
+          nodes: [documentation_page, software_repository, document_chunk]
+          edges:
+            - software_repository contains documentation_page
+            - documentation_page contains document_chunk
+            # Uncomment together with the matching reference-cache params:
+            # - document_chunk references jira_issue
+            # - document_chunk references cmssw_release
+            # - document_chunk references site
+            # - document_chunk references infrastructure_service
       source_class: discovery_crawl
       record_identity_kind: scoped_locator
       record_identity_fields: [project, path]
@@ -138,6 +181,17 @@ ingest); (2) ``output_scope_summary`` must accompany
         source_name: gitlab_docs
         required: true
         records_path: data/gitlab-docs/records.json
+        # Optional reference-target caches: see the docsite entry above
+        # for the warning; uncommenting one requires the matching edge
+        # lines in output_signature AND output_scope_summary.
+        # jira_records_path: data/jira/records.json
+        # sites_path: data/cric/sites.json
+        # releases_path: data/cmssw-releases/records.json
+        # services_path: data/cric-core/services.json
+      sync:
+        triggers: [manual, reconcile]
+        default_event_mode: scope_complete
+        reconcile_mode: scope_complete
 
     cmsweb_docs:                        # cms instance of the renamed class
       module: archi.sources.docs
@@ -151,6 +205,28 @@ ingest); (2) ``output_scope_summary`` must accompany
         authority_scope:
           source_family: <family>
           source_name: cmsweb_docs
+        output_signature:
+          nodes:
+            - {subtype: documentation_page}
+            - {subtype: document_chunk}
+          edges:
+            - {src_subtype: documentation_page, edge_type: contains, dst_subtype: document_chunk}
+            # Uncomment together with the matching reference-cache
+            # params (same warning as the docsite entry above):
+            # - {src_subtype: document_chunk, edge_type: references, dst_subtype: jira_issue}
+            # - {src_subtype: document_chunk, edge_type: references, dst_subtype: cmssw_release}
+            # - {src_subtype: document_chunk, edge_type: references, dst_subtype: site}
+            # - {src_subtype: document_chunk, edge_type: references, dst_subtype: infrastructure_service}
+        output_scope_summary:
+          summary: SSO-crawled documentation pages and text chunks from the live sitemap
+          nodes: [documentation_page, document_chunk]
+          edges:
+            - documentation_page contains document_chunk
+            # Uncomment together with the matching reference-cache params:
+            # - document_chunk references jira_issue
+            # - document_chunk references cmssw_release
+            # - document_chunk references site
+            # - document_chunk references infrastructure_service
       source_class: discovery_crawl
       record_identity_kind: scoped_locator
       record_identity_fields: [url]
@@ -163,6 +239,11 @@ ingest); (2) ``output_scope_summary`` must accompany
         source_name: cmsweb_docs
         sitemap_url: https://cms-http-group.docs.cern.ch/sitemap.xml
         cookie_file_env: CMS_HTTP_GROUP_DOCS_COOKIE_FILE
+        # Optional reference-target caches: see the docsite entry above.
+        # jira_records_path: data/jira/records.json
+        # sites_path: data/cric/sites.json
+        # releases_path: data/cmssw-releases/records.json
+        # services_path: data/cric-core/services.json
       sync:
         triggers: [manual, reconcile]
         default_event_mode: scope_complete
@@ -386,6 +467,15 @@ class SSOCookieDocsSource(DocumentationSource):
     :mod:`archi.auth.cookies` for the acquisition contract); only its
     *path* travels through the environment variable named by
     ``cookie_file_env`` — never a credential value.
+
+    Scope semantics: when ``max_pages`` actually truncates the sitemap
+    frontier the run emits what it crawled but never claims
+    ``completed_scope`` (the un-crawled pages would otherwise be
+    retracted under ``missing_from_completed_scope``). Non-HTML sitemap
+    entries (by response Content-Type; a missing header is treated as
+    HTML) are skipped and counted in health, and are excluded from the
+    source's scope by design — a clean crawl that skipped them may
+    still claim the scope.
     """
 
     name = "sso_docs"
@@ -515,6 +605,19 @@ class SSOCookieDocsSource(DocumentationSource):
                 chunker_name=self.chunker_name,
             )
 
+        truncation_note = ""
+        if crawl.truncated:
+            truncation_note = (
+                f"; sitemap frontier truncated by max_pages="
+                f"{self.max_pages} ({crawl.total_urls}/"
+                f"{crawl.sitemap_total} sitemap URLs crawled)"
+            )
+        skip_note = ""
+        if crawl.skipped_non_html:
+            skip_note = (
+                f"; skipped {len(crawl.skipped_non_html)} non-HTML "
+                "sitemap entries (excluded from scope by design)"
+            )
         if crawl.failed_urls:
             # A partially failed crawl must never claim a complete scope
             # (missing_from_completed_scope would retract the failed
@@ -533,7 +636,30 @@ class SSOCookieDocsSource(DocumentationSource):
                     reason=(
                         f"partial crawl: {len(crawl.failed_urls)}/"
                         f"{crawl.total_urls} sitemap pages failed (fetch "
-                        f"error or SSO login bounce), e.g. {samples}; "
+                        f"error or SSO login bounce), e.g. {samples}"
+                        f"{truncation_note}{skip_note}; "
+                        "no complete scope claimed"
+                    ),
+                ),
+            )
+        if crawl.truncated:
+            # max_pages actually cut the sitemap frontier: the
+            # un-crawled pages would be retracted under
+            # missing_from_completed_scope if this run claimed a
+            # complete scope. Emit what was crawled and claim nothing.
+            return SourceRun(
+                facts=_facts(),
+                completed_scope=False,
+                run_mode=mode,
+                health=SourceHealth(
+                    status="ok",
+                    mode="live",
+                    credential_refs=(self.cookie_file_env,),
+                    record_count=len(records),
+                    content_hash=record_hash,
+                    reason=(
+                        "SSO docs fetched through CERN SSO cookie"
+                        f"{truncation_note}{skip_note}; "
                         "no complete scope claimed"
                     ),
                 ),
@@ -548,7 +674,10 @@ class SSOCookieDocsSource(DocumentationSource):
                 credential_refs=(self.cookie_file_env,),
                 record_count=len(records),
                 content_hash=record_hash,
-                reason="SSO docs fetched through CERN SSO cookie",
+                reason=(
+                    "SSO docs fetched through CERN SSO cookie"
+                    f"{skip_note}"
+                ),
             ),
         )
 
@@ -575,17 +704,29 @@ class SSOCookieDocsSource(DocumentationSource):
                 f"login page; refresh the cookie file referenced by "
                 f"{self.cookie_file_env}"
             )
-        urls = _parse_sitemap(sitemap.content)
-        if self.max_pages is not None:
-            urls = urls[: self.max_pages]
+        all_urls = _parse_sitemap(sitemap.content)
+        urls = all_urls
+        truncated = False
+        if self.max_pages is not None and len(all_urls) > self.max_pages:
+            urls = all_urls[: self.max_pages]
+            truncated = True
         records: list[DocumentationRecord] = []
         failed_urls: list[str] = []
+        skipped_non_html: list[str] = []
         for url in urls:
             try:
                 resp = session.get(url, timeout=30)
                 resp.raise_for_status()
             except Exception:  # noqa: BLE001
                 failed_urls.append(url)
+                continue
+            content_type = _content_type(resp)
+            if content_type and not _is_html_content_type(content_type):
+                # PDFs/binaries listed in the sitemap are not
+                # documentation pages; regex tag-stripping would turn
+                # them into mojibake. Counted, excluded from scope by
+                # design (not a crawl failure).
+                skipped_non_html.append(url)
                 continue
             final_url = str(getattr(resp, "url", url) or url)
             text = getattr(resp, "text", "") or ""
@@ -610,16 +751,40 @@ class SSOCookieDocsSource(DocumentationSource):
             records=tuple(records),
             failed_urls=tuple(failed_urls),
             total_urls=len(urls),
+            sitemap_total=len(all_urls),
+            truncated=truncated,
+            skipped_non_html=tuple(skipped_non_html),
         )
 
 
 @dataclass(frozen=True)
 class _CrawlOutcome:
-    """One sitemap crawl: emitted records plus the pages that failed."""
+    """One sitemap crawl: emitted records plus the pages that failed.
+
+    ``total_urls`` is the crawled frontier (after any ``max_pages``
+    cap); ``sitemap_total`` is the full sitemap size and ``truncated``
+    is True when the cap actually cut the frontier. Non-HTML sitemap
+    entries (by Content-Type) are counted in ``skipped_non_html`` —
+    excluded from the source's scope by design, not crawl failures.
+    """
 
     records: tuple[DocumentationRecord, ...]
     failed_urls: tuple[str, ...]
     total_urls: int
+    sitemap_total: int = 0
+    truncated: bool = False
+    skipped_non_html: tuple[str, ...] = ()
+
+
+def _content_type(response: Any) -> str:
+    """Normalized media type of a response ('' when unavailable)."""
+    headers = getattr(response, "headers", None) or {}
+    raw = headers.get("Content-Type") or headers.get("content-type") or ""
+    return str(raw).split(";")[0].strip().lower()
+
+
+def _is_html_content_type(content_type: str) -> bool:
+    return "html" in content_type
 
 
 _SSO_LOGIN_HOSTS = frozenset({"auth.cern.ch", "login.cern.ch"})

--- a/python/archi/sources/dqm.py
+++ b/python/archi/sources/dqm.py
@@ -74,6 +74,7 @@ from archi.auth.cache import (
     load_json,
     resolve_repo_path,
 )
+from archi.sources._cache_report import skipped_items_status
 
 _GROUP_RE = re.compile(r"Cert_((?:Collisions|Cosmics|Commissioning)\d+)")
 _CERT_TYPE_MAP = {
@@ -150,7 +151,7 @@ class DQMSource:
         )
 
     def run(self, run_id: str, *, mode: str = "cursor") -> SourceRun:
-        records = self._records()
+        records, skipped = self._records_with_skips()
         revision = {
             "run_id": run_id,
             "content_hash": content_hash(self.cache_paths, base=self.base),
@@ -160,31 +161,45 @@ class DQMSource:
         def _facts() -> Iterator[Any]:
             yield from _facts_for_records(records, revision)
 
+        status, reason = skipped_items_status(
+            status="ok",
+            reason="local DQM certification cache used",
+            record_count=len(records),
+            skipped_count=skipped,
+        )
         return SourceRun(
             facts=_facts(),
-            completed_scope=(mode in {"scope_complete", "reconcile"}),
+            completed_scope=(
+                mode in {"scope_complete", "reconcile"} and not skipped
+            ),
             run_mode=mode,
             health=SourceHealth(
-                status="ok",
+                status=status,
                 mode="cache",
                 record_count=len(records),
                 content_hash=revision["content_hash"],
-                reason="local DQM certification cache used",
+                reason=reason,
             ),
         )
 
     def _records(self) -> list[DQMRecord]:
+        return self._records_with_skips()[0]
+
+    def _records_with_skips(self) -> tuple[list[DQMRecord], int]:
         payload = load_json(self.records_path, base=self.base)
         if not isinstance(payload, list):
             raise ValueError(
                 f"{self.records_path}: expected a JSON list of DQM records"
             )
         records: list[DQMRecord] = []
+        skipped = 0
         for item in payload:
             if not isinstance(item, dict):
+                skipped += 1
                 continue
             cert_name = str(item.get("cert_name") or "").strip()
             if not cert_name:
+                skipped += 1
                 continue
             run_range = item.get("run_range")
             parsed_range = None
@@ -199,7 +214,7 @@ class DQMSource:
                     str(v) for v in item.get("datasets") or () if v
                 ),
             ))
-        return records
+        return records, skipped
 
 
 def _checked_at() -> str:

--- a/python/archi/sources/gocdb.py
+++ b/python/archi/sources/gocdb.py
@@ -64,6 +64,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Iterator
+from urllib.parse import urlparse
 
 from okg.substrate.library.sources.base import (
     EdgeFact,
@@ -79,6 +80,7 @@ from archi.auth.cache import (
     load_json,
     resolve_repo_path,
 )
+from archi.sources._cache_report import skipped_items_status
 
 
 @dataclass(frozen=True)
@@ -159,7 +161,7 @@ class GoCDBDowntimeSource:
         )
 
     def run(self, run_id: str, *, mode: str = "cursor") -> SourceRun:
-        records = self._records()
+        records, skipped = self._records_with_skips()
         known_sites = _known_sites(self.sites_path, base=self.base)
         service_lookup = _service_lookup(self.services_path, base=self.base)
         revision = {
@@ -178,31 +180,49 @@ class GoCDBDowntimeSource:
                     service_lookup=service_lookup,
                 )
 
+        status, reason = skipped_items_status(
+            status="ok",
+            reason="local GOCDB downtime cache used",
+            record_count=len(records),
+            skipped_count=skipped,
+        )
         return SourceRun(
             facts=_facts(),
-            completed_scope=(mode in {"scope_complete", "reconcile"}),
+            completed_scope=(
+                mode in {"scope_complete", "reconcile"} and not skipped
+            ),
             run_mode=mode,
             health=SourceHealth(
-                status="ok",
+                status=status,
                 mode="cache",
                 record_count=len(records),
                 content_hash=revision["content_hash"],
-                reason="local GOCDB downtime cache used",
+                reason=reason,
             ),
         )
 
     def _records(self) -> list[DowntimeRecord]:
+        return self._records_with_skips()[0]
+
+    def _records_with_skips(self) -> tuple[list[DowntimeRecord], int]:
         payload = load_json(self.records_path, base=self.base)
         if not isinstance(payload, list):
             raise ValueError(
                 f"{self.records_path}: expected a JSON list of downtimes"
             )
         grouped: dict[int, dict[str, Any]] = {}
+        skipped = 0
         for item in payload:
             if not isinstance(item, dict):
+                skipped += 1
                 continue
-            downtime_id = int(item.get("downtime_id") or 0)
+            try:
+                downtime_id = int(item.get("downtime_id") or 0)
+            except (TypeError, ValueError):
+                skipped += 1
+                continue
             if downtime_id <= 0:
+                skipped += 1
                 continue
             entry = grouped.setdefault(downtime_id, {
                 "downtime_id": downtime_id,
@@ -236,7 +256,7 @@ class GoCDBDowntimeSource:
                 affected_hostnames=tuple(sorted(entry["hostnames"])),
             )
             for entry in grouped.values()
-        ]
+        ], skipped
 
 
 def _checked_at() -> str:
@@ -261,13 +281,26 @@ def _service_lookup(path: str, *, base: str | None = None) -> dict[str, str]:
         node_id = f"svc:{service_name}"
         endpoint = str(service.get("endpoint") or "")
         if endpoint:
-            host = endpoint.split("/", 1)[0].split(":", 1)[0]
+            host = _endpoint_host(endpoint)
             if host:
                 lookup.setdefault(host, node_id)
         name_host = str(service_name).rsplit("-", 1)[-1]
         if "." in name_host:
             lookup.setdefault(name_host, node_id)
     return lookup
+
+
+def _endpoint_host(endpoint: str) -> str:
+    """Hostname of a service endpoint, scheme-prefixed or bare.
+
+    The naive ``split("/", 1)[0]`` parse turned
+    ``https://host.cern.ch:8443/path`` into ``https:``, silently
+    breaking hostname -> service ``affects`` matching; use
+    :func:`urllib.parse.urlparse` when a scheme is present.
+    """
+    if "://" in endpoint:
+        return urlparse(endpoint).hostname or ""
+    return endpoint.split("/", 1)[0].split(":", 1)[0]
 
 
 def _downtime_node(

--- a/python/archi/sources/hypernews.py
+++ b/python/archi/sources/hypernews.py
@@ -109,6 +109,7 @@ from okg.substrate.sources.preflight import file_ref_preflight
 
 from archi.auth.cache import load_json, resolve_repo_path
 from archi.auth.cookies import looks_like_login_page
+from archi.sources._cache_report import skipped_items_status
 from archi.sources.docs import (
     _chunks,
     _pg_text,
@@ -135,6 +136,28 @@ class HyperNewsRecord:
     @property
     def node_id(self) -> str:
         return f"hn:{self.thread_id}"
+
+
+@dataclass
+class _FetchOutcome:
+    """Result of a live crawl, with every failure made visible.
+
+    A crawl that lost forums, threads, or the cookie must never be
+    mistaken for a complete one: ``missing_from_completed_scope`` would
+    retract every record the failed fetches used to produce.
+    """
+
+    records: list[HyperNewsRecord]
+    total_forums: int
+    failed_forums: list[str]
+    failed_hydrations: int = 0
+    truncated: bool = False
+    listed_threads: int = 0
+    error: str = ""
+
+    @property
+    def partial(self) -> bool:
+        return bool(self.failed_forums or self.failed_hydrations)
 
 
 class HyperNewsSource:
@@ -255,7 +278,18 @@ class HyperNewsSource:
             )
         cache_path = resolve_repo_path(self.records_path, base=self.base)
         if cache_path.is_file():
-            records = self._records_from_cache()
+            try:
+                records, _skipped = self._records_from_cache()
+            except ValueError as exc:
+                return SourcePreflightResult(
+                    source_name=self.name,
+                    status="endpoint_failed",
+                    mode="cache",
+                    required=self.required,
+                    cache_path=str(cache_path),
+                    reason=str(exc),
+                    checked_at=_checked_at(),
+                )
             return SourcePreflightResult(
                 source_name=self.name,
                 status="ok",
@@ -364,19 +398,102 @@ class HyperNewsSource:
 
         records = self._records
         run_health_mode = "fixture"
+        run_status = "ok"
         run_reason = "HyperNews fixture records supplied"
         credential_refs: tuple[str, ...] = ()
+        allow_scope = True
         if records is None:
             cache_path = resolve_repo_path(self.records_path, base=self.base)
             if cache_path.is_file():
-                records = self._records_from_cache()
+                records, skipped = self._records_from_cache()
                 run_health_mode = "cache"
-                run_reason = "HyperNews records read from local cache"
+                if not records:
+                    # An empty cache would otherwise claim a healthy
+                    # complete scope over zero threads (and replay
+                    # forever); refuse instead of retracting everything.
+                    return SourceRun(
+                        facts=[],
+                        completed_scope=False,
+                        run_mode=mode,
+                        health=SourceHealth(
+                            status="endpoint_failed",
+                            mode="cache",
+                            record_count=0,
+                            reason=(
+                                "HyperNews records cache "
+                                f"{self.records_path} contains no usable "
+                                "threads; refusing an empty complete "
+                                "scope (delete the cache to force a "
+                                "live re-fetch)"
+                            ),
+                        ),
+                    )
+                run_status, run_reason = skipped_items_status(
+                    status="ok",
+                    reason="HyperNews records read from local cache",
+                    record_count=len(records),
+                    skipped_count=skipped,
+                )
+                allow_scope = not skipped
             else:
-                records = self._fetch_and_cache()
                 run_health_mode = "live"
-                run_reason = "HyperNews records fetched through SSO cookie"
                 credential_refs = (self.cookie_file_env,)
+                outcome = self._fetch()
+                if not outcome.records:
+                    return SourceRun(
+                        facts=[],
+                        completed_scope=False,
+                        run_mode=mode,
+                        health=SourceHealth(
+                            status="endpoint_failed",
+                            mode="live",
+                            credential_refs=credential_refs,
+                            record_count=0,
+                            endpoint=self.base_url,
+                            reason=_total_failure_reason(outcome),
+                        ),
+                    )
+                records = outcome.records
+                run_reason = (
+                    "HyperNews records fetched through SSO cookie"
+                )
+                problems: list[str] = []
+                if outcome.failed_forums:
+                    samples = "; ".join(outcome.failed_forums[:3])
+                    problems.append(
+                        f"{len(outcome.failed_forums)}/"
+                        f"{outcome.total_forums} forum listings failed "
+                        f"(e.g. {samples})"
+                    )
+                if outcome.failed_hydrations:
+                    problems.append(
+                        f"{outcome.failed_hydrations}/"
+                        f"{outcome.listed_threads} thread fetches "
+                        "failed and were dropped"
+                    )
+                if problems:
+                    # Emit what succeeded, but never claim a complete
+                    # scope over a partially failed crawl (docs.py
+                    # partial-crawl idiom).
+                    run_status = "endpoint_failed"
+                    allow_scope = False
+                    run_reason = (
+                        "partial HyperNews crawl: "
+                        + "; ".join(problems)
+                        + "; no complete scope claimed"
+                    )
+                if outcome.truncated:
+                    allow_scope = False
+                    run_reason += (
+                        f"; max_threads={self.max_threads} truncated "
+                        "forum listings; no complete scope claimed"
+                    )
+                # Only a full, untruncated crawl may be persisted: a
+                # partial cache would replay on the next run as a
+                # healthy complete scope and retract the missing
+                # threads.
+                if not problems and not outcome.truncated:
+                    self._write_cache(records)
         record_hash = _records_hash(records)
         revision = {
             "run_id": run_id,
@@ -437,10 +554,12 @@ class HyperNewsSource:
 
         return SourceRun(
             facts=_facts(),
-            completed_scope=(mode in {"scope_complete", "reconcile"}),
+            completed_scope=(
+                mode in {"scope_complete", "reconcile"} and allow_scope
+            ),
             run_mode=mode,
             health=SourceHealth(
-                status="ok",
+                status=run_status,
                 mode=run_health_mode,
                 credential_refs=credential_refs,
                 record_count=len(records),
@@ -449,16 +568,34 @@ class HyperNewsSource:
             ),
         )
 
-    def _records_from_cache(self) -> list[HyperNewsRecord]:
+    def _records_from_cache(self) -> tuple[list[HyperNewsRecord], int]:
         raw = load_json(self.records_path, base=self.base)
         if isinstance(raw, dict):
-            raw = raw.get("records", [])
-        return [
-            _record_from_dict(item) for item in raw if isinstance(item, dict)
-        ]
+            if "records" not in raw:
+                raise ValueError(
+                    f"{self.records_path}: expected a 'records' list in "
+                    "the cache dict; refusing to treat a drifted payload "
+                    "as zero threads"
+                )
+            raw = raw["records"]
+        if not isinstance(raw, list):
+            raise ValueError(
+                f"{self.records_path}: expected a JSON list of threads"
+            )
+        records: list[HyperNewsRecord] = []
+        skipped = 0
+        for item in raw:
+            if not isinstance(item, dict):
+                skipped += 1
+                continue
+            record = _record_from_dict(item)
+            if not record.thread_id:
+                skipped += 1
+                continue
+            records.append(record)
+        return records, skipped
 
-    def _fetch_and_cache(self) -> list[HyperNewsRecord]:
-        records = self._fetch()
+    def _write_cache(self, records: list[HyperNewsRecord]) -> None:
         path = resolve_repo_path(self.records_path, base=self.base)
         path.parent.mkdir(parents=True, exist_ok=True)
         tmp = path.with_suffix(path.suffix + ".tmp")
@@ -468,31 +605,50 @@ class HyperNewsSource:
             encoding="utf-8",
         )
         tmp.replace(path)
-        return records
 
-    def _fetch(self) -> list[HyperNewsRecord]:
+    def _fetch(self) -> _FetchOutcome:
         import http.cookiejar
         import requests
 
         cookie_file = os.environ.get(self.cookie_file_env, "")
         if not cookie_file or not Path(cookie_file).is_file():
-            return []
+            return _FetchOutcome(
+                records=[],
+                total_forums=len(self.forums),
+                failed_forums=list(self.forums),
+                error="cookie file missing or unreadable",
+            )
         jar = http.cookiejar.MozillaCookieJar(cookie_file)
         jar.load(ignore_discard=True, ignore_expires=True)
         session = requests.Session()
         session.cookies = jar
         records: list[HyperNewsRecord] = []
+        failed_forums: list[str] = []
+        truncated = False
         for forum in self.forums:
             forum_url = f"{self.base_url}/HyperNews/CMS/get/{forum}.html"
             try:
                 resp = session.get(forum_url, timeout=self.fetch_timeout)
                 resp.raise_for_status()
-            except Exception:
+            except Exception as exc:  # noqa: BLE001
+                failed_forums.append(f"{forum}: {type(exc).__name__}")
                 continue
-            records.extend(self._parse_threads(resp.text, forum))
+            parsed = self._parse_threads(resp.text, forum)
+            if (
+                self.max_threads is not None
+                and len(parsed) >= self.max_threads
+            ):
+                truncated = True
+            records.extend(parsed)
 
+        listed_threads = len(records)
         if not records:
-            return []
+            return _FetchOutcome(
+                records=[],
+                total_forums=len(self.forums),
+                failed_forums=failed_forums,
+                truncated=truncated,
+            )
 
         thread_local = threading.local()
 
@@ -507,14 +663,17 @@ class HyperNewsSource:
             thread_local.session = worker_session
             return worker_session
 
-        def _hydrate(thread: HyperNewsRecord) -> HyperNewsRecord:
+        def _hydrate(thread: HyperNewsRecord) -> HyperNewsRecord | None:
             try:
                 thread_resp = _session().get(
                     thread.url, timeout=self.fetch_timeout,
                 )
                 thread_resp.raise_for_status()
-            except Exception:
-                return thread
+            except Exception:  # noqa: BLE001
+                # Emitting the un-hydrated listing stub would blank the
+                # thread's body/author and drop its chunks under a
+                # complete scope; drop it and report instead.
+                return None
             return HyperNewsRecord(
                 thread_id=thread.thread_id,
                 title=thread.title,
@@ -528,7 +687,16 @@ class HyperNewsSource:
 
         workers = max(1, int(self.max_workers))
         with ThreadPoolExecutor(max_workers=workers) as executor:
-            return list(executor.map(_hydrate, records))
+            results = list(executor.map(_hydrate, records))
+        hydrated = [record for record in results if record is not None]
+        return _FetchOutcome(
+            records=hydrated,
+            total_forums=len(self.forums),
+            failed_forums=failed_forums,
+            failed_hydrations=len(results) - len(hydrated),
+            truncated=truncated,
+            listed_threads=listed_threads,
+        )
 
     def _parse_threads(self, markup: str, forum: str) -> list[HyperNewsRecord]:
         records: list[HyperNewsRecord] = []
@@ -557,6 +725,31 @@ class HyperNewsSource:
 
 def _checked_at() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def _total_failure_reason(outcome: _FetchOutcome) -> str:
+    """Reason string for a live crawl that produced zero records."""
+    if outcome.error:
+        detail = f"HyperNews fetch failed: {outcome.error}"
+    elif outcome.failed_forums:
+        samples = "; ".join(outcome.failed_forums[:3])
+        detail = (
+            f"{len(outcome.failed_forums)}/{outcome.total_forums} "
+            f"forum listings failed (e.g. {samples})"
+        )
+        if len(outcome.failed_forums) < outcome.total_forums:
+            detail += (
+                "; the reachable forum listings parsed to zero threads"
+            )
+    else:
+        detail = (
+            f"all {outcome.total_forums} forum listings were reachable "
+            "but parsed to zero threads (markup drift?)"
+        )
+    return (
+        f"{detail}; treated as fetch failure — no records cache "
+        "written and no scope claimed"
+    )
 
 
 def _thread_node(

--- a/python/archi/sources/hypernews.py
+++ b/python/archi/sources/hypernews.py
@@ -290,6 +290,19 @@ class HyperNewsSource:
                     reason=str(exc),
                     checked_at=_checked_at(),
                 )
+            if not records:
+                # Match run()'s refusal: an empty cache must not look
+                # healthy in preflight while run() rejects it.
+                return SourcePreflightResult(
+                    source_name=self.name,
+                    status="endpoint_failed",
+                    mode="cache",
+                    required=self.required,
+                    cache_path=str(cache_path),
+                    record_count=0,
+                    reason=self._empty_cache_reason(),
+                    checked_at=_checked_at(),
+                )
             return SourcePreflightResult(
                 source_name=self.name,
                 status="ok",
@@ -411,6 +424,8 @@ class HyperNewsSource:
                     # An empty cache would otherwise claim a healthy
                     # complete scope over zero threads (and replay
                     # forever); refuse instead of retracting everything.
+                    # (Preflight reports the same refusal, so this is
+                    # normally caught before reaching here.)
                     return SourceRun(
                         facts=[],
                         completed_scope=False,
@@ -419,13 +434,7 @@ class HyperNewsSource:
                             status="endpoint_failed",
                             mode="cache",
                             record_count=0,
-                            reason=(
-                                "HyperNews records cache "
-                                f"{self.records_path} contains no usable "
-                                "threads; refusing an empty complete "
-                                "scope (delete the cache to force a "
-                                "live re-fetch)"
-                            ),
+                            reason=self._empty_cache_reason(),
                         ),
                     )
                 run_status, run_reason = skipped_items_status(
@@ -566,6 +575,13 @@ class HyperNewsSource:
                 content_hash=record_hash,
                 reason=run_reason,
             ),
+        )
+
+    def _empty_cache_reason(self) -> str:
+        return (
+            f"HyperNews records cache {self.records_path} contains no "
+            "usable threads; refusing an empty complete scope (delete "
+            "the cache to force a live re-fetch)"
         )
 
     def _records_from_cache(self) -> tuple[list[HyperNewsRecord], int]:

--- a/python/archi/sources/indico.py
+++ b/python/archi/sources/indico.py
@@ -91,6 +91,7 @@ from archi.auth.cache import (
     load_json,
     resolve_repo_path,
 )
+from archi.sources._cache_report import skipped_items_status
 
 _TAG_RE = re.compile(r"<[^>]+>")
 _WHITESPACE_RE = re.compile(r"\s+")
@@ -191,7 +192,7 @@ class IndicoSource:
         )
 
     def run(self, run_id: str, *, mode: str = "cursor") -> SourceRun:
-        records = self._records()
+        records, skipped = self._records_with_skips()
         revision = {
             "run_id": run_id,
             "content_hash": content_hash(self.cache_paths, base=self.base),
@@ -205,20 +206,31 @@ class IndicoSource:
                     record, revision, self.chunker_name
                 )
 
+        status, reason = skipped_items_status(
+            status="ok",
+            reason="local Indico cache used",
+            record_count=len(records),
+            skipped_count=skipped,
+        )
         return SourceRun(
             facts=_facts(),
-            completed_scope=(mode in {"scope_complete", "reconcile"}),
+            completed_scope=(
+                mode in {"scope_complete", "reconcile"} and not skipped
+            ),
             run_mode=mode,
             health=SourceHealth(
-                status="ok",
+                status=status,
                 mode="cache",
                 record_count=len(records),
                 content_hash=revision["content_hash"],
-                reason="local Indico cache used",
+                reason=reason,
             ),
         )
 
     def _records(self) -> list[IndicoEventRecord]:
+        return self._records_with_skips()[0]
+
+    def _records_with_skips(self) -> tuple[list[IndicoEventRecord], int]:
         payload = load_json(self.records_path, base=self.base)
         if not isinstance(payload, list):
             raise ValueError(
@@ -226,15 +238,22 @@ class IndicoSource:
             )
         records: list[IndicoEventRecord] = []
         seen_event_ids: set[str] = set()
+        skipped = 0
         for item in payload:
             if not isinstance(item, dict):
+                skipped += 1
                 continue
             event_id = str(item.get("id") or item.get("event_id") or "")
-            if not event_id or event_id in seen_event_ids:
+            if not event_id:
+                skipped += 1
+                continue
+            # Duplicate event ids are a deliberate dedup (the record is
+            # still represented by its first occurrence), not drift.
+            if event_id in seen_event_ids:
                 continue
             seen_event_ids.add(event_id)
             records.append(_parse_event(event_id, item, self.base_url))
-        return records
+        return records, skipped
 
 
 def _checked_at() -> str:
@@ -414,7 +433,14 @@ def _pdf_document_facts(
         )
         for chunk_index, offset, chunk_text in _chunks(pdf.text):
             chunk_hash = _sha256(chunk_text)
-            chunk_id = f"chunk:{chunk_hash[:16]}"
+            # Salt the chunk id with the parent doc id + index (the
+            # hypernews pattern): a bare content hash collides identical
+            # boilerplate from different events onto one node with
+            # contradictory parents.
+            chunk_id = (
+                "chunk:"
+                f"{_sha256(f'{doc_id}\\0{chunk_index}\\0{chunk_text}')[:16]}"
+            )
             chunk_record_id = {
                 **source_record_id,
                 "chunk_index": chunk_index,

--- a/python/archi/sources/jira.py
+++ b/python/archi/sources/jira.py
@@ -60,6 +60,16 @@ Changes from the cms original:
   literal backslash-zero separator (the original's ``f'..\\0..'``
   inside an f-string), *not* the NUL byte docs.py uses. Changing it
   would re-key every jira chunk at cutover.
+- 2026-08 adversarial review (see
+  ``pact/changes/circleback-fixes/notes-live.md``): ``run()`` now
+  cross-checks the parsed record count against ``meta.json``'s
+  ``record_count`` (the original consulted the meta file only in the
+  cache-missing preflight branch). On a mismatch the cache is treated
+  as truncated/stale: facts are still emitted, health is
+  ``endpoint_failed`` (the closed status vocabulary has no
+  ``degraded``) with both counts in the reason, and the run never
+  claims ``completed_scope`` — a truncated cache claimed complete
+  would retract every record it happened to drop.
 
 Registry-entry template — INGEST-PROVEN 2026-08-11 on a scratch
 instance (okg dev@21c5b8c3e). Three things beyond the registry entry
@@ -488,6 +498,36 @@ class JiraIssueSource:
                         targets,
                     )
 
+        expected = _expected_count(self.meta_path, base=self.base)
+        if expected is not None and expected != len(records):
+            # meta.json says the fetch produced `expected` records but
+            # the cache parsed a different number: the records file is
+            # truncated or stale relative to its own metadata. Emit
+            # what parsed, but never claim a completed scope — under
+            # missing_from_completed_scope a truncated cache claimed
+            # complete would retract every record it dropped. The
+            # closed status vocabulary has no 'degraded', so report
+            # endpoint_failed.
+            return SourceRun(
+                facts=_facts(),
+                completed_scope=False,
+                run_mode=mode,
+                health=SourceHealth(
+                    status="endpoint_failed",
+                    mode="cache",
+                    credential_refs=self._credential_refs,
+                    alias_refs=self._alias_refs,
+                    record_count=len(records),
+                    content_hash=revision["content_hash"],
+                    reason=(
+                        f"JIRA records cache parsed {len(records)} records "
+                        f"but {self.meta_path} reports record_count="
+                        f"{expected}; cache looks truncated or stale, "
+                        "facts emitted, no complete scope claimed"
+                    ),
+                    checked_at=_checked_at(),
+                ),
+            )
         return SourceRun(
             facts=_facts(),
             completed_scope=(mode in {"scope_complete", "reconcile"}),

--- a/python/archi/sources/monit.py
+++ b/python/archi/sources/monit.py
@@ -31,8 +31,9 @@ emission, and cache-or-live run shape. Changes from the original:
 - ``source_name`` is a constructor parameter (multiple instances of one
   class can coexist in a registry), defaulting to the cms names.
 
-Failure semantics (the docs.py/twiki.py completeness discipline — the
-original already satisfied it; kept, not weakened):
+Failure semantics (the docs.py/twiki.py completeness discipline; the
+2026-08 adversarial review hardened the cms original's version of it —
+see ``pact/changes/circleback-fixes/notes-live.md``):
 
 - A missing configured credential (no cache file and ``token_env``
   unset) is ``missing_credential`` health with ``completed_scope=False``
@@ -45,11 +46,30 @@ original already satisfied it; kept, not weakened):
   ``missing_credential`` / ``auth_failed`` / ``tls_failed`` /
   ``endpoint_failed`` / ``cache_missing`` / ``not_applicable`` / ...);
   ``SourceHealth.__post_init__`` rejects anything else.
-- A *successful* read that returns zero buckets reports
-  ``skipped_optional`` and may still claim the mode's scope (the scope
-  is genuinely empty); the dataset overlay's streaming path raises on a
-  mid-pagination failure so the runner fails the run instead of
+- A *partial* OpenSearch response — ``timed_out: true``, failed shards,
+  or a bucket-limited terms aggregation that dropped buckets
+  (``sum_other_doc_count`` / ``doc_count_error_upper_bound`` > 0) —
+  still emits the records it carries but reports ``endpoint_failed``
+  (the closed vocabulary has no ``degraded``) with
+  ``completed_scope=False``: a truncated snapshot must never become the
+  retraction baseline. The dataset overlay's streaming path instead
+  raises on any partial page so the runner fails the run rather than
   committing a partial scope.
+- A *successful* read that returns zero buckets reports
+  ``skipped_optional`` with ``completed_scope=False``: under the
+  ``ignore_unavailable: true`` wildcard-index queries these sources
+  issue, a renamed index or stalled ingestion pipeline is
+  indistinguishable from a genuinely empty window, so an empty result
+  never claims a complete (empty) scope that would retract every
+  previously ingested record.
+- The dataset overlay's live page cache is keyed by a fingerprint that
+  includes the resolved snapshot date, and an entry only satisfies a
+  run when its ``cached_at`` is on the same UTC day and younger than
+  ``page_cache_ttl_hours`` — a cached page from a previous day can
+  never satisfy a new day's run. ``cache_live_pages`` stays ``true`` by
+  default on purpose: with date-scoped keys the cache can only replay
+  the current snapshot day's pages, which is its role (crash/resume
+  within a day without re-querying MONIT).
 
 Registry-entry templates — same three prerequisites as the
 archi/sources/jira.py and archi/sources/docs.py templates, plus one
@@ -255,7 +275,14 @@ specific to this family:
         page_size: 250
         max_replica_rses: 250
         page_cache_dir: data/monit-rucio-datasets/pages  # cms: data/cms/monit-rucio-datasets/pages
+        # cache_live_pages stays true on purpose (2026-08 review): the
+        # page-cache fingerprint includes the resolved snapshot date and
+        # entries expire after page_cache_ttl_hours (same UTC day only),
+        # so the cache can only replay the current day's pages — its
+        # crash/resume role — never yesterday's datasets stamped with
+        # today's date.
         cache_live_pages: true
+        page_cache_ttl_hours: 24.0
         # CMS defaults, shown for overriding on another instance:
         # grafana_base_url: https://monit-grafana.cern.ch
         # datasource_id: 10151
@@ -274,7 +301,7 @@ import os
 import re
 import time
 from dataclasses import asdict, dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Callable, Iterable, Iterator
 
@@ -411,6 +438,102 @@ class RucioDatasetRecord:
         return f"dataset:{self.dataset}"
 
 
+@dataclass(frozen=True)
+class _ResponseQuality:
+    """Completeness markers of one MONIT OpenSearch response.
+
+    An HTTP-200 ``_msearch`` response can still be partial:
+    ``timed_out: true``, failed shards, or bucket-limited terms
+    aggregations that dropped buckets (``sum_other_doc_count`` /
+    ``doc_count_error_upper_bound`` > 0). Any of those must keep the
+    run from claiming a completed scope — under
+    ``missing_from_completed_scope`` a partial snapshot claimed
+    complete would retract every record the response happened to drop.
+    """
+
+    timed_out: bool = False
+    shards_failed: int = 0
+    shards_total: int = 0
+    truncated_aggs: tuple[str, ...] = ()
+
+    @property
+    def complete(self) -> bool:
+        return not (
+            self.timed_out or self.shards_failed or self.truncated_aggs
+        )
+
+    def describe(self) -> str:
+        parts = []
+        if self.timed_out:
+            parts.append("timed_out=true")
+        if self.shards_failed:
+            total = self.shards_total or "?"
+            parts.append(f"shards failed {self.shards_failed}/{total}")
+        if self.truncated_aggs:
+            parts.append(
+                "truncated terms aggregations: "
+                + ", ".join(self.truncated_aggs)
+            )
+        return "; ".join(parts) or "complete"
+
+
+def _response_quality(payload: dict[str, Any]) -> _ResponseQuality:
+    response = _first_response(payload)
+    shards = response.get("_shards") or {}
+    truncated: list[str] = []
+    _collect_agg_truncations(
+        response.get("aggregations") or {}, "", truncated
+    )
+    return _ResponseQuality(
+        timed_out=bool(response.get("timed_out")),
+        shards_failed=int(shards.get("failed") or 0),
+        shards_total=int(shards.get("total") or 0),
+        truncated_aggs=tuple(truncated),
+    )
+
+
+def _collect_agg_truncations(node: Any, path: str, out: list[str]) -> None:
+    """Record bucket-limited aggregations that silently dropped buckets.
+
+    Walks the aggregation tree (nested aggregations live inside each
+    bucket) and flags any ``buckets`` aggregation whose
+    ``sum_other_doc_count`` or ``doc_count_error_upper_bound`` is
+    positive — the fixed ``size`` cap truncated it.
+    """
+    if not isinstance(node, dict):
+        return
+    for name, value in node.items():
+        if not isinstance(value, dict):
+            continue
+        child = f"{path}.{name}" if path else name
+        buckets = value.get("buckets")
+        if not isinstance(buckets, list):
+            continue
+        other = int(value.get("sum_other_doc_count") or 0)
+        bound = int(value.get("doc_count_error_upper_bound") or 0)
+        if other > 0 or bound > 0:
+            out.append(
+                f"{child} (sum_other_doc_count={other}, "
+                f"doc_count_error_upper_bound={bound})"
+            )
+        for bucket in buckets:
+            _collect_agg_truncations(bucket, child, out)
+
+
+def _merge_quality(
+    left: _ResponseQuality,
+    right: _ResponseQuality,
+) -> _ResponseQuality:
+    return _ResponseQuality(
+        timed_out=left.timed_out or right.timed_out,
+        shards_failed=left.shards_failed + right.shards_failed,
+        shards_total=max(left.shards_total, right.shards_total),
+        truncated_aggs=tuple(dict.fromkeys(
+            (*left.truncated_aggs, *right.truncated_aggs)
+        )),
+    )
+
+
 class MONITSAMSource:
     """Emit site-level SAM/SiteMon monitoring snapshots."""
 
@@ -472,7 +595,7 @@ class MONITSAMSource:
         **_: Any,
     ) -> SourceRun:
         try:
-            records, run_mode, revision = self._load_records(run_id)
+            records, run_mode, revision, quality = self._load_records(run_id)
         except MissingMONITCredential as exc:
             return _missing_credential_run(mode, self.token_env, str(exc))
         except Exception as exc:  # noqa: BLE001
@@ -493,13 +616,16 @@ class MONITSAMSource:
             records=records,
             ok_reason="MONIT SAM/SiteMon records loaded",
             empty_reason="MONIT SAM/SiteMon query returned no site buckets",
+            quality=quality,
         )
 
     def _load_records(
         self,
         run_id: str,
-    ) -> tuple[list[SiteAvailabilityRecord], str, dict[str, Any]]:
-        records, run_mode, hash_value = _load_cache_or_live(
+    ) -> tuple[
+        list[SiteAvailabilityRecord], str, dict[str, Any], _ResponseQuality
+    ]:
+        records, run_mode, hash_value, quality = _load_cache_or_live(
             records_path=self.records_path,
             token_env=self.token_env,
             cache_loader=self._records_from_cache,
@@ -514,20 +640,30 @@ class MONITSAMSource:
             to_time=self.to_time,
             hash_value=hash_value,
             n_records=len(records),
-        )
+        ), quality
 
-    def _records_from_cache(self) -> list[SiteAvailabilityRecord]:
+    def _records_from_cache(
+        self,
+    ) -> tuple[list[SiteAvailabilityRecord], _ResponseQuality]:
         payload = load_json(self.records_path, base=self.base)
         if isinstance(payload, dict) and "responses" in payload:
-            return _parse_sitemon_response(payload, snapshot_date=_today())
+            return (
+                _parse_sitemon_response(payload, snapshot_date=_today()),
+                _response_quality(payload),
+            )
         if not isinstance(payload, list):
             raise ValueError(
                 f"{self.records_path}: expected a list of records or "
                 "MONIT _msearch response"
             )
-        return [_sam_record_from_mapping(item) for item in payload if item]
+        return (
+            [_sam_record_from_mapping(item) for item in payload if item],
+            _ResponseQuality(),
+        )
 
-    def _records_from_live(self, token: str) -> list[SiteAvailabilityRecord]:
+    def _records_from_live(
+        self, token: str
+    ) -> tuple[list[SiteAvailabilityRecord], _ResponseQuality]:
         response = _monit_msearch(
             grafana_base_url=self.grafana_base_url,
             datasource_id=self.datasource_id,
@@ -541,7 +677,10 @@ class MONITSAMSource:
             ),
             timeout=self.timeout,
         )
-        return _parse_sitemon_response(response, snapshot_date=_today())
+        return (
+            _parse_sitemon_response(response, snapshot_date=_today()),
+            _response_quality(response),
+        )
 
 
 class MONITCondorSource:
@@ -603,7 +742,7 @@ class MONITCondorSource:
         **_: Any,
     ) -> SourceRun:
         try:
-            records, run_mode, revision = self._load_records(run_id)
+            records, run_mode, revision, quality = self._load_records(run_id)
         except MissingMONITCredential as exc:
             return _missing_credential_run(mode, self.token_env, str(exc))
         except Exception as exc:  # noqa: BLE001
@@ -624,13 +763,16 @@ class MONITCondorSource:
             records=records,
             ok_reason="MONIT Condor records loaded",
             empty_reason="MONIT Condor query returned no site buckets",
+            quality=quality,
         )
 
     def _load_records(
         self,
         run_id: str,
-    ) -> tuple[list[CondorComputeRecord], str, dict[str, Any]]:
-        records, run_mode, hash_value = _load_cache_or_live(
+    ) -> tuple[
+        list[CondorComputeRecord], str, dict[str, Any], _ResponseQuality
+    ]:
+        records, run_mode, hash_value, quality = _load_cache_or_live(
             records_path=self.records_path,
             token_env=self.token_env,
             cache_loader=self._records_from_cache,
@@ -645,20 +787,30 @@ class MONITCondorSource:
             to_time=self.to_time,
             hash_value=hash_value,
             n_records=len(records),
-        )
+        ), quality
 
-    def _records_from_cache(self) -> list[CondorComputeRecord]:
+    def _records_from_cache(
+        self,
+    ) -> tuple[list[CondorComputeRecord], _ResponseQuality]:
         payload = load_json(self.records_path, base=self.base)
         if isinstance(payload, dict) and "responses" in payload:
-            return _parse_condor_response(payload, snapshot_date=_today())
+            return (
+                _parse_condor_response(payload, snapshot_date=_today()),
+                _response_quality(payload),
+            )
         if not isinstance(payload, list):
             raise ValueError(
                 f"{self.records_path}: expected a list of records or "
                 "MONIT _msearch response"
             )
-        return [_condor_record_from_mapping(item) for item in payload if item]
+        return (
+            [_condor_record_from_mapping(item) for item in payload if item],
+            _ResponseQuality(),
+        )
 
-    def _records_from_live(self, token: str) -> list[CondorComputeRecord]:
+    def _records_from_live(
+        self, token: str
+    ) -> tuple[list[CondorComputeRecord], _ResponseQuality]:
         response = _monit_msearch(
             grafana_base_url=self.grafana_base_url,
             datasource_id=self.datasource_id,
@@ -671,7 +823,10 @@ class MONITCondorSource:
             ),
             timeout=self.timeout,
         )
-        return _parse_condor_response(response, snapshot_date=_today())
+        return (
+            _parse_condor_response(response, snapshot_date=_today()),
+            _response_quality(response),
+        )
 
 
 class MONITRucioTransferSource:
@@ -735,7 +890,7 @@ class MONITRucioTransferSource:
         **_: Any,
     ) -> SourceRun:
         try:
-            records, run_mode, revision = self._load_records(run_id)
+            records, run_mode, revision, quality = self._load_records(run_id)
         except MissingMONITCredential as exc:
             return _missing_credential_run(mode, self.token_env, str(exc))
         except Exception as exc:  # noqa: BLE001
@@ -756,13 +911,16 @@ class MONITRucioTransferSource:
             records=records,
             ok_reason="MONIT Rucio transfer records loaded",
             empty_reason="MONIT Rucio transfer query returned no transfer buckets",
+            quality=quality,
         )
 
     def _load_records(
         self,
         run_id: str,
-    ) -> tuple[list[RucioTransferRecord], str, dict[str, Any]]:
-        records, run_mode, hash_value = _load_cache_or_live(
+    ) -> tuple[
+        list[RucioTransferRecord], str, dict[str, Any], _ResponseQuality
+    ]:
+        records, run_mode, hash_value, quality = _load_cache_or_live(
             records_path=self.records_path,
             token_env=self.token_env,
             cache_loader=self._records_from_cache,
@@ -777,24 +935,36 @@ class MONITRucioTransferSource:
             to_time=self.to_time,
             hash_value=hash_value,
             n_records=len(records),
-        )
+        ), quality
 
-    def _records_from_cache(self) -> list[RucioTransferRecord]:
+    def _records_from_cache(
+        self,
+    ) -> tuple[list[RucioTransferRecord], _ResponseQuality]:
         payload = load_json(self.records_path, base=self.base)
         if isinstance(payload, dict) and "responses" in payload:
-            return _parse_rucio_transfer_response(payload, snapshot_date=_today())
+            return (
+                _parse_rucio_transfer_response(
+                    payload, snapshot_date=_today()
+                ),
+                _response_quality(payload),
+            )
         if not isinstance(payload, list):
             raise ValueError(
                 f"{self.records_path}: expected a list of records or "
                 "MONIT _msearch response"
             )
-        return _dedupe_rucio_transfer_records([
-            _rucio_transfer_record_from_mapping(item)
-            for item in payload
-            if item
-        ])
+        return (
+            _dedupe_rucio_transfer_records([
+                _rucio_transfer_record_from_mapping(item)
+                for item in payload
+                if item
+            ]),
+            _ResponseQuality(),
+        )
 
-    def _records_from_live(self, token: str) -> list[RucioTransferRecord]:
+    def _records_from_live(
+        self, token: str
+    ) -> tuple[list[RucioTransferRecord], _ResponseQuality]:
         response = _monit_msearch(
             grafana_base_url=self.grafana_base_url,
             datasource_id=self.datasource_id,
@@ -808,9 +978,9 @@ class MONITRucioTransferSource:
             ),
             timeout=self.timeout,
         )
-        return _parse_rucio_transfer_response(
-            response,
-            snapshot_date=_today(),
+        return (
+            _parse_rucio_transfer_response(response, snapshot_date=_today()),
+            _response_quality(response),
         )
 
 
@@ -840,6 +1010,7 @@ class MONITRucioDatasetSource:
         max_replica_rses: int = 250,
         page_cache_dir: str = "data/monit-rucio-datasets/pages",
         cache_live_pages: bool = True,
+        page_cache_ttl_hours: float = 24.0,
         exclude_dataset_patterns: tuple[str, ...] = (
             DEFAULT_EXCLUDED_DATASET_PATTERNS
         ),
@@ -858,6 +1029,7 @@ class MONITRucioDatasetSource:
         self.max_replica_rses = max_replica_rses
         self.page_cache_dir = page_cache_dir
         self.cache_live_pages = cache_live_pages
+        self.page_cache_ttl_hours = page_cache_ttl_hours
         self.exclude_dataset_patterns = tuple(exclude_dataset_patterns)
         self.timeout = timeout
         self.base = base
@@ -906,11 +1078,53 @@ class MONITRucioDatasetSource:
                 n_records=-1,
             )
 
+            # Fetch the first page eagerly: a degraded first page must
+            # fail the run before any scope claim exists, and a
+            # zero-bucket wildcard result (ignore_unavailable masks a
+            # renamed index or a stalled pipeline) must never claim a
+            # complete empty scope — that would retract every
+            # previously ingested dataset.
+            try:
+                first_page = self._load_live_page(
+                    token=token, page_number=0, after_key=None
+                )
+            except Exception as exc:  # noqa: BLE001
+                return _endpoint_failed_run(
+                    mode, self.token_env, exc, endpoint=self.grafana_base_url
+                )
+            first_datasets = (
+                _first_response(first_page)
+                .get("aggregations", {})
+                .get("datasets", {})
+            )
+            if not first_datasets.get("buckets"):
+                return SourceRun(
+                    facts=[],
+                    completed_scope=False,
+                    run_mode=mode,
+                    health=SourceHealth(
+                        status="skipped_optional",
+                        mode="live",
+                        credential_refs=(self.token_env,),
+                        record_count=0,
+                        endpoint=self.grafana_base_url,
+                        reason=(
+                            "MONIT Rucio dataset query returned no dataset "
+                            "buckets; with ignore_unavailable a zero-bucket "
+                            "wildcard result is indistinguishable from a "
+                            "renamed index or stalled pipeline, so no "
+                            "complete scope is claimed"
+                        ),
+                        checked_at=_checked_at(),
+                    ),
+                )
+
             def _live() -> Iterator[NodeFact | EdgeFact | ProgressMarker]:
                 yield from self._live_facts(
                     token=token,
                     revision=revision,
                     since_progress=since_progress or {},
+                    first_page=first_page,
                 )
 
             return SourceRun(
@@ -932,7 +1146,7 @@ class MONITRucioDatasetSource:
             )
 
         try:
-            records, run_mode, revision = self._load_records(run_id)
+            records, run_mode, revision, quality = self._load_records(run_id)
         except MissingMONITCredential as exc:
             return _missing_credential_run(mode, self.token_env, str(exc))
         except Exception as exc:  # noqa: BLE001
@@ -953,13 +1167,16 @@ class MONITRucioDatasetSource:
             records=records,
             ok_reason="MONIT Rucio dataset records loaded",
             empty_reason="MONIT Rucio dataset query returned no dataset buckets",
+            quality=quality,
         )
 
     def _load_records(
         self,
         run_id: str,
-    ) -> tuple[list[RucioDatasetRecord], str, dict[str, Any]]:
-        records, run_mode, hash_value = _load_cache_or_live(
+    ) -> tuple[
+        list[RucioDatasetRecord], str, dict[str, Any], _ResponseQuality
+    ]:
+        records, run_mode, hash_value, quality = _load_cache_or_live(
             records_path=self.records_path,
             token_env=self.token_env,
             cache_loader=self._records_from_cache,
@@ -974,25 +1191,33 @@ class MONITRucioDatasetSource:
             to_time=self.to_time,
             hash_value=hash_value,
             n_records=len(records),
-        )
+        ), quality
 
-    def _records_from_cache(self) -> list[RucioDatasetRecord]:
+    def _records_from_cache(
+        self,
+    ) -> tuple[list[RucioDatasetRecord], _ResponseQuality]:
         payload = load_json(self.records_path, base=self.base)
         if isinstance(payload, dict) and "responses" in payload:
-            return self._parse_response(payload)
+            return self._parse_response(payload), _response_quality(payload)
         if not isinstance(payload, list):
             raise ValueError(
                 f"{self.records_path}: expected a list of records or "
                 "MONIT _msearch response"
             )
-        return [
-            _rucio_dataset_record_from_mapping(item)
-            for item in payload
-            if item
-        ]
+        return (
+            [
+                _rucio_dataset_record_from_mapping(item)
+                for item in payload
+                if item
+            ],
+            _ResponseQuality(),
+        )
 
-    def _records_from_live(self, token: str) -> list[RucioDatasetRecord]:
+    def _records_from_live(
+        self, token: str
+    ) -> tuple[list[RucioDatasetRecord], _ResponseQuality]:
         records: list[RucioDatasetRecord] = []
+        quality = _ResponseQuality()
         after_key: dict[str, Any] | None = None
         while True:
             response = _monit_msearch(
@@ -1010,6 +1235,7 @@ class MONITRucioDatasetSource:
                 timeout=self.timeout,
             )
             records.extend(self._parse_response(response))
+            quality = _merge_quality(quality, _response_quality(response))
             response0 = _first_response(response)
             after_key = (
                 response0.get("aggregations", {})
@@ -1018,7 +1244,7 @@ class MONITRucioDatasetSource:
             )
             if not after_key:
                 break
-        return records
+        return records, quality
 
     def _parse_response(
         self, payload: dict[str, Any]
@@ -1030,12 +1256,17 @@ class MONITRucioDatasetSource:
         )
 
     def _query_fingerprint(self) -> str:
+        # The snapshot date is part of the key: the query body's literal
+        # "now-24h"/"now" resolve to a different window every day, so a
+        # date-free fingerprint would let one day's cached pages satisfy
+        # every later day's run forever (2026-08 review blocker).
         return _query_fingerprint(
             source=self.name,
             from_time=self.from_time,
             to_time=self.to_time,
             page_size=self.page_size,
             max_replica_rses=self.max_replica_rses,
+            snapshot_date=_today(),
         )
 
     def _live_facts(
@@ -1044,16 +1275,20 @@ class MONITRucioDatasetSource:
         token: str,
         revision: dict[str, Any],
         since_progress: dict[str, str],
+        first_page: dict[str, Any] | None = None,
     ) -> Iterator[NodeFact | EdgeFact | ProgressMarker]:
         after_key: dict[str, Any] | None = None
         page_number = 0
         n_records = 0
         while True:
-            response = self._load_live_page(
-                token=token,
-                page_number=page_number,
-                after_key=after_key,
-            )
+            if page_number == 0 and first_page is not None:
+                response = first_page
+            else:
+                response = self._load_live_page(
+                    token=token,
+                    page_number=page_number,
+                    after_key=after_key,
+                )
             records = self._parse_response(response)
             for record in records:
                 fingerprint = _record_fingerprint(record)
@@ -1104,7 +1339,11 @@ class MONITRucioDatasetSource:
         )
         if self.cache_live_pages and cache_path.is_file():
             cached = json.loads(cache_path.read_text())
-            if cached.get("after_key_in") == after_key:
+            if cached.get("after_key_in") == after_key and (
+                _page_cache_entry_fresh(
+                    cached, ttl_hours=self.page_cache_ttl_hours
+                )
+            ):
                 return cached["response"]
 
         response = _monit_msearch(
@@ -1121,6 +1360,16 @@ class MONITRucioDatasetSource:
             ),
             timeout=self.timeout,
         )
+        quality = _response_quality(response)
+        if not quality.complete:
+            # The streaming path cannot retroactively downgrade the
+            # already-returned health/scope claim, so a partial page
+            # fails the run (and is never cached) instead of letting a
+            # partial scope be committed.
+            raise RuntimeError(
+                f"partial MONIT OpenSearch response on page {page_number}: "
+                f"{quality.describe()}"
+            )
         if self.cache_live_pages:
             cache_path.parent.mkdir(parents=True, exist_ok=True)
             tmp_path = cache_path.with_suffix(".tmp")
@@ -1169,13 +1418,13 @@ def _monit_preflight(
     records_path: str,
     token_env: str,
     endpoint: str,
-    cache_loader: Callable[[], list[Any]],
+    cache_loader: Callable[[], tuple[list[Any], _ResponseQuality]],
     cache_reason: str,
     base: str | None = None,
 ) -> SourcePreflightResult:
     path = resolve_repo_path(records_path, base=base)
     if path.is_file():
-        records = cache_loader()
+        records, _ = cache_loader()
         return SourcePreflightResult(
             source_name=source_name,
             status="ok",
@@ -1214,18 +1463,19 @@ def _load_cache_or_live(
     *,
     records_path: str,
     token_env: str,
-    cache_loader: Callable[[], list[Any]],
-    live_loader: Callable[[str], list[Any]],
+    cache_loader: Callable[[], tuple[list[Any], _ResponseQuality]],
+    live_loader: Callable[[str], tuple[list[Any], _ResponseQuality]],
     base: str | None = None,
-) -> tuple[list[Any], str, str]:
+) -> tuple[list[Any], str, str, _ResponseQuality]:
     path = resolve_repo_path(records_path, base=base)
     if path.is_file():
-        return cache_loader(), "cache", _file_hash(path)
+        records, quality = cache_loader()
+        return records, "cache", _file_hash(path), quality
     token = os.environ.get(token_env)
     if not token:
         raise MissingMONITCredential(f"{token_env} is not set and {path} is missing")
-    records = live_loader(token)
-    return records, "live", _records_hash(records)
+    records, quality = live_loader(token)
+    return records, "live", _records_hash(records), quality
 
 
 def _missing_credential_run(
@@ -1284,19 +1534,46 @@ def _source_run(
     records: list[Any],
     ok_reason: str,
     empty_reason: str,
+    quality: _ResponseQuality | None = None,
 ) -> SourceRun:
+    partial = quality is not None and not quality.complete
+    if partial:
+        # HTTP 200 but the response itself is partial (timed out, shard
+        # failures, or capped terms aggregations): emit the records it
+        # carries, but the closed status vocabulary has no 'degraded',
+        # so report endpoint_failed — and never claim the scope, or
+        # missing_from_completed_scope would retract every record the
+        # partial response happened to drop.
+        status = "endpoint_failed"
+        reason = (
+            f"partial MONIT OpenSearch response ({quality.describe()}); "
+            f"{len(records)} records emitted, no complete scope claimed"
+        )
+        completed = False
+    elif not records:
+        # Zero buckets under an ignore_unavailable wildcard-index query
+        # is indistinguishable from a renamed index or a stalled
+        # ingestion pipeline, so never claim a complete empty scope (it
+        # would retract every previously ingested record).
+        status = "skipped_optional"
+        reason = f"{empty_reason}; no complete scope claimed"
+        completed = False
+    else:
+        status = "ok"
+        reason = ok_reason
+        completed = mode in {"scope_complete", "reconcile"}
     return SourceRun(
         facts=facts,
-        completed_scope=(mode in {"scope_complete", "reconcile"}),
+        completed_scope=completed,
         run_mode=mode,
         health=SourceHealth(
-            status="ok" if records else "skipped_optional",
+            status=status,
             mode=run_mode,
             credential_refs=((token_env,) if run_mode == "live" else ()),
             record_count=len(records),
             content_hash=revision["content_hash"],
             endpoint=endpoint if run_mode == "live" else None,
-            reason=ok_reason if records else empty_reason,
+            reason=reason,
             checked_at=_checked_at(),
         ),
     )
@@ -1929,6 +2206,7 @@ def _query_fingerprint(
     to_time: str,
     page_size: int,
     max_replica_rses: int,
+    snapshot_date: str,
 ) -> str:
     import hashlib
 
@@ -1938,9 +2216,44 @@ def _query_fingerprint(
         "to_time": to_time,
         "page_size": page_size,
         "max_replica_rses": max_replica_rses,
-        "query_version": "rucio_dataset_composite_v2",
+        # Relative time expressions ("now-24h") resolve differently
+        # every day; the snapshot date keys the cache to the day the
+        # window actually covered. v3 also invalidates every date-free
+        # v2 cache entry.
+        "snapshot_date": snapshot_date,
+        "query_version": "rucio_dataset_composite_v3",
     }, sort_keys=True).encode("utf-8")
     return hashlib.sha256(payload).hexdigest()
+
+
+def _page_cache_entry_fresh(
+    cached: dict[str, Any],
+    *,
+    ttl_hours: float,
+) -> bool:
+    """True when a live page-cache entry may satisfy this run.
+
+    The entry must carry a parseable ``cached_at`` stamped on the same
+    UTC day as this run's snapshot date and be younger than
+    *ttl_hours*. A page from a previous day (or of unknown age) must
+    never satisfy a new day's run — replaying it would emit
+    yesterday's datasets stamped with today's date under a completed
+    scope claim, and the substrate would retract everything else.
+    """
+    raw = cached.get("cached_at")
+    if not isinstance(raw, str) or not raw:
+        return False
+    try:
+        cached_at = datetime.fromisoformat(raw)
+    except ValueError:
+        return False
+    if cached_at.tzinfo is None:
+        cached_at = cached_at.replace(tzinfo=timezone.utc)
+    cached_at = cached_at.astimezone(timezone.utc)
+    if cached_at.strftime("%Y-%m-%d") != _today():
+        return False
+    age = datetime.now(timezone.utc) - cached_at
+    return timedelta(0) <= age <= timedelta(hours=ttl_hours)
 
 
 def _page_cache_path(

--- a/python/archi/sources/siteconf.py
+++ b/python/archi/sources/siteconf.py
@@ -251,9 +251,12 @@ class SITECONFSource:
         token = _env_value(self.token_env, self.aliases)
         endpoint = f"{self.base_url}/api/v4/groups/{self.group_id}/projects"
         try:
+            # Mirror the crawl's listing exactly (include_subgroups):
+            # a group whose projects live only in subgroups must not
+            # get a false-negative preflight that blocks run().
             resp = requests.get(
                 endpoint,
-                params={"per_page": 1},
+                params={"include_subgroups": "true", "per_page": 1},
                 headers={"PRIVATE-TOKEN": token},
                 timeout=20,
             )

--- a/python/archi/sources/siteconf.py
+++ b/python/archi/sources/siteconf.py
@@ -233,6 +233,82 @@ class SITECONFSource:
                 ),
                 checked_at=_checked_at(),
             )
+        return self._group_probe(env_result)
+
+    def _group_probe(
+        self,
+        env_result: SourcePreflightResult,
+    ) -> SourcePreflightResult:
+        """Probe group visibility, not just token validity.
+
+        ``/api/v4/user`` accepts any live token; a token without group
+        visibility then gets an HTTP-200 *empty* project list from the
+        group crawl, which used to become a healthy completed scope
+        over zero records (retract-all).
+        """
+        import requests
+
+        token = _env_value(self.token_env, self.aliases)
+        endpoint = f"{self.base_url}/api/v4/groups/{self.group_id}/projects"
+        try:
+            resp = requests.get(
+                endpoint,
+                params={"per_page": 1},
+                headers={"PRIVATE-TOKEN": token},
+                timeout=20,
+            )
+        except Exception as exc:  # noqa: BLE001
+            return SourcePreflightResult(
+                source_name=self.name,
+                status="endpoint_failed",
+                mode="live",
+                required=self.required,
+                credential_refs=env_result.credential_refs,
+                alias_refs=env_result.alias_refs,
+                endpoint=endpoint,
+                reason=f"GitLab group probe failed: {type(exc).__name__}",
+                checked_at=_checked_at(),
+            )
+        if resp.status_code in {401, 403}:
+            return SourcePreflightResult(
+                source_name=self.name,
+                status="auth_failed",
+                mode="live",
+                required=self.required,
+                credential_refs=env_result.credential_refs,
+                alias_refs=env_result.alias_refs,
+                endpoint=endpoint,
+                reason=(
+                    f"GitLab token cannot access group {self.group_id}"
+                ),
+                checked_at=_checked_at(),
+            )
+        payload: Any = None
+        if resp.status_code < 400:
+            try:
+                payload = resp.json()
+            except ValueError:
+                payload = None
+        if (
+            resp.status_code >= 400
+            or not isinstance(payload, list)
+            or not payload
+        ):
+            return SourcePreflightResult(
+                source_name=self.name,
+                status="endpoint_failed",
+                mode="live",
+                required=self.required,
+                credential_refs=env_result.credential_refs,
+                alias_refs=env_result.alias_refs,
+                endpoint=endpoint,
+                reason=(
+                    f"GitLab group {self.group_id} project list is not "
+                    "visible to this token (HTTP "
+                    f"{resp.status_code}, empty or non-list payload)"
+                ),
+                checked_at=_checked_at(),
+            )
         return SourcePreflightResult(
             source_name=self.name,
             status="ok",
@@ -240,8 +316,8 @@ class SITECONFSource:
             required=self.required,
             credential_refs=env_result.credential_refs,
             alias_refs=env_result.alias_refs,
-            endpoint=f"{self.base_url}/api/v4/user",
-            reason="GitLab token accepted",
+            endpoint=endpoint,
+            reason="GitLab token accepted and group projects visible",
             checked_at=_checked_at(),
         )
 
@@ -260,7 +336,41 @@ class SITECONFSource:
                 ),
             )
 
-        records = self._records if self._records is not None else self._fetch()
+        if self._records is not None:
+            records = self._records
+            truncated = False
+        else:
+            records, n_projects, truncated = self._fetch()
+            if not records:
+                # An HTTP-200 empty project list (token without group
+                # visibility) or a crawl that parsed zero site configs
+                # must never become a healthy completed scope over zero
+                # records — that would retract every site_config.
+                return SourceRun(
+                    facts=[],
+                    completed_scope=False,
+                    run_mode=mode,
+                    health=SourceHealth(
+                        status="endpoint_failed",
+                        mode="live",
+                        credential_refs=(self.token_env,),
+                        record_count=0,
+                        endpoint=self.base_url,
+                        reason=(
+                            (
+                                f"GitLab group {self.group_id} returned "
+                                "an empty project list; the token may "
+                                "lack group visibility"
+                            )
+                            if n_projects == 0
+                            else (
+                                f"{n_projects} GitLab projects listed "
+                                "but zero SITECONF records parsed"
+                            )
+                        )
+                        + "; no scope claimed",
+                    ),
+                )
         record_hash = _records_hash(records)
         revision = {
             "run_id": run_id,
@@ -283,9 +393,19 @@ class SITECONFSource:
                         source_revision=revision,
                     )
 
+        reason = "SITECONF records fetched from GitLab"
+        if truncated:
+            # A truncated project list is a sliding window, not the
+            # full group scope.
+            reason += (
+                f"; max_projects={self.max_projects} truncated the "
+                "project list; no complete scope claimed"
+            )
         return SourceRun(
             facts=_facts(),
-            completed_scope=(mode in {"scope_complete", "reconcile"}),
+            completed_scope=(
+                mode in {"scope_complete", "reconcile"} and not truncated
+            ),
             run_mode=mode,
             health=SourceHealth(
                 status="ok",
@@ -295,17 +415,18 @@ class SITECONFSource:
                 ),
                 record_count=len(records),
                 content_hash=record_hash,
-                reason="SITECONF records fetched from GitLab",
+                reason=reason,
             ),
         )
 
-    def _fetch(self) -> list[SiteConfRecord]:
+    def _fetch(self) -> tuple[list[SiteConfRecord], int, bool]:
+        """(records, listed_project_count, cap_truncated)."""
         import requests
 
         token = _env_value(self.token_env, self.aliases)
         headers = {"PRIVATE-TOKEN": token} if token else {}
         session = requests.Session()
-        projects = self._list_projects(session, headers)
+        projects, truncated = self._list_projects(session, headers)
         records: list[SiteConfRecord] = []
         for project in projects:
             site_name = _pg_text(str(project.get("path") or ""))
@@ -320,13 +441,13 @@ class SITECONFSource:
             )
             if record is not None:
                 records.append(record)
-        return records
+        return records, len(projects), truncated
 
     def _list_projects(
         self,
         session: Any,
         headers: dict[str, str],
-    ) -> list[dict[str, Any]]:
+    ) -> tuple[list[dict[str, Any]], bool]:
         projects: list[dict[str, Any]] = []
         page = 1
         while True:
@@ -349,9 +470,10 @@ class SITECONFSource:
                 self.max_projects is not None
                 and len(projects) >= self.max_projects
             ):
-                return projects[:self.max_projects]
+                # The cap fired: pages/items beyond it were not listed.
+                return projects[:self.max_projects], True
             page += 1
-        return projects
+        return projects, False
 
     def _fetch_site_config(
         self,

--- a/python/archi/sources/wmstats.py
+++ b/python/archi/sources/wmstats.py
@@ -146,7 +146,7 @@ class WMStatsWorkflowSource:
         )
 
     def run(self, run_id: str, *, mode: str = "cursor") -> SourceRun:
-        records = self._records()
+        records, skipped = self._records_with_skips()
         revision = {
             "run_id": run_id,
             "content_hash": content_hash(self.cache_paths, base=self.base),
@@ -158,25 +158,33 @@ class WMStatsWorkflowSource:
 
         return SourceRun(
             facts=_facts(),
-            completed_scope=(mode in {"scope_complete", "reconcile"}),
+            completed_scope=(
+                mode in {"scope_complete", "reconcile"} and not skipped
+            ),
             run_mode=mode,
             health=cache_source_health(
                 description="WMStats workflow",
                 cache_paths=self.cache_paths,
                 record_count=len(records),
+                skipped_count=skipped,
                 base=self.base,
             ),
         )
 
     def _records(self) -> list[WorkflowRecord]:
+        return self._records_with_skips()[0]
+
+    def _records_with_skips(self) -> tuple[list[WorkflowRecord], int]:
         payload = load_json(self.records_path, base=self.base)
         if not isinstance(payload, list):
             raise ValueError(
                 f"{self.records_path}: expected a JSON list of workflows"
             )
         records: list[WorkflowRecord] = []
+        skipped = 0
         for item in payload:
             if not isinstance(item, dict):
+                skipped += 1
                 continue
             name = str(
                 item.get("workflow_name")
@@ -185,6 +193,7 @@ class WMStatsWorkflowSource:
                 or ""
             ).strip()
             if not name:
+                skipped += 1
                 continue
             output = (
                 item.get("output_datasets")
@@ -230,7 +239,7 @@ class WMStatsWorkflowSource:
                 ),
                 updated_at=str(item.get("updated_at") or ""),
             ))
-        return records
+        return records, skipped
 
 
 def _facts_for_records(

--- a/python/archi/tools/monit.py
+++ b/python/archi/tools/monit.py
@@ -28,6 +28,17 @@ Changes from the original:
   structured ``error`` payloads, and every payload carries
   ``boundary: external_live`` plus ``observed_at``, source/index, the
   sanitized query, and the explicit time window.
+- 2026-08 adversarial review (see
+  ``pact/changes/circleback-fixes/notes-live.md``): every
+  ``requests.RequestException`` (ConnectionError, ...) and a non-JSON
+  200 body (Grafana HTML error page) also come back as structured
+  ``error`` payloads instead of escaping as raw exceptions; the echoed
+  ``time_window`` is exactly the window the query body used (both are
+  sanitized once, identically); and the terms ``.keyword``->raw retry
+  fires only when the ``.keyword`` attempt failed with a field-related
+  error or matched documents yet produced no buckets — a zero-match
+  empty bucket list is a valid result and is returned as-is (and a
+  failing raw retry never replaces a valid empty ``.keyword`` result).
 
 Wiring — an instance registers the tools in its ``deployment.yaml``
 ``agent_tools`` block (adapted from the cms block; the mapping key is
@@ -292,6 +303,10 @@ def monit_search(
     """Generic MONIT OpenSearch Lucene search (parameterized core)."""
     observed_at = _observed_at()
     clean_query = _clean_query(query, token_env=token_env)
+    # Sanitize the window once; the query body and the echoed
+    # time_window must use the exact same values.
+    from_time = _sanitize_time(from_time, "now-24h")
+    to_time = _sanitize_time(to_time, "now")
     effective_max = _bounded_int(max_results, default=DEFAULT_MAX_RESULTS,
                                  lower=1, upper=MAX_RESULTS_HARD_LIMIT)
     effective_page = _bounded_int(page, default=1, lower=1, upper=1000)
@@ -378,6 +393,19 @@ def monit_search(
             total={"value": 0, "relation": "eq"},
             error=_http_error_message(exc),
         )
+    except (requests.exceptions.RequestException, json.JSONDecodeError) as exc:
+        # ConnectionError, TLS failures, non-JSON 200 bodies (Grafana
+        # HTML error pages), ...: same structured payload as the
+        # timeout/HTTP paths — never a raw exception to the agent.
+        return _search_payload(
+            source_name=source_name,
+            observed_at=observed_at,
+            query=descriptor,
+            time_window=time_window,
+            results=[],
+            total={"value": 0, "relation": "eq"},
+            error=_request_error_message(exc),
+        )
 
 
 def monit_aggregate(
@@ -398,6 +426,10 @@ def monit_aggregate(
     """Generic MONIT OpenSearch aggregation (parameterized core)."""
     observed_at = _observed_at()
     clean_query = _clean_query(query, token_env=token_env)
+    # Sanitize the window once; the query body and the echoed
+    # time_window must use the exact same values.
+    from_time = _sanitize_time(from_time, "now-24h")
+    to_time = _sanitize_time(to_time, "now")
     clean_group_by = (group_by or "").strip()
     clean_agg_type = (agg_type or "terms").strip().lower()
     effective_top_n = _bounded_int(top_n, default=DEFAULT_TOP_N,
@@ -450,14 +482,33 @@ def monit_aggregate(
             timeout=timeout,
         )
         first = _first_response(response)
+        keyword_error = _response_error(first)
+        matched_but_bucketless = (
+            not keyword_error
+            and not _aggregation_buckets(first)
+            and _total_descriptor(
+                first.get("hits", {}).get("total", 0)
+            )["value"] > 0
+        )
         if (
             clean_agg_type == "terms"
             and agg_field != clean_group_by
-            and not _aggregation_buckets(first)
-            and not _response_error(first)
+            and (
+                (
+                    keyword_error
+                    and _looks_like_field_error(keyword_error, agg_field)
+                )
+                or matched_but_bucketless
+            )
         ):
-            # .keyword produced no buckets (e.g. numeric field): retry
-            # with the raw field name.
+            # The auto-appended .keyword sub-field is missing or not
+            # aggregatable (field-related error, or documents matched
+            # yet produced zero buckets — e.g. a numeric field whose
+            # .keyword is unmapped): retry with the raw field name.
+            # A zero-bucket .keyword result with zero matching
+            # documents is a valid empty aggregation and is returned
+            # as-is — retrying it used to surface fielddata errors for
+            # legitimately empty windows.
             body = _aggregation_body(
                 lucene_query=clean_query,
                 field=clean_group_by,
@@ -466,7 +517,7 @@ def monit_aggregate(
                 from_time=from_time,
                 to_time=to_time,
             )
-            response = _post_msearch(
+            retry_response = _post_msearch(
                 grafana_base_url=grafana_base_url,
                 token_env=token_env,
                 datasource_id=datasource_id,
@@ -474,7 +525,12 @@ def monit_aggregate(
                 body=body,
                 timeout=timeout,
             )
-            first = _first_response(response)
+            retry_first = _first_response(retry_response)
+            if keyword_error or not _response_error(retry_first):
+                # Use the retry only when the .keyword attempt had
+                # failed or the raw attempt succeeded; a failing raw
+                # retry must not replace a valid empty .keyword result.
+                first = retry_first
         error = _response_error(first)
         if error:
             aggregation = {
@@ -519,6 +575,24 @@ def monit_aggregate(
             "total_matching_documents": 0,
             "buckets": [],
             "error": _http_error_message(exc),
+        }
+        return _aggregation_payload(
+            source_name=source_name,
+            observed_at=observed_at,
+            query=descriptor,
+            time_window=time_window,
+            aggregation=aggregation,
+        )
+    except (requests.exceptions.RequestException, json.JSONDecodeError) as exc:
+        # ConnectionError, TLS failures, non-JSON 200 bodies (Grafana
+        # HTML error pages), ...: same structured payload as the
+        # timeout/HTTP paths — never a raw exception to the agent.
+        aggregation = {
+            "agg_type": clean_agg_type,
+            "group_by": clean_group_by,
+            "total_matching_documents": 0,
+            "buckets": [],
+            "error": _request_error_message(exc),
         }
         return _aggregation_payload(
             source_name=source_name,
@@ -775,10 +849,21 @@ def _clean_query(query: str, *, token_env: str = DEFAULT_TOKEN_ENV) -> str:
     return clean
 
 
+def _sanitize_time(value: str | None, default: str) -> str:
+    """One sanitization for both the query body and the echoed window."""
+    return ((value or "").strip()) or default
+
+
 def _time_window(from_time: str, to_time: str) -> dict[str, str]:
+    """Echo of the exact window the query body used.
+
+    Callers pass values already normalized by :func:`_sanitize_time`;
+    no further defaulting/stripping happens here, so the echo cannot
+    drift from what was actually queried.
+    """
     return {
-        "from": (from_time or "now-24h").strip(),
-        "to": (to_time or "now").strip(),
+        "from": from_time,
+        "to": to_time,
         "time_field": "metadata.timestamp",
     }
 
@@ -801,6 +886,37 @@ def _http_error_message(exc: requests.exceptions.HTTPError) -> str:
     if status in {401, 403}:
         return f"MONIT OpenSearch authentication failed with HTTP {status}"
     return f"MONIT OpenSearch request failed with HTTP {status}"
+
+
+def _request_error_message(exc: Exception) -> str:
+    """Structured message for transport/parse failures.
+
+    Built from the exception *type* only — exception text can embed
+    URLs/hosts, and these messages travel back to the agent verbatim.
+    """
+    if isinstance(exc, json.JSONDecodeError):
+        return "MONIT OpenSearch returned a non-JSON response body"
+    return f"MONIT OpenSearch request failed: {type(exc).__name__}"
+
+
+_FIELD_ERROR_MARKERS = (
+    "no mapping found",
+    "fielddata",
+    "field data",
+    "unknown field",
+    "failed to find field",
+    "not aggregatable",
+)
+
+
+def _looks_like_field_error(error: str, field: str) -> bool:
+    """True when an OpenSearch error is about the aggregation field
+    itself (missing ``.keyword`` sub-field, non-aggregatable type) —
+    the only case where retrying with the raw field name can help."""
+    lowered = error.lower()
+    if field and field.lower() in lowered:
+        return True
+    return any(marker in lowered for marker in _FIELD_ERROR_MARKERS)
 
 
 __all__ = [

--- a/python/tests/enrichment/test_alias.py
+++ b/python/tests/enrichment/test_alias.py
@@ -24,7 +24,12 @@ NODE_ROWS = [
     # Wrong prefix for its subtype: must not be indexed.
     {"node_id": "weird:thing", "subtype": "site", "attrs": {}},
 ]
-DATASET_ROWS = [{"node_id": "dataset:/A/B/RAW"}]
+DATASET_ROWS = [
+    {"node_id": "dataset:/A/B/RAW"},
+    # Case-distinct twin: DBS dataset paths are case-sensitive, so both
+    # must stay individually resolvable.
+    {"node_id": "dataset:/a/b/raw"},
+]
 
 
 class FakeCursor:
@@ -96,3 +101,40 @@ def test_dataset_index_is_lazy_and_cached(monkeypatch):
     assert match.canonical == "dataset:/A/B/RAW"
     assert backend.match("/X/Y/MISS", entity_type="cms_dataset") == []
     assert fake.dataset_queries == 1  # loaded once, then cached
+
+
+def test_dataset_alias_is_case_sensitive(monkeypatch):
+    # circleback finding: _norm case-folding collapsed case-distinct
+    # dataset ids into whichever loaded last. DBS paths are
+    # case-sensitive, so each case-distinct twin resolves to itself and
+    # a case-mismatched query resolves to nothing.
+    backend, _ = _backend(monkeypatch)
+    (match,) = backend.match("/A/B/RAW", entity_type="cms_dataset")
+    assert match.canonical == "dataset:/A/B/RAW"
+    (match,) = backend.match("/a/b/raw", entity_type="cms_dataset")
+    assert match.canonical == "dataset:/a/b/raw"
+    assert backend.match("/A/b/RAW", entity_type="cms_dataset") == []
+    # "dataset:"-prefixed needles still resolve (exact case).
+    (match,) = backend.match("dataset:/A/B/RAW", entity_type="cms_dataset")
+    assert match.canonical == "dataset:/A/B/RAW"
+
+
+def test_non_dataset_matching_stays_case_insensitive(monkeypatch):
+    # Case is transcription noise for sites/releases/hostnames; only
+    # dataset paths carry case-sensitive identity.
+    backend, _ = _backend(monkeypatch)
+    (match,) = backend.match("t2_us_mit", entity_type="cms_site")
+    assert match.canonical == "site:T2_US_MIT"
+    (match,) = backend.match("EOSCMS.cern.ch", entity_type="cms_hostname")
+    assert match.canonical == "service:eoscms"
+
+
+def test_dataset_misses_are_not_cached(monkeypatch):
+    # circleback finding: every unresolved mention used to be cached as
+    # a negative entry, growing the index without bound.
+    backend, _ = _backend(monkeypatch)
+    backend.match("/A/B/RAW", entity_type="cms_dataset")
+    size_before = len(backend._dataset_by_value)
+    for i in range(50):
+        assert backend.match(f"/X/Y{i}/MISS", entity_type="cms_dataset") == []
+    assert len(backend._dataset_by_value) == size_before

--- a/python/tests/enrichment/test_anonymizer.py
+++ b/python/tests/enrichment/test_anonymizer.py
@@ -138,6 +138,17 @@ def test_encoded_and_nbsp_variants_redacted():
     )
     assert "&lt;tag&gt;" in out
 
+    # Double-encoded forms: normalization iterates to a bounded
+    # fixpoint, so one &amp;-wrapping layer cannot smuggle PII through.
+    out = an.anonymize("Contact jdoe&amp;#64;cern.ch about run 381000.")
+    assert "jdoe" not in out
+    assert "run 381000" in out
+    out = an_names.anonymize_markup(
+        "<p>Report prepared by John&amp;nbsp;Doe covering all transfer failures seen</p>"
+    )
+    assert "John" not in out and "Doe" not in out
+    assert "transfer failures" in out
+
 
 def test_ner_off_author_shapes_redacted():
     # Finding 3: NER-disabled mode leaked authors outside the four
@@ -198,6 +209,24 @@ def test_operational_lines_survive_greeting_signoff_filters():
     assert "Thank you note was filed as CMSCOMPPR-1." in out
     assert "Regards to whoever fixed run 381000." in out
     assert "Best effort reprocessing is enabled." in out
+
+
+def test_greeting_prefixed_operational_lines_survive():
+    # Reviewer delta: the expanded greeting word-list must only delete
+    # SHORT greeting lines (greeting word + at most four trailing
+    # words); greeting-prefixed operational sentences survive.
+    an = _anonymizer()
+    text = (
+        "Good morning update: transfers to T2_US_MIT stuck\n"
+        "Hello world example output was attached to run 381000 report\n"
+        "Good morning all,\n"
+        "Hey folks,\n"
+    )
+    out = an.anonymize(text)
+    assert "Good morning update: transfers to T2_US_MIT stuck" in out
+    assert "run 381000 report" in out
+    assert "Good morning all" not in out
+    assert "Hey folks" not in out
 
 
 def test_real_greetings_and_signoffs_still_stripped():

--- a/python/tests/enrichment/test_anonymizer.py
+++ b/python/tests/enrichment/test_anonymizer.py
@@ -66,3 +66,154 @@ def test_construction_never_imports_spacy_eagerly():
     # NER-disabled instances never load a model at all.
     off = _anonymizer()
     assert off._nlp is None and off._nlp_loaded is True
+
+
+# ---------------------------------------------------------------------------
+# Leak corpus (circleback adversarial review). Each block pins one
+# previously-leaking format plus the neighboring previously-passing
+# behavior, so a regression in either direction fails loudly.
+# ---------------------------------------------------------------------------
+
+
+def test_email_local_part_never_leaks_fragments():
+    # Finding 1: the RFC-simple default pattern left local-part
+    # fragments behind ("john.doe+", "o'").
+    an = _anonymizer()
+    cases = {
+        "Contact john.doe+ops@cern.ch about the transfer.": (
+            "john",
+            "doe",
+            "+ops",
+        ),
+        "Contact o'brien@cern.ch about the transfer.": ("o'", "brien"),
+        "See https://x.test/page?mail=john.doe%40cern.ch for run 381000": (
+            "john",
+            "doe",
+            "%40",
+        ),
+        'Reach "john doe"@cern.ch if the drain stalls.': ("john", "doe"),
+        "Plain jdoe@cern.ch still redacted.": ("jdoe",),
+    }
+    for text, fragments in cases.items():
+        out = an.anonymize(text)
+        for fragment in fragments:
+            assert fragment not in out, (text, out)
+    # Operational context around the address survives.
+    out = an.anonymize("Contact john.doe+ops@cern.ch about run 381000.")
+    assert "run 381000" in out
+    out = an.anonymize("See https://x.test/page?mail=john.doe%40cern.ch now")
+    assert "https://x.test/page?mail=" in out
+
+
+def test_encoded_and_nbsp_variants_redacted():
+    # Finding 2: discovery ran on unescaped text but replacement on the
+    # raw input, so NBSP/entity-encoded occurrences survived.
+    an_names = _anonymizer(known_names=["John Doe"])
+    out = an_names.anonymize("Assigned to John\xa0Doe for run 381000.")
+    assert "John" not in out and "Doe" not in out
+    assert "run 381000" in out
+
+    out = an_names.anonymize_markup(
+        "<p>Report prepared by John&nbsp;Doe covering all transfer failures seen</p>"
+    )
+    assert "John" not in out and "Doe" not in out
+    assert "transfer failures" in out
+
+    an = _anonymizer()
+    out = an.anonymize_markup(
+        "<p>Contact jdoe&#64;cern.ch for details on the failed transfers</p>"
+    )
+    assert "jdoe" not in out
+    assert "failed transfers" in out
+
+    out = an.anonymize("Contact jdoe&#64;cern.ch about run 381000.")
+    assert "jdoe" not in out
+    out = an.anonymize("Contact jdoe&#x40;cern.ch about run 381000.")
+    assert "jdoe" not in out
+
+    # Escaped angle brackets stay escaped: normalization must not
+    # create or break markup structure.
+    out = an.anonymize_markup(
+        "<p>Escaped &lt;tag&gt; text stays escaped in the output here</p>"
+    )
+    assert "&lt;tag&gt;" in out
+
+
+def test_ner_off_author_shapes_redacted():
+    # Finding 3: NER-disabled mode leaked authors outside the four
+    # hardcoded markup shapes.
+    an = _anonymizer()
+
+    # dc:creator without CDATA.
+    out = an.anonymize_markup(
+        "<item><dc:creator>Hasan Ozturk</dc:creator>"
+        "<description>Disk full at T2</description></item>"
+    )
+    assert "Hasan" not in out and "Ozturk" not in out
+    assert "Disk full at T2" in out
+
+    # dc:creator with CDATA still redacted (previously passing).
+    out = an.anonymize_markup(
+        "<item><dc:creator><![CDATA[Jane Roe]]></dc:creator>"
+        "<description>Transfer backlog cleared at the T1 site</description></item>"
+    )
+    assert "Jane Roe" not in out
+    assert "Transfer backlog cleared" in out
+
+    # mailto anchor text.
+    out = an.anonymize_markup(
+        '<p>Ping <a href="mailto:jdoe@cern.ch">John Doe</a>'
+        " when the drain of the pool completes</p>"
+    )
+    assert "John Doe" not in out and "jdoe" not in out
+    assert "drain of the pool completes" in out
+
+    # TWiki signature line, text pass.
+    out = an.anonymize("Disk pool drained at T2_US_MIT.\n-- Main.JohnDoe - 2024-01-15")
+    assert "JohnDoe" not in out
+    assert "T2_US_MIT" in out
+
+    # TWiki signature line, markup pass, non-ISO date.
+    out = an.anonymize_markup(
+        "Some twiki topic body mentioning run 381000 here\n-- Main.JaneRoe - 15 Jan 2024\n"
+    )
+    assert "JaneRoe" not in out
+    assert "run 381000" in out
+
+
+def test_operational_lines_survive_greeting_signoff_filters():
+    # Finding 4: "^\w+," deleted any line whose first word had a
+    # trailing comma; sign-off patterns prefix-matched content lines.
+    an = _anonymizer()
+    text = (
+        "However, run 381000 was affected badly.\n"
+        "Note, T2_US_MIT needs a re-run of the workflow.\n"
+        "Thank you note was filed as CMSCOMPPR-1.\n"
+        "Regards to whoever fixed run 381000.\n"
+        "Best effort reprocessing is enabled.\n"
+    )
+    out = an.anonymize(text)
+    assert "However, run 381000 was affected badly." in out
+    assert "Note, T2_US_MIT needs a re-run of the workflow." in out
+    assert "Thank you note was filed as CMSCOMPPR-1." in out
+    assert "Regards to whoever fixed run 381000." in out
+    assert "Best effort reprocessing is enabled." in out
+
+
+def test_real_greetings_and_signoffs_still_stripped():
+    # Finding 4, other direction: the tightened defaults must still
+    # strip actual greeting/sign-off lines.
+    an = _anonymizer()
+    text = (
+        "Hi all,\n"
+        "Dear colleagues,\n"
+        "Good morning team,\n"
+        "The transfer failed overnight.\n"
+        "Thanks in advance,\n"
+        "Best regards, John\n"
+        "Cheers,\n"
+        "Yours sincerely,\n"
+        "-- \n"
+    )
+    out = an.anonymize(text)
+    assert out.strip() == "The transfer failed overnight."

--- a/python/tests/enrichment/test_defaults.py
+++ b/python/tests/enrichment/test_defaults.py
@@ -87,6 +87,32 @@ def test_cross_link_rules_file_and_unknown_name():
         defaults.cross_link_rules_file("no_such_rules.yaml")
 
 
+def test_global_tag_release_linker_treats_empty_rule_sources_as_absent():
+    # circleback finding: a key-presence check treated rules_files=None
+    # or [] as a caller override, silently loading the entire substrate
+    # ontology rule set under the cms linker name.
+    for kwargs in (
+        {"rules_files": None},
+        {"rules_files": []},
+        {"rules": None},
+        {"rules_dir": None},
+        {"rules": None, "rules_files": [], "rules_dir": None},
+    ):
+        linker = GlobalTagReleaseLinker(**kwargs)
+        assert [rule.id for rule in linker.rules] == [
+            "cms_global_tag_release_depends_on_cmssw_release"
+        ], kwargs
+
+
+def test_global_tag_release_linker_honors_explicit_rule_sources():
+    # A real caller-provided source still wins over the packaged default.
+    rules_dir = defaults.cross_link_rules_file("global_tag_release.yaml").parent
+    linker = GlobalTagReleaseLinker(rules_dir=str(rules_dir))
+    assert [rule.id for rule in linker.rules] == [
+        "cms_global_tag_release_depends_on_cmssw_release"
+    ]
+
+
 def test_global_tag_release_linker_wraps_packaged_rule():
     linker = GlobalTagReleaseLinker()
     assert linker.name == "cms_declarative_global_tag_release"

--- a/python/tests/sources/test_cmssw.py
+++ b/python/tests/sources/test_cmssw.py
@@ -111,3 +111,57 @@ def test_releases_map_mode_same_emission_shape(tmp_path):
 def test_parse_releases_map_limit():
     records = parse_releases_map(RELEASES_MAP, limit=1)
     assert [r.label for r in records] == ["CMSSW_14_0_2"]
+
+
+# --- circleback-fixes regressions ---
+
+
+def test_skipped_cache_items_never_claim_scope(tmp_path):
+    root = tmp_path / "data" / "cmssw-releases"
+    root.mkdir(parents=True)
+    (root / "records.json").write_text(
+        json.dumps(RECORDS + ["junk", {"type": "no label"}])
+    )
+    source = CMSSWReleaseSource(base=str(tmp_path))
+    run = source.run("run-1", mode="scope_complete")
+    nodes = _nodes(run.facts)
+    assert "cmssw_release:CMSSW_14_0_1" in nodes  # survivors still emitted
+    assert run.completed_scope is False
+    assert run.health.status == "ok"
+    assert "skipped 2" in run.health.reason
+
+
+def test_all_items_unparseable_is_endpoint_failed(tmp_path):
+    root = tmp_path / "data" / "cmssw-releases"
+    root.mkdir(parents=True)
+    (root / "records.json").write_text(json.dumps(["junk", 42]))
+    source = CMSSWReleaseSource(base=str(tmp_path))
+    run = source.run("run-1", mode="scope_complete")
+    assert list(run.facts) == []
+    assert run.completed_scope is False
+    assert run.health.status == "endpoint_failed"
+
+
+def test_limit_truncation_never_claims_scope(tmp_path):
+    root = tmp_path / "data" / "cmssw-releases"
+    root.mkdir(parents=True)
+    (root / "releases.map").write_text(RELEASES_MAP)
+    source = CMSSWReleaseSource(
+        map_cache_path="data/cmssw-releases/releases.map",
+        fetch=False,
+        limit=1,
+        base=str(tmp_path),
+    )
+    run = source.run("run-1", mode="scope_complete")
+    assert run.completed_scope is False
+    assert "limit=1" in run.health.reason
+    # a cap that does not actually truncate keeps the scope claim
+    untruncated = CMSSWReleaseSource(
+        map_cache_path="data/cmssw-releases/releases.map",
+        fetch=False,
+        limit=10,
+        base=str(tmp_path),
+    )
+    assert untruncated.run(
+        "run-2", mode="scope_complete"
+    ).completed_scope is True

--- a/python/tests/sources/test_cmssw.py
+++ b/python/tests/sources/test_cmssw.py
@@ -40,6 +40,12 @@ RELEASES_MAP = "\n".join([
     "",
 ])
 
+# Same map without the NOT_A_RELEASE junk line: a fully parseable map,
+# for tests that assert an intact completed-scope claim.
+CLEAN_RELEASES_MAP = "\n".join(
+    line for line in RELEASES_MAP.splitlines() if "NOT_A_RELEASE" not in line
+)
+
 
 def _nodes(facts):
     return {f.node_id: f for f in facts if isinstance(f, NodeFact)}
@@ -145,7 +151,7 @@ def test_all_items_unparseable_is_endpoint_failed(tmp_path):
 def test_limit_truncation_never_claims_scope(tmp_path):
     root = tmp_path / "data" / "cmssw-releases"
     root.mkdir(parents=True)
-    (root / "releases.map").write_text(RELEASES_MAP)
+    (root / "releases.map").write_text(CLEAN_RELEASES_MAP)
     source = CMSSWReleaseSource(
         map_cache_path="data/cmssw-releases/releases.map",
         fetch=False,
@@ -165,3 +171,41 @@ def test_limit_truncation_never_claims_scope(tmp_path):
     assert untruncated.run(
         "run-2", mode="scope_complete"
     ).completed_scope is True
+
+
+def test_map_skipped_lines_never_claim_scope(tmp_path):
+    # RELEASES_MAP carries one unparseable line (NOT_A_RELEASE): the
+    # survivors are emitted, but the scope claim is forfeited.
+    root = tmp_path / "data" / "cmssw-releases"
+    root.mkdir(parents=True)
+    (root / "releases.map").write_text(RELEASES_MAP)
+    source = CMSSWReleaseSource(
+        map_cache_path="data/cmssw-releases/releases.map",
+        fetch=False,
+        base=str(tmp_path),
+    )
+    run = source.run("run-1", mode="scope_complete")
+    nodes = _nodes(run.facts)
+    assert "cmssw_release:CMSSW_14_0_1" in nodes
+    assert run.completed_scope is False
+    assert run.health.status == "ok"
+    assert "skipped 1" in run.health.reason
+
+
+def test_map_zero_parse_from_nonempty_map_is_endpoint_failed(tmp_path):
+    # Reviewer repro: a key rename (label= -> tag=) filtered every line
+    # uncounted, claiming ok + completed_scope=True over zero records.
+    root = tmp_path / "data" / "cmssw-releases"
+    root.mkdir(parents=True)
+    (root / "releases.map").write_text(
+        CLEAN_RELEASES_MAP.replace("label=", "tag=")
+    )
+    source = CMSSWReleaseSource(
+        map_cache_path="data/cmssw-releases/releases.map",
+        fetch=False,
+        base=str(tmp_path),
+    )
+    run = source.run("run-1", mode="scope_complete")
+    assert list(run.facts) == []
+    assert run.completed_scope is False
+    assert run.health.status == "endpoint_failed"

--- a/python/tests/sources/test_conddb.py
+++ b/python/tests/sources/test_conddb.py
@@ -82,3 +82,42 @@ def test_missing_cmssw_cache_emits_conddb_only_family_node(tmp_path):
         if isinstance(e, EdgeFact) and e.edge_type == "depends_on"
     }
     assert ("global_tag:140X_dataRun3_v2", "cmssw_release:CMSSW_14_0_X") in depends
+
+
+# --- circleback-fixes regressions ---
+
+
+def test_skipped_cache_items_never_claim_scope(tmp_path):
+    source = _source(tmp_path, with_cmssw=True)
+    (tmp_path / "data" / "conddb-global-tags" / "records.json").write_text(
+        json.dumps(RECORDS + ["junk", {"scenario": "no name"}])
+    )
+    run = source.run("run-1", mode="scope_complete")
+    nodes = {f.node_id for f in run.facts if isinstance(f, NodeFact)}
+    assert "global_tag:140X_dataRun3_v2" in nodes  # survivors still emitted
+    assert run.completed_scope is False
+    assert run.health.status == "ok"
+    assert "skipped 2" in run.health.reason
+
+
+def test_all_items_unparseable_is_endpoint_failed(tmp_path):
+    source = _source(tmp_path, with_cmssw=True)
+    (tmp_path / "data" / "conddb-global-tags" / "records.json").write_text(
+        json.dumps(["junk"])
+    )
+    run = source.run("run-1", mode="scope_complete")
+    assert list(run.facts) == []
+    assert run.completed_scope is False
+    assert run.health.status == "endpoint_failed"
+
+
+def test_change_probe_covers_cmssw_cache(tmp_path):
+    # circleback-fixes regression: run() reads the cmssw cache for
+    # release-target gating, so a cmssw-cache update must fire the probe.
+    source = _source(tmp_path, with_cmssw=True)
+    before = source.change_probe.build_token()
+    (tmp_path / "data" / "cmssw-releases" / "records.json").write_text(
+        json.dumps([{"label": "CMSSW_14_0_2"}])
+    )
+    after = source.change_probe.build_token()
+    assert before != after

--- a/python/tests/sources/test_cric.py
+++ b/python/tests/sources/test_cric.py
@@ -1,6 +1,8 @@
 """req.w2.sources-catalogs — CRICSource / CRICCoreSource emission, offline."""
 import json
 
+import pytest
+
 from okg.substrate.library.sources.base import EdgeFact, NodeFact
 
 from archi.sources.cric import CRICCoreSource, CRICSource
@@ -108,6 +110,21 @@ def test_cric_preflight_missing_cache(tmp_path):
     result = source.preflight()
     assert result.status == "cache_missing"
     assert result.required is True
+
+
+def test_drifted_responsibilities_payload_fails_loud(tmp_path):
+    # circleback-fixes regression: an error-shaped/drifted payload used
+    # to be read as "no responsibilities" under ok/completed_scope,
+    # retracting every operator record.
+    source = _write_cric(tmp_path)
+    (tmp_path / "data" / "cric" / "responsibilities.json").write_text(
+        json.dumps({"error": "auth required"})
+    )
+    with pytest.raises(ValueError, match="responsibilit"):
+        source.run("run-1", mode="scope_complete")
+    result = source.preflight()
+    assert result.status == "endpoint_failed"
+    assert "result" in result.reason
 
 
 CORE_SERVICES = {

--- a/python/tests/sources/test_dbs.py
+++ b/python/tests/sources/test_dbs.py
@@ -66,3 +66,25 @@ def test_preflight_optional_cache(tmp_path):
     assert missing.preflight().required is False
     empty = _source(tmp_path, [])
     assert empty.preflight().status == "skipped_optional"
+
+
+# --- circleback-fixes regressions ---
+
+
+def test_skipped_cache_items_never_claim_scope(tmp_path):
+    source = _source(tmp_path, RECORDS + ["junk", {"data_tier_name": "RAW"}])
+    run = source.run("run-1", mode="scope_complete")
+    nodes = {f.node_id for f in run.facts if isinstance(f, NodeFact)}
+    # survivors still emitted, but drift forfeits the scope claim
+    assert "dataset:/TTto2L2Nu/Run3Summer23-v1/AODSIM" in nodes
+    assert run.completed_scope is False
+    assert run.health.status == "ok"
+    assert "skipped 2" in run.health.reason
+
+
+def test_all_items_unparseable_is_endpoint_failed(tmp_path):
+    source = _source(tmp_path, ["junk", 42])
+    run = source.run("run-1", mode="scope_complete")
+    assert list(run.facts) == []
+    assert run.completed_scope is False
+    assert run.health.status == "endpoint_failed"

--- a/python/tests/sources/test_docs.py
+++ b/python/tests/sources/test_docs.py
@@ -281,11 +281,14 @@ COOKIE_ENV = "ARCHI_T_DOCS_COOKIE_FILE"
 
 
 class _FakeResponse:
-    def __init__(self, status_code=200, text="", url="", content=b""):
+    def __init__(
+        self, status_code=200, text="", url="", content=b"", headers=None
+    ):
         self.status_code = status_code
         self.text = text
         self.url = url
         self.content = content or text.encode("utf-8")
+        self.headers = headers or {}
 
     def raise_for_status(self):
         if self.status_code >= 400:
@@ -529,6 +532,96 @@ def test_sso_run_honors_max_pages(monkeypatch, tmp_path):
     assert [p.attrs["url"] for p in pages] == [
         "https://docs.example.cern.ch/a/"
     ]
+
+
+def test_sso_max_pages_truncation_never_claims_scope(monkeypatch, tmp_path):
+    """Finding 5 (adversarial review): when max_pages actually truncates
+    the sitemap frontier, a clean crawl must surface the truncation and
+    never claim a complete scope — the un-crawled pages would otherwise
+    be retracted under missing_from_completed_scope."""
+    cookie_path = tmp_path / "sso.txt"
+    _write_cookie_file(cookie_path)
+    monkeypatch.setenv(COOKIE_ENV, str(cookie_path))
+    sitemap = (
+        b'<?xml version="1.0" encoding="UTF-8"?>\n'
+        b'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+        b"  <url><loc>https://docs.example.cern.ch/a/</loc></url>\n"
+        b"  <url><loc>https://docs.example.cern.ch/empty/</loc></url>\n"
+        b"  <url><loc>https://docs.example.cern.ch/b/</loc></url>\n"
+        b"</urlset>\n"
+    )
+    responses = _default_responses()
+    responses[SITEMAP_URL] = _FakeResponse(200, "", SITEMAP_URL, sitemap)
+    _fake_sessions(monkeypatch, responses)
+    run = _sso_source(max_pages=2).run("r", mode="scope_complete")
+    pages = _nodes(list(run.facts), "documentation_page")
+    # Only the truncated frontier was crawled and emitted...
+    assert {p.attrs["url"] for p in pages} == {
+        "https://docs.example.cern.ch/a/"
+    }
+    # ...and the run must not claim the scope, with truncation surfaced.
+    assert run.completed_scope is False
+    assert run.health.status == "ok"
+    assert "max_pages=2" in run.health.reason
+    assert "2/3" in run.health.reason
+    assert "no complete scope" in run.health.reason
+    # A cap that does not actually truncate changes nothing.
+    _fake_sessions(monkeypatch, responses)
+    run = _sso_source(max_pages=3).run("r", mode="scope_complete")
+    assert run.completed_scope is True
+    assert run.health.status == "ok"
+    assert "max_pages" not in run.health.reason
+
+
+def test_sso_non_html_sitemap_entries_skipped_not_ingested(
+    monkeypatch, tmp_path
+):
+    """Finding 10 (adversarial review): PDFs/binaries in the sitemap must
+    be skipped by Content-Type (counted, excluded from scope by design)
+    instead of being regex-stripped into mojibake documentation pages."""
+    cookie_path = tmp_path / "sso.txt"
+    _write_cookie_file(cookie_path)
+    monkeypatch.setenv(COOKIE_ENV, str(cookie_path))
+    sitemap = (
+        b'<?xml version="1.0" encoding="UTF-8"?>\n'
+        b'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+        b"  <url><loc>https://docs.example.cern.ch/a/</loc></url>\n"
+        b"  <url><loc>https://docs.example.cern.ch/report.pdf</loc></url>\n"
+        b"  <url><loc>https://docs.example.cern.ch/b/</loc></url>\n"
+        b"</urlset>\n"
+    )
+    responses = _default_responses()
+    responses[SITEMAP_URL] = _FakeResponse(200, "", SITEMAP_URL, sitemap)
+    # An explicit HTML content type (with charset) still ingests.
+    responses["https://docs.example.cern.ch/a/"] = _FakeResponse(
+        200,
+        "<html><title>Page A</title><body>Alpha body</body></html>",
+        "https://docs.example.cern.ch/a/",
+        headers={"Content-Type": "text/html; charset=utf-8"},
+    )
+    responses["https://docs.example.cern.ch/report.pdf"] = _FakeResponse(
+        200,
+        "%PDF-1.4 \x93\xff binary stream",
+        "https://docs.example.cern.ch/report.pdf",
+        content=b"%PDF-1.4 binary",
+        headers={"Content-Type": "application/pdf"},
+    )
+    _fake_sessions(monkeypatch, responses)
+    run = _sso_source().run("r", mode="scope_complete")
+    pages = {
+        n.attrs["url"] for n in _nodes(list(run.facts), "documentation_page")
+    }
+    # The PDF is not a documentation page; HTML pages (with or without a
+    # Content-Type header) are.
+    assert pages == {
+        "https://docs.example.cern.ch/a/",
+        "https://docs.example.cern.ch/b/",
+    }
+    # Skipped non-HTML entries are excluded from scope by design: they
+    # are surfaced in health but do not block the scope claim.
+    assert run.completed_scope is True
+    assert run.health.status == "ok"
+    assert "skipped 1 non-HTML" in run.health.reason
 
 
 def test_sso_sitemap_login_bounce_raises(monkeypatch, tmp_path):

--- a/python/tests/sources/test_dqm.py
+++ b/python/tests/sources/test_dqm.py
@@ -16,10 +16,10 @@ RECORDS = [
 ]
 
 
-def _source(tmp_path):
+def _source(tmp_path, records=RECORDS):
     root = tmp_path / "data" / "dqm"
     root.mkdir(parents=True)
-    (root / "records.json").write_text(json.dumps(RECORDS))
+    (root / "records.json").write_text(json.dumps(records))
     return DQMSource(base=str(tmp_path))
 
 
@@ -65,3 +65,25 @@ def test_preflight_ok_with_hash(tmp_path):
     assert result.status == "ok"
     assert result.record_count == 1
     assert result.content_hash
+
+
+# --- circleback-fixes regressions ---
+
+
+def test_skipped_cache_items_never_claim_scope(tmp_path):
+    source = _source(tmp_path, RECORDS + ["junk", {"filename": "no cert"}])
+    run = source.run("run-1", mode="scope_complete")
+    nodes = {f.node_id for f in run.facts if isinstance(f, NodeFact)}
+    cert_id = "data_certification:Cert_Collisions2024_378981_385194_Golden"
+    assert cert_id in nodes  # survivors still emitted
+    assert run.completed_scope is False
+    assert run.health.status == "ok"
+    assert "skipped 2" in run.health.reason
+
+
+def test_all_items_unparseable_is_endpoint_failed(tmp_path):
+    source = _source(tmp_path, ["junk"])
+    run = source.run("run-1", mode="scope_complete")
+    assert list(run.facts) == []
+    assert run.completed_scope is False
+    assert run.health.status == "endpoint_failed"

--- a/python/tests/sources/test_gocdb.py
+++ b/python/tests/sources/test_gocdb.py
@@ -85,3 +85,48 @@ def test_preflight_reports_missing_records_cache(tmp_path):
     result = source.preflight()
     assert result.status == "cache_missing"
     assert result.required is True
+
+
+# --- circleback-fixes regressions ---
+
+
+def test_skipped_cache_items_never_claim_scope(tmp_path):
+    source = _source(tmp_path)
+    (tmp_path / "data" / "gocdb-downtimes" / "records.json").write_text(
+        json.dumps(RECORDS + ["junk", {"downtime_id": 0}])
+    )
+    run = source.run("run-1", mode="scope_complete")
+    nodes = {f.node_id for f in run.facts if isinstance(f, NodeFact)}
+    assert "downtime:101" in nodes  # survivors still emitted
+    assert run.completed_scope is False
+    assert run.health.status == "ok"
+    assert "skipped 2" in run.health.reason
+
+
+def test_all_items_unparseable_is_endpoint_failed(tmp_path):
+    source = _source(tmp_path)
+    (tmp_path / "data" / "gocdb-downtimes" / "records.json").write_text(
+        json.dumps(["junk", {"downtime_id": "not-a-number"}])
+    )
+    run = source.run("run-1", mode="scope_complete")
+    assert list(run.facts) == []
+    assert run.completed_scope is False
+    assert run.health.status == "endpoint_failed"
+
+
+def test_scheme_prefixed_endpoint_maps_hostname_to_service(tmp_path):
+    # circleback-fixes regression: "https://h:8443/p".split("/", 1)[0]
+    # yielded "https:", silently breaking hostname -> service matching.
+    source = _source(tmp_path)
+    (tmp_path / "data" / "cric-core" / "services.json").write_text(
+        json.dumps(
+            {"reqmgr2": {"endpoint": "https://cmsweb.cern.ch:8443/reqmgr2"}}
+        )
+    )
+    facts = list(source.run("run-1", mode="scope_complete").facts)
+    edges = {
+        (e.src, e.edge_type, e.dst)
+        for e in facts
+        if isinstance(e, EdgeFact)
+    }
+    assert ("downtime:101", "affects", "svc:reqmgr2") in edges

--- a/python/tests/sources/test_hypernews.py
+++ b/python/tests/sources/test_hypernews.py
@@ -244,6 +244,68 @@ def test_empty_cache_refuses_complete_scope(tmp_path):
     assert run.health.status == "endpoint_failed"
 
 
+def test_preflight_empty_cache_matches_run_refusal(tmp_path):
+    # Preflight must not report ok/record_count=0 for a cache that
+    # run() then refuses with endpoint_failed.
+    root = tmp_path / "data" / "hypernews"
+    root.mkdir(parents=True)
+    (root / "records.json").write_text("[]")
+    source = HyperNewsSource(base=str(tmp_path))
+    result = source.preflight()
+    assert result.status == "endpoint_failed"
+    assert result.record_count == 0
+    run = source.run("run-1", mode="scope_complete")
+    assert run.health.status == "endpoint_failed"
+    assert result.reason == run.health.reason
+
+
+def test_clean_live_crawl_claims_scope_writes_cache_and_replays(
+    tmp_path, monkeypatch
+):
+    # Happy path: a fully successful multi-forum crawl keeps its
+    # completed-scope claim, persists the cache, and a second run reads
+    # that cache and still claims scope.
+    _cookie_env(tmp_path, monkeypatch)
+    mcops_listing = (
+        '<li value="3"><a href="/HyperNews/CMS/get/mcOps/3.html">'
+        "Third thread</a></li>"
+    )
+
+    def handler(url):
+        if url.endswith("/get/comp-ops.html"):
+            return _FakeResp(LISTING)
+        if url.endswith("/get/mcOps.html"):
+            return _FakeResp(mcops_listing)
+        return _FakeResp(THREAD_PAGE)
+
+    _patch_http(monkeypatch, handler)
+    expected_ids = {"hn:comp-ops/1", "hn:comp-ops/2", "hn:mcOps/3"}
+    source = HyperNewsSource(base=str(tmp_path))
+    run = source.run("run-1", mode="scope_complete")
+    threads = [
+        f for f in run.facts
+        if isinstance(f, NodeFact) and f.subtype == "forum_thread"
+    ]
+    assert {t.node_id for t in threads} == expected_ids
+    assert all(t.attrs["body"] == "Thread body text" for t in threads)
+    assert run.completed_scope is True
+    assert run.health.status == "ok"
+    assert run.health.mode == "live"
+    assert (tmp_path / "data" / "hypernews" / "records.json").is_file()
+
+    replay = HyperNewsSource(base=str(tmp_path)).run(
+        "run-2", mode="scope_complete"
+    )
+    replay_threads = [
+        f for f in replay.facts
+        if isinstance(f, NodeFact) and f.subtype == "forum_thread"
+    ]
+    assert {t.node_id for t in replay_threads} == expected_ids
+    assert replay.completed_scope is True
+    assert replay.health.status == "ok"
+    assert replay.health.mode == "cache"
+
+
 def test_cache_skips_unparseable_items_without_scope_claim(tmp_path):
     root = tmp_path / "data" / "hypernews"
     root.mkdir(parents=True)

--- a/python/tests/sources/test_hypernews.py
+++ b/python/tests/sources/test_hypernews.py
@@ -2,7 +2,11 @@
 import hashlib
 import json
 
-from okg.substrate.library.sources.base import EdgeFact, NodeFact
+from okg.substrate.library.sources.base import (
+    EdgeFact,
+    NodeFact,
+    SourcePreflightResult,
+)
 
 from archi.sources.hypernews import HyperNewsSource
 
@@ -89,3 +93,195 @@ def test_missing_cache_and_cookie_reports_not_ok_and_no_facts(tmp_path):
     assert list(run.facts) == []
     assert run.completed_scope is False
     assert run.health.status != "ok"
+
+
+# --- circleback-fixes regressions: live-crawl and cache failure modes ---
+
+LISTING = "\n".join([
+    '<li value="1"><a href="/HyperNews/CMS/get/comp-ops/1.html">'
+    "First thread</a></li>",
+    '<li value="2"><a href="/HyperNews/CMS/get/comp-ops/2.html">'
+    "Second thread</a></li>",
+])
+THREAD_PAGE = "<html><body>Thread body text</body></html>"
+
+
+class _FakeResp:
+    def __init__(self, text, status_code=200, url=""):
+        self.text = text
+        self.status_code = status_code
+        self.url = url
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+def _cookie_env(tmp_path, monkeypatch):
+    cookie = tmp_path / "cookies.txt"
+    cookie.write_text("# Netscape HTTP Cookie File\n")
+    monkeypatch.setenv("HYPERNEWS_COOKIE_FILE", str(cookie))
+
+
+def _patch_http(monkeypatch, handler):
+    import requests
+
+    def _get(self, url, timeout=None, **kwargs):
+        return handler(url)
+
+    monkeypatch.setattr(requests.Session, "get", _get)
+
+
+def _ok_preflight(self, mode="live"):
+    return SourcePreflightResult(
+        source_name="hypernews", status="ok", mode="live"
+    )
+
+
+def test_forum_listing_failure_degrades_and_never_claims_scope(
+    tmp_path, monkeypatch
+):
+    _cookie_env(tmp_path, monkeypatch)
+
+    def handler(url):
+        if url.endswith("/get/comp-ops.html"):
+            return _FakeResp(LISTING)
+        if url.endswith("/get/mcOps.html"):
+            raise ConnectionError("forum listing down")
+        return _FakeResp(THREAD_PAGE)
+
+    _patch_http(monkeypatch, handler)
+    source = HyperNewsSource(base=str(tmp_path))
+    run = source.run("run-1", mode="scope_complete")
+    threads = [
+        f for f in run.facts
+        if isinstance(f, NodeFact) and f.subtype == "forum_thread"
+    ]
+    # the reachable forum's threads are still emitted...
+    assert {t.node_id for t in threads} == {"hn:comp-ops/1", "hn:comp-ops/2"}
+    # ...but a partial crawl never claims a complete scope
+    assert run.completed_scope is False
+    assert run.health.status == "endpoint_failed"
+    assert "mcOps" in run.health.reason
+    # and is never persisted as a replayable "complete" cache
+    assert not (tmp_path / "data" / "hypernews" / "records.json").exists()
+
+
+def test_total_fetch_failure_writes_no_cache_and_fails_loud(
+    tmp_path, monkeypatch
+):
+    _cookie_env(tmp_path, monkeypatch)
+    monkeypatch.setattr(HyperNewsSource, "preflight", _ok_preflight)
+
+    def handler(url):
+        raise ConnectionError("everything down")
+
+    _patch_http(monkeypatch, handler)
+    source = HyperNewsSource(base=str(tmp_path))
+    run = source.run("run-1", mode="scope_complete")
+    assert list(run.facts) == []
+    assert run.completed_scope is False
+    assert run.health.status == "endpoint_failed"
+    assert "forum listings failed" in run.health.reason
+    # the old code persisted [] here, poisoning every later run
+    assert not (tmp_path / "data" / "hypernews" / "records.json").exists()
+
+
+def test_zero_threads_across_forums_is_failure_not_empty_success(
+    tmp_path, monkeypatch
+):
+    _cookie_env(tmp_path, monkeypatch)
+
+    def handler(url):
+        return _FakeResp("<html>markup with no thread list</html>")
+
+    _patch_http(monkeypatch, handler)
+    source = HyperNewsSource(base=str(tmp_path))
+    run = source.run("run-1", mode="scope_complete")
+    assert list(run.facts) == []
+    assert run.completed_scope is False
+    assert run.health.status == "endpoint_failed"
+    assert "zero threads" in run.health.reason
+    assert not (tmp_path / "data" / "hypernews" / "records.json").exists()
+
+
+def test_failed_hydration_drops_record_instead_of_blanking_it(
+    tmp_path, monkeypatch
+):
+    _cookie_env(tmp_path, monkeypatch)
+
+    def handler(url):
+        if url.endswith("/get/comp-ops.html"):
+            return _FakeResp(LISTING)
+        if url.endswith("/comp-ops/1.html"):
+            return _FakeResp(THREAD_PAGE)
+        raise ConnectionError("thread fetch failed")
+
+    _patch_http(monkeypatch, handler)
+    source = HyperNewsSource(base=str(tmp_path), forums=["comp-ops"])
+    run = source.run("run-1", mode="scope_complete")
+    threads = [
+        f for f in run.facts
+        if isinstance(f, NodeFact) and f.subtype == "forum_thread"
+    ]
+    # the un-hydrated thread is dropped, not emitted with a blank body
+    assert {t.node_id for t in threads} == {"hn:comp-ops/1"}
+    assert threads[0].attrs["body"] == "Thread body text"
+    assert run.completed_scope is False
+    assert run.health.status == "endpoint_failed"
+    assert "dropped" in run.health.reason
+    assert not (tmp_path / "data" / "hypernews" / "records.json").exists()
+
+
+def test_empty_cache_refuses_complete_scope(tmp_path):
+    root = tmp_path / "data" / "hypernews"
+    root.mkdir(parents=True)
+    (root / "records.json").write_text("[]")
+    source = HyperNewsSource(base=str(tmp_path))
+    run = source.run("run-1", mode="scope_complete")
+    assert list(run.facts) == []
+    assert run.completed_scope is False
+    assert run.health.status == "endpoint_failed"
+
+
+def test_cache_skips_unparseable_items_without_scope_claim(tmp_path):
+    root = tmp_path / "data" / "hypernews"
+    root.mkdir(parents=True)
+    (root / "records.json").write_text(
+        json.dumps(RECORDS + ["junk", {"title": "no thread id"}])
+    )
+    source = HyperNewsSource(base=str(tmp_path))
+    run = source.run("run-1", mode="scope_complete")
+    threads = [
+        f for f in run.facts
+        if isinstance(f, NodeFact) and f.subtype == "forum_thread"
+    ]
+    assert [t.node_id for t in threads] == ["hn:comp-ops/123"]
+    assert run.completed_scope is False
+    assert run.health.status == "ok"
+    assert "skipped 2" in run.health.reason
+
+
+def test_max_threads_truncation_never_claims_scope(tmp_path, monkeypatch):
+    _cookie_env(tmp_path, monkeypatch)
+
+    def handler(url):
+        if url.endswith("/get/comp-ops.html"):
+            return _FakeResp(LISTING)
+        return _FakeResp(THREAD_PAGE)
+
+    _patch_http(monkeypatch, handler)
+    source = HyperNewsSource(
+        base=str(tmp_path), forums=["comp-ops"], max_threads=1
+    )
+    run = source.run("run-1", mode="scope_complete")
+    threads = [
+        f for f in run.facts
+        if isinstance(f, NodeFact) and f.subtype == "forum_thread"
+    ]
+    assert len(threads) == 1
+    assert run.completed_scope is False
+    assert run.health.status == "ok"
+    assert "max_threads" in run.health.reason
+    # a truncated window must not be persisted as a complete cache
+    assert not (tmp_path / "data" / "hypernews" / "records.json").exists()

--- a/python/tests/sources/test_indico.py
+++ b/python/tests/sources/test_indico.py
@@ -52,9 +52,12 @@ def test_meeting_document_and_chunk_emission(tmp_path):
     nodes = {f.node_id: f for f in facts if isinstance(f, NodeFact)}
     meeting_id = "meeting_minutes:1465000"
     doc_id = "doc:indico:event/1465000/pdf/0"
-    chunk_id = (
-        "chunk:" + hashlib.sha256(PDF_TEXT.encode("utf-8")).hexdigest()[:16]
-    )
+    # Chunk ids are salted with the parent doc id + chunk index (the
+    # hypernews pattern, literal backslash-zero separator) so identical
+    # boilerplate in different events cannot collide onto one node.
+    chunk_id = "chunk:" + hashlib.sha256(
+        f"{doc_id}\\0{0}\\0{PDF_TEXT}".encode("utf-8")
+    ).hexdigest()[:16]
     assert set(nodes) == {meeting_id, doc_id, chunk_id}  # dup event dropped
     meeting = nodes[meeting_id]
     assert meeting.subtype == "meeting_minutes"
@@ -97,3 +100,61 @@ def test_url_fallback_uses_base_url_and_preflight(tmp_path):
     result = source.preflight()
     assert result.status == "ok"
     assert result.record_count == 1
+
+
+# --- circleback-fixes regressions ---
+
+
+def test_identical_pdf_text_in_different_events_gets_distinct_chunks(
+    tmp_path,
+):
+    # A content-hash-only chunk id collided identical boilerplate from
+    # different events onto one node with contradictory parents.
+    records = [
+        {"id": "100", "title": "A", "_pdf_texts": [{"text": PDF_TEXT}]},
+        {"id": "200", "title": "B", "_pdf_texts": [{"text": PDF_TEXT}]},
+    ]
+    root = tmp_path / "data" / "indico"
+    root.mkdir(parents=True)
+    (root / "records.json").write_text(json.dumps(records))
+    source = IndicoSource(base=str(tmp_path))
+    facts = list(source.run("run-1", mode="scope_complete").facts)
+    chunks = [
+        f for f in facts
+        if isinstance(f, NodeFact) and f.subtype == "document_chunk"
+    ]
+    assert len(chunks) == 2
+    assert len({c.node_id for c in chunks}) == 2
+    parents = {
+        (e.src, e.dst)
+        for e in facts
+        if isinstance(e, EdgeFact) and e.edge_type == "contains"
+        and e.dst.startswith("chunk:")
+    }
+    assert len(parents) == 2  # one distinct parent doc per chunk
+
+
+def test_skipped_cache_items_never_claim_scope(tmp_path):
+    root = tmp_path / "data" / "indico"
+    root.mkdir(parents=True)
+    (root / "records.json").write_text(
+        json.dumps(RECORDS + ["junk", {"title": "no id"}])
+    )
+    source = IndicoSource(base=str(tmp_path))
+    run = source.run("run-1", mode="scope_complete")
+    nodes = {f.node_id for f in run.facts if isinstance(f, NodeFact)}
+    assert "meeting_minutes:1465000" in nodes  # survivors still emitted
+    assert run.completed_scope is False
+    assert run.health.status == "ok"
+    assert "skipped 2" in run.health.reason
+
+
+def test_all_items_unparseable_is_endpoint_failed(tmp_path):
+    root = tmp_path / "data" / "indico"
+    root.mkdir(parents=True)
+    (root / "records.json").write_text(json.dumps(["junk"]))
+    source = IndicoSource(base=str(tmp_path))
+    run = source.run("run-1", mode="scope_complete")
+    assert list(run.facts) == []
+    assert run.completed_scope is False
+    assert run.health.status == "endpoint_failed"

--- a/python/tests/sources/test_jira.py
+++ b/python/tests/sources/test_jira.py
@@ -75,8 +75,14 @@ def _write_caches(tmp_path, records=None, with_targets=False):
         (tmp_path / "data" / "jira" / "records.json").write_text(
             json.dumps(records)
         )
+    # A clean fixture carries a record_count that matches the records
+    # cache; run() cross-checks the two and treats a mismatch as a
+    # truncated cache (see the mismatch regression tests below). The
+    # cache-missing fixtures keep the original 72000 that the preflight
+    # tests report on.
+    meta_count = 72000 if records is None else len(records)
     (tmp_path / "data" / "jira" / "meta.json").write_text(
-        json.dumps({"record_count": 72000})
+        json.dumps({"record_count": meta_count})
     )
     kwargs = {}
     if with_targets:
@@ -288,6 +294,52 @@ def test_run_health_ok_with_content_hash(tmp_path):
     assert run.health.mode == "cache"
     assert run.health.record_count == 2
     assert run.health.content_hash
+
+
+def test_meta_record_count_mismatch_never_claims_scope(tmp_path):
+    """Adversarial-review finding 6: a truncated-but-valid records cache
+    (meta.json reports 72000 records, the file parses 2) must emit what
+    parsed but report the mismatch and never claim a completed scope —
+    claiming it would retract every record the truncation dropped."""
+    source = _write_caches(tmp_path, [FLAT_ISSUE, API_ISSUE])
+    (tmp_path / "data" / "jira" / "meta.json").write_text(
+        json.dumps({"record_count": 72000})
+    )
+    run = source.run("r", mode="scope_complete")
+    facts = list(run.facts)
+    # The parsed records are still emitted...
+    assert {n.node_id for n in _nodes(facts, "jira_issue")} == {
+        "jira:CMSPROD-101",
+        "jira:CMSPROD-100",
+    }
+    # ...but the run is degraded and claims nothing.
+    assert run.completed_scope is False
+    assert run.health.status == "endpoint_failed"
+    assert run.health.record_count == 2
+    assert "record_count=72000" in run.health.reason
+    assert "parsed 2 records" in run.health.reason
+
+
+def test_meta_without_record_count_stays_clean(tmp_path):
+    """A meta.json that carries no record_count cannot cross-check the
+    cache and must not degrade the run."""
+    source = _write_caches(tmp_path, [FLAT_ISSUE])
+    (tmp_path / "data" / "jira" / "meta.json").write_text(
+        json.dumps({"fetched_at": "2026-08-11T00:00:00Z"})
+    )
+    run = source.run("r", mode="scope_complete")
+    assert list(run.facts)
+    assert run.completed_scope is True
+    assert run.health.status == "ok"
+
+
+def test_meta_record_count_match_claims_scope(tmp_path):
+    """A matching record_count is a clean run (the fixture default)."""
+    source = _write_caches(tmp_path, [FLAT_ISSUE, API_ISSUE])
+    run = source.run("r", mode="scope_complete")
+    assert len(_nodes(list(run.facts), "jira_issue")) == 2
+    assert run.completed_scope is True
+    assert run.health.status == "ok"
 
 
 # --- preflight --------------------------------------------------------------

--- a/python/tests/sources/test_monit.py
+++ b/python/tests/sources/test_monit.py
@@ -5,7 +5,9 @@ list of plain record mappings, or a raw MONIT ``_msearch`` response
 (``{"responses": [...]}``). Live paths run against a monkeypatched
 ``requests.post``.
 """
+import copy
 import json
+import time
 
 import pytest
 
@@ -611,3 +613,277 @@ def test_rucio_dataset_list_cache_records(tmp_path, monkeypatch):
 def test_required_kwonly_and_no_positional_params():
     with pytest.raises(TypeError):
         MONITSAMSource("positional")  # keyword-only constructor
+
+
+# --- adversarial-review regressions (pact/changes/circleback-fixes) ----------
+
+def test_sam_live_timed_out_response_degrades_scope(tmp_path, monkeypatch):
+    """Finding 2: an HTTP-200 response with timed_out=true must emit its
+    data but report endpoint_failed and never claim a completed scope."""
+    monkeypatch.setenv(TOKEN_ENV, "test-token")
+    partial = copy.deepcopy(SITEMON_RESPONSE)
+    partial["responses"][0]["timed_out"] = True
+    _fake_post(monkeypatch, lambda *a: partial)
+    run = _sam_source(tmp_path).run("r", mode="scope_complete")
+    facts = list(run.facts)
+    assert len(_nodes(facts, "monitoring_snapshot")) == 2  # data emitted
+    assert run.completed_scope is False
+    assert run.health.status == "endpoint_failed"
+    assert "timed_out" in run.health.reason
+
+
+def test_condor_live_shard_failures_degrade_scope(tmp_path, monkeypatch):
+    """Finding 2: _shards.failed > 0 means an unknown slice of the window
+    is missing; the run must not claim a completed scope."""
+    monkeypatch.setenv(TOKEN_ENV, "test-token")
+    partial = copy.deepcopy(CONDOR_RESPONSE)
+    partial["responses"][0]["_shards"] = {
+        "total": 40, "successful": 12, "skipped": 0, "failed": 28,
+    }
+    _fake_post(monkeypatch, lambda *a: partial)
+    source = MONITCondorSource(
+        records_path="data/monit-condor/records.json",
+        token_env=TOKEN_ENV,
+        base=str(tmp_path),
+    )
+    run = source.run("r", mode="reconcile")
+    facts = list(run.facts)
+    assert len(_nodes(facts, "monitoring_snapshot")) == 1  # data emitted
+    assert run.completed_scope is False
+    assert run.health.status == "endpoint_failed"
+    assert "shards failed 28/40" in run.health.reason
+
+
+def test_transfer_live_terms_truncation_degrades_scope(tmp_path, monkeypatch):
+    """Finding 3: sum_other_doc_count > 0 on a bucket-limited terms agg
+    means sites were silently dropped; never claim the scope."""
+    monkeypatch.setenv(TOKEN_ENV, "test-token")
+    partial = copy.deepcopy(TRANSFER_RESPONSE)
+    partial["responses"][0]["aggregations"]["by_src_rse"][
+        "sum_other_doc_count"
+    ] = 123456
+    _fake_post(monkeypatch, lambda *a: partial)
+    source = MONITRucioTransferSource(
+        records_path="data/monit-rucio-transfer/records.json",
+        token_env=TOKEN_ENV,
+        base=str(tmp_path),
+    )
+    run = source.run("r", mode="scope_complete")
+    facts = list(run.facts)
+    assert _nodes(facts, "transfer_job")  # data still emitted
+    assert run.completed_scope is False
+    assert run.health.status == "endpoint_failed"
+    assert "by_src_rse" in run.health.reason
+    assert "sum_other_doc_count=123456" in run.health.reason
+
+
+def test_nested_terms_truncation_is_detected(tmp_path, monkeypatch):
+    """Finding 3: truncation markers on nested (per-bucket) aggregations
+    are found by the recursive walk, not just top-level aggs."""
+    monkeypatch.setenv(TOKEN_ENV, "test-token")
+    partial = copy.deepcopy(SITEMON_RESPONSE)
+    groups = partial["responses"][0]["aggregations"]["groups"]
+    groups["buckets"][0]["status_breakdown"][
+        "doc_count_error_upper_bound"
+    ] = 7
+    _fake_post(monkeypatch, lambda *a: partial)
+    run = _sam_source(tmp_path).run("r", mode="scope_complete")
+    list(run.facts)
+    assert run.completed_scope is False
+    assert run.health.status == "endpoint_failed"
+    assert "groups.status_breakdown" in run.health.reason
+
+
+def test_cached_raw_response_with_partial_markers_degrades_scope(
+    tmp_path, monkeypatch
+):
+    """Finding 2 (cache variant): a records cache holding a raw _msearch
+    response that was itself partial must not claim a completed scope."""
+    monkeypatch.delenv(TOKEN_ENV, raising=False)
+    partial = copy.deepcopy(SITEMON_RESPONSE)
+    partial["responses"][0]["timed_out"] = True
+    _write(tmp_path, "data/monit-sam/records.json", partial)
+    run = _sam_source(tmp_path).run("r", mode="scope_complete")
+    facts = list(run.facts)
+    assert len(_nodes(facts, "monitoring_snapshot")) == 2
+    assert run.completed_scope is False
+    assert run.health.status == "endpoint_failed"
+
+
+def test_sam_live_zero_buckets_never_claims_empty_scope(
+    tmp_path, monkeypatch
+):
+    """Finding 4: with ignore_unavailable wildcard queries a zero-bucket
+    result is indistinguishable from a renamed index or stalled
+    pipeline; claiming a complete empty scope would retract everything."""
+    monkeypatch.setenv(TOKEN_ENV, "test-token")
+    _fake_post(monkeypatch, lambda *a: {"responses": [{
+        "timed_out": False,
+        "_shards": {"total": 40, "successful": 40, "failed": 0},
+        "aggregations": {"groups": {"buckets": []}},
+    }]})
+    run = _sam_source(tmp_path).run("r", mode="scope_complete")
+    assert list(run.facts) == []
+    assert run.completed_scope is False
+    assert run.health.status == "skipped_optional"
+    assert "no complete scope" in run.health.reason
+
+
+def test_sam_empty_cache_never_claims_scope(tmp_path, monkeypatch):
+    """Finding 4 (cache variant): an empty records cache also never
+    claims a complete empty scope."""
+    monkeypatch.delenv(TOKEN_ENV, raising=False)
+    _write(tmp_path, "data/monit-sam/records.json", [])
+    run = _sam_source(tmp_path).run("r", mode="scope_complete")
+    assert run.completed_scope is False
+    assert run.health.status == "skipped_optional"
+
+
+def test_rucio_dataset_live_zero_buckets_never_claims_empty_scope(
+    tmp_path, monkeypatch
+):
+    """Finding 4 (streaming path): a zero-bucket first page must return a
+    skipped_optional run with completed_scope=False, not a completed
+    empty stream."""
+    monkeypatch.setenv(TOKEN_ENV, "test-token")
+    empty = {"responses": [{"aggregations": {"datasets": {"buckets": []}}}]}
+    calls = _fake_post(monkeypatch, lambda *a: empty)
+    run = _dataset_source(tmp_path).run("r", mode="scope_complete")
+    assert list(run.facts) == []
+    assert run.completed_scope is False
+    assert run.health.status == "skipped_optional"
+    assert "no complete scope" in run.health.reason
+    assert len(calls) == 1
+
+
+def test_rucio_dataset_live_partial_first_page_fails_run(
+    tmp_path, monkeypatch
+):
+    """Finding 2 (streaming path): a degraded first page fails the run
+    before any facts or scope claims are produced, and the partial page
+    is never cached for later replay."""
+    monkeypatch.setenv(TOKEN_ENV, "test-token")
+    partial = copy.deepcopy(DATASET_RESPONSE)
+    partial["responses"][0]["timed_out"] = True
+    _fake_post(monkeypatch, lambda *a: partial)
+    run = _dataset_source(tmp_path).run("r", mode="scope_complete")
+    assert list(run.facts) == []
+    assert run.completed_scope is False
+    assert run.health.status == "endpoint_failed"
+    assert "partial MONIT OpenSearch response" in run.health.reason
+    pages_dir = tmp_path / "data" / "monit-rucio-datasets" / "pages"
+    assert not pages_dir.exists() or not list(pages_dir.rglob("*.json"))
+
+
+def test_rucio_dataset_live_partial_later_page_raises_midstream(
+    tmp_path, monkeypatch
+):
+    """Finding 2 (streaming path): a degraded later page raises so the
+    runner fails the run instead of committing a partial scope."""
+    monkeypatch.setenv(TOKEN_ENV, "test-token")
+    page1 = {"responses": [{"aggregations": {"datasets": {
+        "buckets": [DATASET_BUCKET],
+        "after_key": {"dataset": "/Prim/Era-v1/RECO"},
+    }}}]}
+    page2 = {"responses": [{
+        "timed_out": True,
+        "aggregations": {"datasets": {"buckets": []}},
+    }]}
+
+    def _respond(url, headers, data):
+        query = json.loads(data.split("\n")[1])
+        composite = query["aggs"]["datasets"]["composite"]
+        return page2 if "after" in composite else page1
+
+    _fake_post(monkeypatch, _respond)
+    run = _dataset_source(tmp_path).run("r", mode="scope_complete")
+    with pytest.raises(RuntimeError, match="partial MONIT OpenSearch"):
+        list(run.facts)
+
+
+def test_rucio_dataset_page_cache_is_day_scoped(tmp_path, monkeypatch):
+    """Finding 1 (BLOCKER): after one live run, a later day's run must
+    re-query MONIT instead of replaying the previous day's cached pages
+    (which would emit day-1's datasets stamped with day-2's date under a
+    completed-scope claim)."""
+    monkeypatch.setenv(TOKEN_ENV, "test-token")
+    state = {"dataset": "/Day1/Era-v1/RECO"}
+
+    def _respond(url, headers, data):
+        return {"responses": [{"aggregations": {"datasets": {"buckets": [{
+            "key": {"dataset": state["dataset"]},
+            "replicas": {"buckets": [{"key": "T2_CH_CERN"}]},
+            "sample": {"hits": {"hits": []}},
+        }]}}}]}
+
+    calls = _fake_post(monkeypatch, _respond)
+    # Freeze day 1 at the real current UTC date so the entries written
+    # by the run (cached_at = real now) belong to "day 1".
+    from datetime import datetime, timedelta, timezone
+
+    day1 = datetime.now(timezone.utc)
+    day2 = day1 + timedelta(days=1)
+    monkeypatch.setattr(
+        monit_mod, "_today", lambda: day1.strftime("%Y-%m-%d")
+    )
+    run1 = _dataset_source(tmp_path).run("d1", mode="scope_complete")
+    names1 = {n.attrs["name"] for n in _nodes(list(run1.facts), "dataset")}
+    assert names1 == {"/Day1/Era-v1/RECO"}
+    assert len(calls) == 1
+
+    # Same day, same query: the cache legitimately replays (crash/resume).
+    rerun = _dataset_source(tmp_path).run("d1b", mode="scope_complete")
+    assert {
+        n.attrs["name"] for n in _nodes(list(rerun.facts), "dataset")
+    } == names1
+    assert len(calls) == 1  # no new HTTP
+
+    # Next day the upstream changed completely: the run must NOT replay
+    # day-1's pages and must emit day-2's datasets.
+    state["dataset"] = "/Day2/Era-v1/RECO"
+    monkeypatch.setattr(
+        monit_mod, "_today", lambda: day2.strftime("%Y-%m-%d")
+    )
+    run2 = _dataset_source(tmp_path).run("d2", mode="scope_complete")
+    names2 = {n.attrs["name"] for n in _nodes(list(run2.facts), "dataset")}
+    assert names2 == {"/Day2/Era-v1/RECO"}
+    assert len(calls) == 2  # fresh HTTP on the new day
+    assert run2.completed_scope is True
+
+
+def test_rucio_dataset_page_cache_honors_ttl(tmp_path, monkeypatch):
+    """Finding 1: even a same-day cache entry only satisfies a run while
+    it is younger than page_cache_ttl_hours."""
+    monkeypatch.setenv(TOKEN_ENV, "test-token")
+    calls = _fake_post(monkeypatch, lambda *a: DATASET_RESPONSE)
+    list(_dataset_source(tmp_path).run("r1", mode="scope_complete").facts)
+    assert len(calls) == 1
+    # Same day, default TTL: replayed.
+    list(_dataset_source(tmp_path).run("r2", mode="scope_complete").facts)
+    assert len(calls) == 1
+    # TTL exceeded: the same-day entry no longer satisfies the run.
+    time.sleep(0.01)
+    strict = _dataset_source(tmp_path, page_cache_ttl_hours=0.0)
+    list(strict.run("r3", mode="scope_complete").facts)
+    assert len(calls) == 2
+
+
+def test_rucio_dataset_page_cache_entry_without_cached_at_is_stale(
+    tmp_path, monkeypatch
+):
+    """Finding 1: an entry of unknown age (no/corrupt cached_at, e.g. a
+    legacy cache) can never satisfy a run."""
+    monkeypatch.setenv(TOKEN_ENV, "test-token")
+    calls = _fake_post(monkeypatch, lambda *a: DATASET_RESPONSE)
+    list(_dataset_source(tmp_path).run("r1", mode="scope_complete").facts)
+    assert len(calls) == 1
+    pages = sorted(
+        (tmp_path / "data" / "monit-rucio-datasets" / "pages").rglob("*.json")
+    )
+    assert pages
+    for page in pages:
+        entry = json.loads(page.read_text())
+        entry.pop("cached_at", None)
+        page.write_text(json.dumps(entry))
+    list(_dataset_source(tmp_path).run("r2", mode="scope_complete").facts)
+    assert len(calls) == 2

--- a/python/tests/sources/test_siteconf.py
+++ b/python/tests/sources/test_siteconf.py
@@ -1,7 +1,11 @@
 """req.w2.sources-catalogs — SITECONFSource emission (fixture mode)."""
 import json
 
-from okg.substrate.library.sources.base import EdgeFact, NodeFact
+from okg.substrate.library.sources.base import (
+    EdgeFact,
+    NodeFact,
+    SourcePreflightResult,
+)
 
 from archi.sources.siteconf import SiteConfRecord, SITECONFSource
 
@@ -58,3 +62,114 @@ def test_unknown_site_gets_node_but_no_edge_and_preflight_fixture(tmp_path):
     assert result.status == "ok"
     assert result.mode == "fixture"
     assert result.record_count == 1
+
+
+# --- circleback-fixes regressions: live-crawl failure modes ---
+
+
+class _Resp:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+def _ok_preflight(self, mode="live"):
+    return SourcePreflightResult(
+        source_name="siteconf", status="ok", mode="live"
+    )
+
+
+def test_empty_project_list_fails_loud_instead_of_empty_scope(
+    tmp_path, monkeypatch
+):
+    # HTTP-200 empty project list (token without group visibility) used
+    # to become ok/completed_scope over 0 records -> retract-all.
+    monkeypatch.setattr(SITECONFSource, "preflight", _ok_preflight)
+    monkeypatch.setattr(
+        SITECONFSource,
+        "_list_projects",
+        lambda self, session, headers: ([], False),
+    )
+    source = _source(tmp_path, None)
+    run = source.run("run-1", mode="scope_complete")
+    assert list(run.facts) == []
+    assert run.completed_scope is False
+    assert run.health.status == "endpoint_failed"
+    assert "empty project list" in run.health.reason
+
+
+def test_zero_parsed_records_from_projects_fails_loud(tmp_path, monkeypatch):
+    monkeypatch.setattr(SITECONFSource, "preflight", _ok_preflight)
+    monkeypatch.setattr(
+        SITECONFSource,
+        "_list_projects",
+        lambda self, session, headers: (
+            [{"id": 7, "path": "not-a-site"}], False
+        ),
+    )
+    source = _source(tmp_path, None)
+    run = source.run("run-1", mode="scope_complete")
+    assert list(run.facts) == []
+    assert run.completed_scope is False
+    assert run.health.status == "endpoint_failed"
+    assert "zero SITECONF records" in run.health.reason
+
+
+def test_preflight_group_probe_flags_invisible_group(monkeypatch):
+    import requests
+
+    monkeypatch.setenv("CERN_GITLAB_TOKEN", "tok")
+
+    def fake_get(url, **kwargs):
+        if url.endswith("/api/v4/user"):
+            return _Resp(200, {"username": "svc"})
+        return _Resp(200, [])  # group visible check: empty list
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    result = SITECONFSource().preflight()
+    assert result.status == "endpoint_failed"
+    assert "group" in result.reason
+
+
+def test_max_projects_truncation_never_claims_scope(tmp_path, monkeypatch):
+    import requests
+
+    monkeypatch.setattr(SITECONFSource, "preflight", _ok_preflight)
+
+    class _FakeSession:
+        def get(self, url, params=None, headers=None, timeout=None):
+            if params and params.get("page") == 1:
+                return _Resp(200, [
+                    {"id": 11, "path": "T2_US_MIT"},
+                    {"id": 12, "path": "T2_US_XYZ"},
+                ])
+            return _Resp(200, [])
+
+    monkeypatch.setattr(requests, "Session", _FakeSession)
+    monkeypatch.setattr(
+        SITECONFSource,
+        "_fetch_site_config",
+        lambda self, session, **kwargs: SiteConfRecord(
+            site_name=kwargs["site_name"], raw_storage_json="{}"
+        ),
+    )
+    source = SITECONFSource(
+        records=None, base=str(tmp_path), max_projects=1
+    )
+    (tmp_path / "data" / "cric").mkdir(parents=True)
+    (tmp_path / "data" / "cric" / "sites.json").write_text(
+        json.dumps({"T2_US_MIT": {}})
+    )
+    run = source.run("run-1", mode="scope_complete")
+    nodes = [f for f in run.facts if isinstance(f, NodeFact)]
+    assert [n.node_id for n in nodes] == ["siteconf:T2_US_MIT"]
+    assert run.completed_scope is False
+    assert run.health.status == "ok"
+    assert "max_projects" in run.health.reason

--- a/python/tests/sources/test_siteconf.py
+++ b/python/tests/sources/test_siteconf.py
@@ -138,6 +138,28 @@ def test_preflight_group_probe_flags_invisible_group(monkeypatch):
     assert "group" in result.reason
 
 
+def test_preflight_group_probe_includes_subgroups_like_the_crawl(
+    monkeypatch,
+):
+    # A group whose projects live only in subgroups must not get a
+    # false-negative preflight: the probe must send include_subgroups
+    # exactly like the crawl's listing does.
+    import requests
+
+    monkeypatch.setenv("CERN_GITLAB_TOKEN", "tok")
+
+    def fake_get(url, params=None, **kwargs):
+        if url.endswith("/api/v4/user"):
+            return _Resp(200, {"username": "svc"})
+        if (params or {}).get("include_subgroups") == "true":
+            return _Resp(200, [{"id": 11, "path": "T2_US_MIT"}])
+        return _Resp(200, [])  # subgroup-only project is invisible
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    result = SITECONFSource().preflight()
+    assert result.status == "ok"
+
+
 def test_max_projects_truncation_never_claims_scope(tmp_path, monkeypatch):
     import requests
 

--- a/python/tests/sources/test_wmstats.py
+++ b/python/tests/sources/test_wmstats.py
@@ -63,3 +63,27 @@ def test_preflight_optional_and_empty_cache(tmp_path):
     assert missing.preflight().required is False
     empty = _source(tmp_path, records=[])
     assert empty.preflight().status == "skipped_optional"
+
+
+# --- circleback-fixes regressions ---
+
+
+def test_skipped_cache_items_never_claim_scope(tmp_path):
+    source = _source(
+        tmp_path, records=RECORDS + ["junk", {"Campaign": "no name"}]
+    )
+    run = source.run("run-1", mode="scope_complete")
+    nodes = {f.node_id for f in run.facts if isinstance(f, NodeFact)}
+    wf_id = "workflow:pdmvserv_task_TOP-Run3Summer23-00001"
+    assert wf_id in nodes  # survivors still emitted
+    assert run.completed_scope is False
+    assert run.health.status == "ok"
+    assert "skipped 2" in run.health.reason
+
+
+def test_all_items_unparseable_is_endpoint_failed(tmp_path):
+    source = _source(tmp_path, records=["junk", 42])
+    run = source.run("run-1", mode="scope_complete")
+    assert list(run.facts) == []
+    assert run.completed_scope is False
+    assert run.health.status == "endpoint_failed"

--- a/python/tests/tools/test_monit_live.py
+++ b/python/tests/tools/test_monit_live.py
@@ -240,6 +240,103 @@ def test_search_timeout_is_structured_error(monkeypatch):
     assert payload["boundary"] == "external_live"
 
 
+def test_search_connection_error_is_structured(monkeypatch):
+    """Finding 7: requests.ConnectionError must come back as the same
+    structured error payload as a timeout, not escape as an exception."""
+    monkeypatch.setenv(TOKEN_ENV, "test-token")
+    _fake_post(
+        monkeypatch,
+        lambda *a: requests.exceptions.ConnectionError("dns failure"),
+    )
+    payload = archi_monit_rucio_search("*")
+    assert payload["error"] == (
+        "MONIT OpenSearch request failed: ConnectionError"
+    )
+    assert payload["results"] == []
+    assert payload["boundary"] == "external_live"
+
+
+def test_aggregate_connection_error_is_structured(monkeypatch):
+    monkeypatch.setenv(TOKEN_ENV, "test-token")
+    _fake_post(
+        monkeypatch,
+        lambda *a: requests.exceptions.ConnectionError("dns failure"),
+    )
+    payload = archi_monit_rucio_aggregate("*", "data.reason")
+    assert payload["aggregation"]["error"] == (
+        "MONIT OpenSearch request failed: ConnectionError"
+    )
+    assert payload["aggregation"]["buckets"] == []
+
+
+class _NonJSONResponse:
+    status_code = 200
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        raise requests.exceptions.JSONDecodeError(
+            "Expecting value", "<html>Grafana error page</html>", 0
+        )
+
+
+def test_search_non_json_200_body_is_structured(monkeypatch):
+    """Finding 7: a 200 body that is not JSON (Grafana HTML error page)
+    must come back as a structured error payload."""
+    monkeypatch.setenv(TOKEN_ENV, "test-token")
+    monkeypatch.setattr(
+        monit_tools.requests, "post", lambda *a, **k: _NonJSONResponse()
+    )
+    payload = archi_monit_rucio_search("*")
+    assert payload["error"] == (
+        "MONIT OpenSearch returned a non-JSON response body"
+    )
+    assert payload["results"] == []
+
+
+def test_aggregate_non_json_200_body_is_structured(monkeypatch):
+    monkeypatch.setenv(TOKEN_ENV, "test-token")
+    monkeypatch.setattr(
+        monit_tools.requests, "post", lambda *a, **k: _NonJSONResponse()
+    )
+    payload = archi_monit_rucio_aggregate("*", "data.reason")
+    assert payload["aggregation"]["error"] == (
+        "MONIT OpenSearch returned a non-JSON response body"
+    )
+
+
+def test_time_window_echo_matches_query_body(monkeypatch):
+    """Finding 9: the echoed time_window must reflect exactly the window
+    the query body used — blank inputs are defaulted identically in
+    both, not just in the echo."""
+    monkeypatch.setenv(TOKEN_ENV, "test-token")
+    calls = _fake_post(monkeypatch, lambda *a: SEARCH_RESPONSE)
+    payload = archi_monit_rucio_search("*", from_time="", to_time="  ")
+    (call,) = calls
+    _, body = _body(call)
+    time_range = body["query"]["bool"]["filter"][0]["range"][
+        "metadata.timestamp"
+    ]
+    assert time_range["gte"] == "now-24h"
+    assert time_range["lte"] == "now"
+    assert payload["time_window"]["from"] == time_range["gte"]
+    assert payload["time_window"]["to"] == time_range["lte"]
+
+    calls.clear()
+    payload = archi_monit_rucio_aggregate(
+        "*", "data.reason", from_time=" now-7d ", to_time=None,
+    )
+    _, body = _body(calls[0])
+    time_range = body["query"]["bool"]["filter"][0]["range"][
+        "metadata.timestamp"
+    ]
+    assert time_range["gte"] == "now-7d"
+    assert time_range["lte"] == "now"
+    assert payload["time_window"]["from"] == "now-7d"
+    assert payload["time_window"]["to"] == "now"
+
+
 def test_search_http_401_maps_to_auth_failed_message(monkeypatch):
     monkeypatch.setenv(TOKEN_ENV, "test-token")
     monkeypatch.setattr(
@@ -299,8 +396,11 @@ def test_rucio_aggregate_terms_keyword_and_formatting(monkeypatch):
 
 def test_aggregate_keyword_retry_falls_back_to_raw_field(monkeypatch):
     monkeypatch.setenv(TOKEN_ENV, "test-token")
-    empty = {"responses": [{
-        "hits": {"total": {"value": 0}},
+    # Documents matched but the auto-appended .keyword sub-field is
+    # unmapped (e.g. a numeric field): zero buckets with a non-zero
+    # total triggers the raw-field retry.
+    matched_bucketless = {"responses": [{
+        "hits": {"total": {"value": 917}},
         "aggregations": {"result": {"buckets": []}},
     }]}
 
@@ -309,7 +409,11 @@ def test_aggregate_keyword_retry_falls_back_to_raw_field(monkeypatch):
             data.split("\n")[1]
         )
         field = body["aggs"]["result"]["terms"]["field"]
-        return TERMS_AGG_RESPONSE if field == "data.bytes" else empty
+        return (
+            TERMS_AGG_RESPONSE
+            if field == "data.bytes"
+            else matched_bucketless
+        )
 
     calls = _fake_post(monkeypatch, _respond)
     payload = archi_monit_condor_aggregate("*", "data.bytes")
@@ -320,6 +424,87 @@ def test_aggregate_keyword_retry_falls_back_to_raw_field(monkeypatch):
     payload = archi_monit_condor_aggregate("*", "data.reason.keyword")
     assert len(calls) == 1
     assert payload["aggregation"]["buckets"] == []
+
+
+def test_aggregate_field_error_triggers_raw_retry(monkeypatch):
+    """Finding 8: a field-related .keyword error (fielddata disabled,
+    missing mapping) retries with the raw field name."""
+    monkeypatch.setenv(TOKEN_ENV, "test-token")
+    field_error = {"responses": [{"error": {
+        "type": "search_phase_execution_exception",
+        "reason": "Fielddata is disabled on text fields by default",
+    }}]}
+
+    def _respond(url, headers, data):
+        body = json.loads(data.split("\n")[1])
+        field = body["aggs"]["result"]["terms"]["field"]
+        return TERMS_AGG_RESPONSE if field == "data.reason" else field_error
+
+    calls = _fake_post(monkeypatch, _respond)
+    payload = archi_monit_rucio_aggregate("*", "data.reason")
+    assert len(calls) == 2
+    assert payload["aggregation"]["buckets"]
+    assert "error" not in payload["aggregation"]
+
+
+def test_aggregate_zero_match_empty_buckets_is_valid_result(monkeypatch):
+    """Finding 8 regression: a legitimate zero-bucket .keyword result
+    (zero matching documents) must be returned as-is — the old code
+    retried with the raw field and surfaced its fielddata error."""
+    monkeypatch.setenv(TOKEN_ENV, "test-token")
+    state = {"calls": 0}
+    empty = {"responses": [{
+        "hits": {"total": {"value": 0}},
+        "aggregations": {"result": {"buckets": []}},
+    }]}
+    fielddata_error = {"responses": [{"error": {
+        "type": "search_phase_execution_exception",
+        "reason": "Fielddata is disabled on text fields by default",
+    }}]}
+
+    def _respond(url, headers, data):
+        state["calls"] += 1
+        return empty if state["calls"] == 1 else fielddata_error
+
+    calls = _fake_post(monkeypatch, _respond)
+    payload = archi_monit_rucio_aggregate(
+        "data.event_type:none-match", "data.reason"
+    )
+    assert len(calls) == 1  # no raw-field retry on a zero-match result
+    agg = payload["aggregation"]
+    assert agg["buckets"] == []
+    assert agg["total_matching_documents"] == 0
+    assert "error" not in agg
+
+
+def test_aggregate_failing_raw_retry_keeps_valid_empty_result(monkeypatch):
+    """Finding 8: when the matched-but-bucketless retry itself errors,
+    the valid empty .keyword result wins — never the retry's error."""
+    monkeypatch.setenv(TOKEN_ENV, "test-token")
+    matched_bucketless = {"responses": [{
+        "hits": {"total": {"value": 42}},
+        "aggregations": {"result": {"buckets": []}},
+    }]}
+    fielddata_error = {"responses": [{"error": {
+        "reason": "Fielddata is disabled on text fields by default",
+    }}]}
+
+    def _respond(url, headers, data):
+        body = json.loads(data.split("\n")[1])
+        field = body["aggs"]["result"]["terms"]["field"]
+        return (
+            fielddata_error
+            if field == "data.reason"
+            else matched_bucketless
+        )
+
+    calls = _fake_post(monkeypatch, _respond)
+    payload = archi_monit_rucio_aggregate("*", "data.reason")
+    assert len(calls) == 2
+    agg = payload["aggregation"]
+    assert agg["buckets"] == []
+    assert agg["total_matching_documents"] == 42
+    assert "error" not in agg
 
 
 def test_aggregate_metric_value(monkeypatch):

--- a/skills/indico.md
+++ b/skills/indico.md
@@ -1,65 +1,43 @@
-# Indico MCP server — domain knowledge
+# Indico events in the OKG
 
-You have access to a set of `INDICO_*` tools backed by [Indico](https://indico.cern.ch),
-CERN's event-management system. Use them for **live, precise lookups** about specific
-events, contributions, categories, or attached materials.
+Indico (https://indico.cern.ch) is CERN's event-management system. On this
+deployment its content arrives through the `indico` connector
+(`archi.sources.indico`), which projects configured categories/events into the
+graph — there is no live Indico API tool on a v3 instance; answer from the
+graph, and say so when the graph's snapshot is older than the question needs.
 
-## Tool selection
+## What the connector puts in the graph
 
-- **Event by ID** (e.g. user mentions a number like `137346` or pastes an Indico URL):
-  `INDICO_get_event_details`. Pass `include_contributions: true` only when the user wants
-  the agenda; otherwise the response is much shorter without it.
-- **Search by free-text title/keyword across all categories**: `INDICO_search_events_by_term`.
-- **List events under a known category** (e.g. weekly meetings): `INDICO_search_events_by_category_id`.
-  If you don't know the category ID, walk the tree with `INDICO_search_categories_by_id`
-  starting from `"0"` (root) — don't guess IDs.
-- **Talks/contributions inside an event**: `INDICO_get_event_contributions`. Set
-  `include_subcontributions: true` for sessions broken into sub-talks.
-- **Materials/slides attached to an event** — two modes:
-  - **List only** (default): `INDICO_get_files(event_id, download_files=false)`. Returns
-    filenames, sizes, and API paths. Use this when the user just wants to know *what's
-    attached* to an event.
-  - **Download + ingest** (for "what's in the slides" questions): see the next section.
-- **Who am I / what perms do I have**: `INDICO_get_user_info`.
+- `meeting_minutes` nodes per ingested event (title, date, category, canonical
+  `https://indico.cern.ch/event/<event_id>/` URL in attrs).
+- `document` nodes for event attachments (slides, PDFs) with
+  `contains` edges from the meeting, and `document_chunk` nodes carrying the
+  extracted text (`member_of` / `contains` chunk edges).
+- Cross-references: chunks that mention JIRA keys, releases, or sites get
+  `references` edges via the extraction/enrichment layer, so meetings link
+  into the operational graph.
 
-## Making slides searchable: pair with `ingest_indico_event`
+## How to answer Indico questions
 
-When the user wants the *contents* of an event (slide text, agenda body) — not just
-metadata — use the authenticated MCP path. **Do NOT** use `ingest_url` on Indico URLs:
-the agent's `ingest_url` is wired with a routing rule that refuses Indico event URLs
-and points you back here (it cannot authenticate against CERN SSO with the anonymous
-LinkScraper). If you ever see that refusal, follow it — don't retry.
+- **Event by ID or pasted URL**: extract the integer event id from the URL
+  path and `search` for it (event ids and Indico URLs are indexed); `trace`
+  the `meeting_minutes` node to walk its documents and chunks.
+- **"What was discussed about X"**: `search` for the topic, filter to
+  `meeting_minutes` / `document_chunk` subtypes, then expand promising chunks
+  to their parent meeting for date/context before synthesizing.
+- **"Latest <recurring meeting>"**: search the meeting-series name, order hits
+  by the meeting date attr, and check the pinned generation's freshness — if
+  the newest meeting in the graph predates the series cadence, the snapshot is
+  behind; report that explicitly instead of presenting the newest ingested
+  meeting as current.
+- **Attachment contents**: the chunks ARE the attachment text. Quote from
+  chunks and cite the parent document + meeting URL.
 
-1. `INDICO_get_files(event_id, download_files=true)` — the MCP server authenticates
-   with CERN, downloads each attachment to a shared volume (`/shared/indico-downloads/<event_id>/`),
-   and reports per-file status. This is the only step that hits the network.
-2. `ingest_indico_event(event_id=<id>, event_url=<canonical Indico URL>)` — asks the
-   data-manager to chunk + embed + index everything that just landed in the shared
-   dir. Stamps `event_id`, `url`, and `scraper=indico` into resource metadata.
-3. Retrieve DETERMINISTICALLY with `search_metadata_index` using `event_id:<id>`,
-   then `fetch_catalog_document` by hash. Do **not** loop on `search_vectorstore_hybrid`
-   — exact-match metadata lookups always surface a freshly-ingested event; vector
-   similarity does not.
+## When NOT to lean on this data
 
-Limit: upstream `INDICO_get_files` truncates to ~10 attachments per event. If a
-large event is missing pieces, the response will say so — surface that to the user.
-
-## Indico URL shape
-
-URLs look like `https://indico.cern.ch/event/<event_id>/` and
-`https://indico.cern.ch/category/<category_id>/`. Extract the integer ID from the path
-when the user pastes a URL — don't ask them to repeat it.
-
-## When NOT to call these tools
-
-- Questions about general physics topics, deadlines, slack threads, or repo code: this
-  server is *only* for Indico.
-- Broad historical queries like "what did the SUSY group discuss last year" — that's
-  better served by the vectorstore, which already has scraped slide content indexed.
-  Only fall through to `INDICO_search_events_by_term` if vectorstore results are sparse.
-
-## Errors
-
-If a tool returns "❌ Please configure the Indico connection first", the sidecar's env
-vars (`BEARER_TOKEN` / `API_KEY` / `API_SECRET`) are missing — surface this to the user
-rather than retrying.
+- Live/administrative Indico actions (registering, uploading, permissions)
+  are out of scope — point the user at the Indico UI.
+- Events outside the configured categories are not in the graph; absence of a
+  meeting is evidence of scope, not of the event's nonexistence. Name the
+  configured scope when reporting a miss (the `indico` registry entry's
+  params show which categories/events are ingested).

--- a/skills/indico.md
+++ b/skills/indico.md
@@ -10,12 +10,15 @@ graph, and say so when the graph's snapshot is older than the question needs.
 
 - `meeting_minutes` nodes per ingested event (title, date, category, canonical
   `https://indico.cern.ch/event/<event_id>/` URL in attrs).
-- `document` nodes for event attachments (slides, PDFs) with
+- `document` nodes for PDF attachments whose text was extracted, with
   `contains` edges from the meeting, and `document_chunk` nodes carrying the
-  extracted text (`member_of` / `contains` chunk edges).
-- Cross-references: chunks that mention JIRA keys, releases, or sites get
-  `references` edges via the extraction/enrichment layer, so meetings link
-  into the operational graph.
+  extracted text (`member_of` / `contains` chunk edges). Non-PDF attachments
+  appear only as URLs in the meeting's attrs — their contents are not in the
+  graph.
+- Cross-references: when the deployment's extraction rules are configured for
+  it, chunks that mention JIRA keys, releases, or sites gain `references`
+  edges, linking meetings into the operational graph — verify with a `trace`
+  before promising such links exist.
 
 ## How to answer Indico questions
 

--- a/skills/source_document_exploration.md
+++ b/skills/source_document_exploration.md
@@ -7,7 +7,7 @@ finds a promising chunk but not enough surrounding context.
 ## Exploration Posture
 
 - Treat the OKG as the database to learn from. Inspect schema/source shape with
-  `inspect`, `inspect`, and bounded SQL instead of guessing
+  `inspect`, `aggregate`, and bounded SQL instead of guessing
   which source family exists.
 - Try independent query variants before declaring a gap: exact phrase, shorter
   noun phrase, command/config key, repo/path fragment, source family, service


### PR DESCRIPTION
## What this changes

Fixes every confirmed blocker/major from the deferred whole-package adversarial review of `archi_v3` @ `728739e6` (the revision okg pinned as its external-consumer baseline). The dominant bug class: connectors claiming a complete scope after silently losing input — which, under `missing_from_completed_scope` deletion semantics, retracts good records en masse. Also closes PII leak paths in the anonymizer and playbook/template hygiene. PACT change `pact/changes/circleback-fixes/` (task gated; per-domain deviation notes in the change dir).

## Behavior before → after

- Before: a swallowed forum failure, poisoned empty cache, stale live-page cache, partial OpenSearch response, truncating cap, drifted cache schema, or empty API listing produced a healthy run claiming `completed_scope=True` → mass retraction hazard. `john.doe+ops@cern.ch`, `John&nbsp;Doe`, non-CDATA `dc:creator`, and TWiki signatures survived anonymization; any line starting "Word, …" was deleted whole.
- After: no connector claims a completed scope when any enumerated input failed, was truncated, capped, or zero-parsed from non-empty input (data still flows; the scope claim is forfeited or the run fails loudly — statuses stay in the closed vocabulary). The anonymizer redacts the leak corpus (incl. double-encoded forms) and only strips short greeting/sign-off lines. The v2-era Indico playbook is rewritten for v3; shipped registry templates carry the full strict-admission shape; the bundle's `limit: 300` is gone (a truncating cap permanently disabled deletion semantics).

## Findings and dispositions (severity order)

- 3 blockers fixed: hypernews swallowed-forum + self-poisoning empty cache (`python/archi/sources/hypernews.py`), MONIT day-frozen live-page cache (`python/archi/sources/monit.py`, cache key now day-scoped + TTL, `query_version` bumped so old cache dirs are orphaned not replayed).
- 15 majors fixed across monit/docs/jira/siteconf/cric/cmssw + the systemic per-item parse-skip class (shared helper `python/archi/sources/_cache_report.py`) and 4 anonymizer leak classes.
- Adversarial diff review (independent agent) then attacked the branch: verdict holds; its one real escape — the cmssw `releases.map` path still zero-parse-claiming scope (`python/archi/sources/cmssw.py`) — is fixed with the reviewer's own repro as a test; its minor prescriptions (siteconf probe/crawl asymmetry, hypernews preflight/run mismatch, double-encoded PII, over-broad greeting rule, missing happy-path test) are all in.
- Explicitly NOT fixed here, routed to okg#1178 (recorded on the alignment page): `SourceRun.record_set` never being provided (likely root cause of the deletion-semantics finding okg is triaging) and the enricher derived-edge lifecycle — both substrate contracts. Accepted recall tradeoffs documented in `pact/changes/circleback-fixes/notes-enrichment.md`.
- ~85% of the fixed bugs exist identically in the frozen canonical `okg-deployments/cms` copies; every deviation is recorded per-domain in `pact/changes/circleback-fixes/notes-*.md`.

## How I verified

- Full suite: `/work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests -q` → **326 passed** (72 new regression tests over the 254 baseline; junit ingested as PACT evidence).
- Non-vacuity proven: the diff reviewer ran the new tests against pre-fix code — 64 fail there with the reported defects.
- `okg pact gate task-done circleback-fixes task.circleback-fixes` → holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjTTnEB9pAsrLdLsMFtUzL