### PR TITLE
W5: evaluation framework foundation — atoms, arm registry, engine

### DIFF
--- a/docs/eval.md
+++ b/docs/eval.md
@@ -1,0 +1,272 @@
+# archi.eval — the evaluation framework (W5 foundation)
+
+`archi.eval` answers one question: **does asking an OKG-backed system
+beat asking a plain LLM, and at what cost?** It runs a set of QA
+questions against one or more answering configurations, scores the
+answers, and prints a per-configuration report with pass rates, token
+and cost totals, latency, and the OKG generation the answers were
+produced against.
+
+It ships in the `archi` wheel (`python/archi/eval/`) and needs no
+running service: everything external — the LLM client, the MCP
+session, the judge — is injected, so the framework itself is offline
+and testable.
+
+## The two nouns
+
+**Atom** — one QA unit: a question plus the criteria a correct answer
+must meet. A *static* atom's criteria are literal. A *live-state* atom
+additionally carries an `oracle`: MCP tool calls whose live results
+supply the expected value at run time (ported from PR #608, where the
+answer to "how many downtimes are open right now?" cannot be frozen
+into a dataset).
+
+**Arm** — one answering configuration: a raw LLM, an OKG deployment
+over MCP, a chat UI, a coding agent. The engine runs *atoms x arms*, so
+one run compares arms head to head on identical questions. The arm is
+the v3 restructuring: the v2 PRs hard-wired a single tested agent.
+
+## Running it
+
+```bash
+# what can answer, and what each needs configured
+python -m archi.eval list-arms
+
+# one arm
+python -m archi.eval run --arm raw-llm \
+    --dataset python/tests/eval/fixtures/qa_smoke.yaml \
+    --arm-config raw-llm.yaml
+
+# two arms, compared in one report, pinned to a known generation
+python -m archi.eval run \
+    --arm raw-llm --arm okg-mcp \
+    --arm-config raw-llm.yaml --arm-config okg.yaml \
+    --dataset atoms.yaml \
+    --generation gen:20260821T155948019759Z:56ad3d3dafec \
+    --format json --output report.json
+```
+
+`--arm` repeats; `--arm-config` files pair with `--arm` flags
+positionally. Config files are JSON or YAML objects. `--format md`
+(default) prints the markdown report; `--format json` prints the report
+dict, and `--output` writes it to a file.
+
+Programmatic use is the same engine without the CLI's restrictions —
+this is how you supply a grader or a live MCP invoker today:
+
+```python
+from archi.eval import create_arm, load_dataset, run_eval, build_report
+
+run = run_eval(
+    load_dataset("atoms.yaml"),
+    [create_arm("raw-llm", {"model": "...", "client": my_client})],
+    grader=my_grader,             # optional, see "LLM grading"
+    oracle_invoker=my_invoker,    # required for live-state atoms
+    generation_id="gen:...",
+)
+report = build_report(run)
+```
+
+## The arms
+
+| id | what it is | config keys |
+|---|---|---|
+| `raw-llm` | no-context LLM baseline — the floor other arms must beat | `model`, `client`, `system_prompt` |
+| `okg-mcp` | an OKG deployment answering over its MCP tools | `deployment`, `dsn`, `mcp_endpoint`, `model`, `ask_tool`, `invoke` |
+| `openwebui-chat` | **stub** — an OpenWebUI chat deployment | `base_url`, `api_key_env`, `model` |
+| `codex` | **stub** — a terminal coding agent | `command`, `workdir`, `model` |
+
+No provider SDK is vendored. `client` (raw-llm) and `invoke` (okg-mcp)
+accept either a Python callable or a `module:attr` dotted path, so the
+CLI can reach an injected client that lives in operator code. Secrets
+are named, never inlined: `api_key_env` holds the *name* of an
+environment variable.
+
+A misconfigured arm raises `NotConfiguredError` and **fails the run**.
+It never degrades into zero scores — a setup mistake that quietly
+scores as "the arm got everything wrong" would poison the comparison.
+
+### Adding an arm
+
+Write a class with `name`, `describe()`, and
+`answer(atom, ctx) -> AnswerRecord`, then register its factory:
+
+```python
+from archi.eval.arms import AnswerRecord, register_arm
+
+MY_CONFIG = {"endpoint": "service URL (required)"}
+
+@register_arm("my-arm", summary="answers via ...", config_keys=MY_CONFIG)
+class MyArm:
+    name = "my-arm"
+
+    def __init__(self, config):
+        self.endpoint = config["endpoint"]
+
+    def describe(self):
+        return f"my service at {self.endpoint}"
+
+    def answer(self, atom, ctx):
+        return AnswerRecord(
+            atom_id=atom.id, arm=self.name, answer=...,
+            latency_ms=..., prompt_tokens=..., cost_usd=...,
+            generation_id=...,   # when the arm touched an OKG deployment
+        )
+```
+
+Fill in the optional cost/latency/generation fields when the backend
+reports them — every rollup in the report reads them straight off the
+`AnswerRecord`s. Raising inside `answer` is fine: the engine records an
+`execution_failed` result and keeps going.
+
+## Dataset format
+
+JSON or YAML, either a bare list of atoms or an object with `atoms`
+and an optional `schema_version: archi-eval-v1`. Validation is strict
+and errors name the offending field, e.g. `atom 3 (id 'q7').checks[0]:
+must set exactly one of 'value' or 'value_from'`.
+
+```yaml
+schema_version: archi-eval-v1
+atoms:
+  - id: cmssw-latest-14x                 # required, unique
+    question: "Which CMSSW 14_0 release is the latest announced?"
+    tags: [catalog, cmssw]               # optional, free-form
+    answer: "CMSSW_14_0_7"               # optional reference answer
+    checks:                              # deterministic criteria
+      - kind: exact                      # exact | contains | regex
+        value: "CMSSW_14_0_7"
+        case_sensitive: true             # default true
+
+  - id: xrootd-fallback
+    question: "Explain what the CMS xrootd fallback mechanism does."
+    gold_facts:                          # graded criteria (needs a grader)
+      - {id: A1, text: "A failed local open triggers it.", required: true}
+      - {id: A2, text: "It streams from another site.", required: false}
+
+  - id: live-open-downtimes              # live-state atom
+    question: "How many GOCDB downtimes are open for T2_US_MIT?"
+    oracle:
+      kind: mcp
+      calls:
+        - id: c1
+          tool: archi_gocdb_open_downtimes
+          arguments: {site: T2_US_MIT}
+          answer_fields: {count: /summary/open_count}   # RFC 6901 pointers
+    checks:
+      - kind: contains
+        value_from: /c1/count            # expected value comes from live state
+```
+
+Every atom needs at least one criterion (`checks`, `gold_facts`, or
+both). `value_from` is only legal on an atom that has an `oracle`. At
+least one gold fact must be `required: true`.
+
+`python/tests/eval/fixtures/qa_smoke.yaml` is the shipped 7-atom
+example (five static, one mixed, one live).
+
+## Scoring
+
+**Deterministic checks** run first and need no model:
+
+- `exact` — whitespace-trimmed equality;
+- `contains` — substring;
+- `regex` — `re.search` over the answer.
+
+`case_sensitive: false` lowercases both sides (for `regex` it sets
+`IGNORECASE`). An atom's check score is the fraction that passed; it
+`passed` only if all did.
+
+**Graded gold facts** use PR #596's math, unchanged: each fact is
+judged `entailed` (+1), `not_mentioned` (0), or `contradicted` (-1);
+`atom_score = max(0, sum / count)`; `required_fact_recall` is the
+entailed share of required facts; the atom passes only when *every*
+required fact is entailed. A `unjudgeable` verdict scores 0 (v2 raised).
+
+When an atom has both, its score is the mean of the two parts and it
+passes only if both parts pass.
+
+**Live-state atoms** follow PR #608: resolve the oracle, ask the arm,
+resolve again, and score only if the canonical-JSON SHA-256 of the
+resolved answer is identical. Otherwise the result is quarantined
+(`answer_changed`), as is a failing oracle (`oracle_failed`) — a
+question whose ground truth moved mid-run tells you nothing about the
+arm.
+
+Result statuses: `scored`, `execution_failed` (the arm raised),
+`evaluation_failed` (the grader raised or broke its contract),
+`ungraded` (gold facts with no grader injected), `oracle_failed`,
+`answer_changed`. Pass rates are computed over `scored +
+execution_failed` — a crash counts against an arm, a quarantined live
+atom does not.
+
+## Generation pinning and cost
+
+Every report header carries the OKG generation the answers were
+produced against. `--generation` wins if given; otherwise the engine
+takes the `generation_id` values the arms reported. If arms disagree
+(or an explicit pin contradicts what the arms reported), the report is
+flagged `generation_conflict` — the comparison is not apples to apples.
+
+Token, cost, and latency rollups come from the `AnswerRecord`s. For
+substrate-side truth, `archi.eval.report.sum_llm_calls(dsn, since=...,
+until=...)` sums the deployment's `okg.llm_calls` rows over the run
+window, optionally filtered by `deployment_name` and `generation_id`.
+The table contract was read from the okg checkout
+(`src/okg/substrate/db/schema.sql`): columns `ts`, `deployment_name`,
+`caller`, `model`, `prompt_tokens`, `completion_tokens`,
+`total_tokens`, `cost_usd`, `latency_ms`, `success`, `generation_id`.
+`psycopg` is imported lazily from the okg host environment and is
+deliberately not an `archi` dependency; `connect=` is injectable.
+
+## What is deliberately stubbed, and why
+
+- **`okg-mcp` live wiring.** The adapter seam (`invoke`) and config are
+  in place and tested with an injected invoker; opening a real MCP
+  session is not implemented. Doing it properly means settling per-user
+  MCP auth (okg#1180) and which tool an instance exposes as its
+  question-answering entry point — both moving on the OKG side.
+- **`openwebui-chat` and `codex`.** Registered with config schemas and
+  docstrings naming the exact wiring each needs, so the registry shape
+  is proven by more than one real arm without committing to two
+  integrations before the comparison design is settled.
+- **LLM grading.** PR #596's judge interface is ported and
+  fixture-tested (`Grader.judge` -> one `Judgment` per gold fact,
+  validated by the engine), but no judge model is wired and #596's
+  comparator prompt is not carried over. Deterministic checks come
+  first deliberately: they are reproducible and free. Wiring a judge is
+  an injection, not a code change.
+- **The real golden sets.** Not imported. They live in the cms-compops
+  instance repo in known-divergent versions that must be reconciled
+  before they become the v3 evaluation baseline. Only the synthetic
+  smoke fixture ships here.
+
+## Provenance
+
+Restructured port of two v2-era PRs, neither of which merged:
+
+- **PR #596** (`feat/archi-eval-command`) — atom-based QA engine.
+  Kept: the gold-fact judging model and scoring math, strict dataset
+  validation with contextual errors, the markdown report shape,
+  lifecycle-status accounting. Dropped: the workspace/manifest/phase
+  machinery (`prepare` / `run` / `score` artifact directories, run
+  digests, retries, job history), the click CLI, the chat-app
+  evaluation routes and RBAC surfaces.
+- **PR #608** (`feat/live-eval`) — MCP-backed live-state QA. Kept: the
+  oracle recipe (tool calls + JSON-pointer selection), canonical-JSON
+  answer hashing, the pre/post-run drift check. Dropped: the dataset
+  v1/v2 migration machinery, the oracle-config/staging surfaces, the
+  atom-generation review UI.
+
+Both PRs were written against the v2 `src/` tree. Nothing here imports
+it, the `mcp` SDK, or `okg`.
+
+## Tests
+
+```bash
+/work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests/eval -q
+```
+
+96 tests, no network: dataset validation, registry resolution and
+`NotConfigured` behavior, scoring edge cases, the live-atom flow with a
+scripted oracle, report aggregation and cost rollups, and CLI smoke.

--- a/docs/eval.md
+++ b/docs/eval.md
@@ -243,7 +243,14 @@ deliberately not an `archi` dependency; `connect=` is injectable.
 
 ## Provenance
 
-Restructured port of two v2-era PRs, neither of which merged:
+**The evaluation work is Antonio Battaglia's.** Both source PRs are his
+(with fixes from Austin Swinney in #608); what follows is a restructured
+port of that work into the v3 distribution, not a new design. The atom
+model, the gold-fact judging and its scoring math, the dataset
+validation, the report shape, and the live-state oracle flow all come
+from him — the arm registry is the only substantial v3 addition. Neither
+PR merged, so the code is re-homed rather than carried as commits;
+authorship is recorded in the port commits' `Co-Authored-By` trailers.
 
 - **PR #596** (`feat/archi-eval-command`) — atom-based QA engine.
   Kept: the gold-fact judging model and scoring math, strict dataset

--- a/docs/okg-alignment.md
+++ b/docs/okg-alignment.md
@@ -20,7 +20,7 @@ reimplementation of OKG services.
 
 ## Current state (update this section when it changes)
 
-*Last updated 2026-08-21, archi branch `w2-twiki` @ `f07022f8`, tested against okg
+*Last updated 2026-08-24, archi branch `w5-eval` @ `9a859e58`, tested against okg
 `dev` @ `f5ec3b58d` (2026-08-18).*
 
 **Sync channel: okg#1178** (established 2026-08-19; surface-change heads-ups land
@@ -62,7 +62,24 @@ The comp-ops instance (`okg-deployments/cms`) is untouched and is the parity tar
 for cutover. New PACT v4 note from the re-pin: `change.tier` is now mandatory
 (`missing_lifecycle_tier` otherwise). The superseded v2 application has been
 removed from the archi_v3 line (W10 teardown pulled forward, 2026-08-21); v2
-lives on `main` until instance cutover.
+lives on `main` until instance cutover. **W5 foundation landed (2026-08-24):
+`python/archi/eval/` is the evaluation framework** — a port of the two open
+v2-era eval PRs (#596 atom-based QA scoring, #608 MCP-backed live-state QA)
+restructured around an *arm registry*, where an arm is one answering
+configuration (`raw-llm` baseline, `okg-mcp`, plus `openwebui-chat` / `codex`
+stubs) and a run compares arms on identical questions. It adds **no substrate
+imports** — the okg surface below is unchanged — and touches OKG only as data:
+each run pins the target deployment's generation id in its report header, and
+cost rollups read `okg.llm_calls` (`ts`, `deployment_name`, `cost_usd`,
+`prompt_tokens`, `completion_tokens`, `total_tokens`, `generation_id`) over the
+run window, with `psycopg` taken from the okg host env rather than declared as
+an archi dependency. Two things that block the live half are on your side:
+`okg-mcp` cannot open a real session until per-user MCP auth (#1180) settles
+and until an instance declares which tool is its question-answering entry
+point — the adapter seam is in place and injected in tests, so wiring it is a
+config change, not a redesign. The comp-ops golden QA sets are deliberately not
+imported yet (divergent versions to reconcile); only a synthetic 7-atom smoke
+fixture ships. Docs: `docs/eval.md`.
 
 ## The exact substrate surface Archi consumes today
 

--- a/pact/changes/w5-eval-foundation/pact.yaml
+++ b/pact/changes/w5-eval-foundation/pact.yaml
@@ -57,7 +57,7 @@ requirements:
 tasks:
 - id: task.w5-eval-foundation
   title: "W5: evaluation framework foundation \u2014 atoms, arm registry, engine"
-  status: todo
+  status: done
   verification: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests -q
     (full suite incl. python/tests/eval)
   requirements:

--- a/pact/changes/w5-eval-foundation/pact.yaml
+++ b/pact/changes/w5-eval-foundation/pact.yaml
@@ -1,0 +1,98 @@
+pact_version: 4
+target_pact_version: 4
+change:
+  id: w5-eval-foundation
+  title: "W5: evaluation framework foundation \u2014 atoms, arm registry, engine"
+  status: proposal
+  rationale: 'Archi v3 needs an evaluation framework that measures more than one answering
+    configuration: the chatbot, an agent driving OKG MCP tools, a coding agent, and
+    raw-LLM baselines must be comparable on the same questions. PR #596 (atom engine
+    + gold-fact judging) and PR #608 (MCP-backed live-state QA) carry the substance
+    but are v2-homed; this change ports both into python/archi/eval restructured around
+    an arm registry (arm = one answering configuration), with generation pinning and
+    cost accounting per run. Deliberately out of scope: live wiring of the chat/codex
+    arms, and reconciliation of the two divergent cms-compops golden sets (they live
+    in the instance repo and need a maintainer decision).'
+  root_cause: Small nontrivial change whose intent, task, acceptance, and proof fit
+    the PACT fast path.
+  tier: 1
+  method_metadata:
+    pact_shape: fast_path
+    fast_path: Compact PACT for small nontrivial work. Upgrade when scope, risk, hierarchy,
+      formal proof, graph evidence, or review complexity increases.
+  affected_areas:
+  - python/archi/eval
+  - docs
+  affected_code: []
+requirements:
+- id: req.w5-eval-foundation
+  title: "W5: evaluation framework foundation \u2014 atoms, arm registry, engine"
+  statement: 'The evaluation framework runs a dataset of QA atoms against any registered
+    arm and produces a comparable, generation-pinned report: datasets validate with
+    contextual errors; the arm registry resolves ids to configured arms and refuses
+    unwired stubs loudly (NotConfiguredError, never a silent zero); deterministic
+    checks and gold-fact judging both score; live-state atoms resolve their expected
+    values from an MCP oracle and quarantine on drift; reports roll up pass rate,
+    latency, tokens and cost. Archi ships no new runtime dependency for it.'
+  evidence_policy:
+    required:
+    - executed_test
+  scenarios:
+  - id: scn.w5-eval-foundation.fast-path
+    title: Fast-path work is verified
+    given:
+    - a small nontrivial change fits one requirement
+    when:
+    - the declared verification runs
+    then:
+    - the requirement has executed proof before completion
+    and: []
+  acceptance:
+  - id: acc.w5-eval-foundation
+    description: python/tests/eval green (atoms, arms, engine, report, CLI) with the
+      full suite passing, and the CLI demonstrably running list-arms plus a scored
+      run over the fixture dataset.
+    evidence:
+    - executed_test
+tasks:
+- id: task.w5-eval-foundation
+  title: "W5: evaluation framework foundation \u2014 atoms, arm registry, engine"
+  status: todo
+  verification: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests -q
+    (full suite incl. python/tests/eval)
+  requirements:
+  - req.w5-eval-foundation
+  evidence: []
+  environment: []
+dependencies: []
+test_plan:
+- id: test.req-w5-eval-foundation.eval-suite
+  requirement: req.w5-eval-foundation
+  test_id: python/tests/eval
+  evidence:
+  - pytest
+formal: []
+waivers: []
+evidence:
+- id: ev.executed-test.req-w5-eval-foundation.20260824T195129724362Z
+  kind: executed_test
+  status: pass
+  refs:
+  - req.w5-eval-foundation
+  artifact: python/tests/eval
+  command: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests -q
+  summary: 'Eval domain 96 passed (atoms 22, arms 14, engine 38, report 11, cli 11);
+    full suite 350 passed. CLI verified outside pytest: list-arms and a scored run
+    over the fixture dataset with a scripted client.'
+  data:
+    attached_at: '2026-08-24T19:51:29.724406+00:00'
+- id: ev.executed-test.acc-w5-eval-foundation.20260824T195131627117Z
+  kind: executed_test
+  status: pass
+  refs:
+  - acc.w5-eval-foundation
+  artifact: python/tests/eval
+  summary: 'Acceptance: eval suite green, full suite 350, CLI list-arms + scored fixture
+    run demonstrated.'
+  data:
+    attached_at: '2026-08-24T19:51:31.627183+00:00'

--- a/python/archi/eval/__init__.py
+++ b/python/archi/eval/__init__.py
@@ -1,0 +1,33 @@
+"""archi.eval — the v3 evaluation framework (W5 foundation).
+
+Runs QA *atoms* (question + expected criteria) against *arms* (answering
+configurations: a raw LLM, an OKG deployment over MCP, a chat UI, ...),
+scores the answers, and aggregates per-arm/per-atom reports with cost,
+latency, and generation-pin rollups.
+
+Provenance: restructured port of two v2-era PRs —
+
+- PR #596 (``feat/archi-eval-command``): the atom-based QA engine. We
+  keep its gold-fact judging model (entailed / not_mentioned /
+  contradicted), scoring math (atom score, required-fact recall,
+  pass = every required fact entailed), strict dataset validation with
+  contextual errors, and the markdown report shape.
+- PR #608 (``feat/live-eval``): live-state QA. We keep its MCP oracle
+  recipe (tool calls + JSON-pointer field selection), canonical-JSON
+  answer hashing, and the pre/post-run drift check (``oracle_failed`` /
+  ``answer_changed``) with an injectable invoker.
+
+What changed in the port: the v2 workspace/phase/manifest machinery,
+click CLI, chat-app routes, and RBAC surfaces were not carried over;
+the engine is a plain in-process run over an *arm registry* (new in
+v3), deterministic checks (exact/contains/regex) are the first-class
+scoring mode with the LLM-graded judge reduced to an injectable
+interface, and nothing here imports the v2 tree, the ``mcp`` SDK, or
+``okg`` itself.
+"""
+
+from .arms import AnswerRecord, Arm, ArmContext, NotConfiguredError  # noqa: F401
+from .arms import create_arm, list_arms, register_arm  # noqa: F401
+from .atoms import QAAtom, load_dataset  # noqa: F401
+from .engine import EvalRun, run_eval  # noqa: F401
+from .report import build_report, render_markdown  # noqa: F401

--- a/python/archi/eval/__main__.py
+++ b/python/archi/eval/__main__.py
@@ -1,0 +1,7 @@
+"""Entry point: ``python -m archi.eval``."""
+import sys
+
+from .cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/archi/eval/arms.py
+++ b/python/archi/eval/arms.py
@@ -1,0 +1,440 @@
+"""Arms — answering configurations — and their registry.
+
+An **arm** is one way of producing an answer to a QA atom: a raw LLM
+call, an OKG deployment queried over MCP, a chat UI, a coding agent.
+The engine runs atoms x arms and compares the arms in one report.
+This abstraction is new in v3: the v2 PRs hard-wired a single tested
+agent (PR #596's ``QAWorkflow`` run phase); the arm registry replaces
+that with ``arm id -> factory(config)`` so new answering setups
+register without touching the engine.
+
+Contract (kept deliberately small):
+
+- ``name`` — the registry id the instance answers as;
+- ``describe()`` — one line for reports and ``list-arms``;
+- ``answer(atom, ctx) -> AnswerRecord`` — answer text or error, plus
+  optional latency / token / cost / generation-id fields.
+
+Shipped arms:
+
+- ``raw-llm`` — a no-context LLM baseline through a pluggable client
+  (callable injection or a ``module:attr`` dotted path); no vendored
+  provider SDK.
+- ``okg-mcp`` — an OKG deployment answering over its MCP tools. The
+  adapter seam (``invoke``) and config are in place; live session
+  wiring is deliberately stubbed (raises :class:`NotConfiguredError`).
+- ``openwebui-chat`` / ``codex`` — registered stubs with config
+  schemas; their docstrings say what wiring they need.
+
+Arms that raise inside ``answer`` produce ``execution_failed`` records
+(the engine catches); a misconfigured arm raises
+:class:`NotConfiguredError`, which the engine deliberately does *not*
+catch — a setup problem should fail the run loudly, not score as
+zeros (per the never-silent-fallback repo rule).
+"""
+from __future__ import annotations
+
+import importlib
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Mapping, Optional, Protocol
+
+from .atoms import QAAtom
+
+
+class NotConfiguredError(RuntimeError):
+    """The arm exists in the registry but is not wired up to run.
+
+    The message must say exactly what is missing and how to provide it.
+    """
+
+
+@dataclass
+class AnswerRecord:
+    """One arm's answer to one atom (PR #596's ``AnswerAttempt``,
+    flattened: no attempt ordinals or config digests, plus the v3
+    token/cost/generation fields the report rolls up)."""
+
+    atom_id: str
+    arm: str
+    answer: Optional[str] = None
+    error: Optional[str] = None
+    latency_ms: Optional[int] = None
+    prompt_tokens: Optional[int] = None
+    completion_tokens: Optional[int] = None
+    cost_usd: Optional[float] = None
+    generation_id: Optional[str] = None
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if (self.answer is None) == (self.error is None):
+            raise ValueError(
+                "an AnswerRecord must carry exactly one of answer or error"
+            )
+
+    @property
+    def ok(self) -> bool:
+        return self.error is None
+
+    def to_dict(self) -> Dict[str, Any]:
+        raw: Dict[str, Any] = {"atom_id": self.atom_id, "arm": self.arm}
+        for name in (
+            "answer",
+            "error",
+            "latency_ms",
+            "prompt_tokens",
+            "completion_tokens",
+            "cost_usd",
+            "generation_id",
+        ):
+            value = getattr(self, name)
+            if value is not None:
+                raw[name] = value
+        if self.extra:
+            raw["extra"] = dict(self.extra)
+        return raw
+
+
+@dataclass(frozen=True)
+class ArmContext:
+    """Per-run context handed to every ``answer`` call."""
+
+    run_id: str
+    generation_id: Optional[str] = None
+
+
+class Arm(Protocol):
+    name: str
+
+    def describe(self) -> str: ...
+
+    def answer(self, atom: QAAtom, ctx: ArmContext) -> AnswerRecord: ...
+
+
+# --- registry ---
+
+
+@dataclass(frozen=True)
+class ArmEntry:
+    arm_id: str
+    factory: Callable[[Mapping[str, Any]], Arm]
+    summary: str
+    config_keys: Dict[str, str]  # key -> one-line description
+
+
+_REGISTRY: Dict[str, ArmEntry] = {}
+
+
+def register_arm(
+    arm_id: str, *, summary: str, config_keys: Optional[Dict[str, str]] = None
+) -> Callable[[Callable[[Mapping[str, Any]], Arm]], Callable[[Mapping[str, Any]], Arm]]:
+    """Register ``factory(config) -> Arm`` under ``arm_id``."""
+
+    def decorator(
+        factory: Callable[[Mapping[str, Any]], Arm],
+    ) -> Callable[[Mapping[str, Any]], Arm]:
+        if arm_id in _REGISTRY:
+            raise ValueError(f"arm id '{arm_id}' is already registered")
+        _REGISTRY[arm_id] = ArmEntry(
+            arm_id=arm_id,
+            factory=factory,
+            summary=summary,
+            config_keys=dict(config_keys or {}),
+        )
+        return factory
+
+    return decorator
+
+
+def create_arm(arm_id: str, config: Optional[Mapping[str, Any]] = None) -> Arm:
+    entry = _REGISTRY.get(arm_id)
+    if entry is None:
+        known = ", ".join(sorted(_REGISTRY)) or "(none)"
+        raise KeyError(f"unknown arm '{arm_id}'; registered arms: {known}")
+    return entry.factory(config or {})
+
+
+def list_arms() -> List[ArmEntry]:
+    return [entry for _, entry in sorted(_REGISTRY.items())]
+
+
+def _check_config(
+    config: Mapping[str, Any], *, arm_id: str, allowed: Dict[str, str]
+) -> None:
+    unknown = sorted(set(config) - set(allowed))
+    if unknown:
+        raise ValueError(
+            f"arm '{arm_id}' got unknown config key(s): {', '.join(unknown)}; "
+            f"allowed: {', '.join(sorted(allowed))}"
+        )
+
+
+def _require(config: Mapping[str, Any], key: str, *, arm_id: str) -> Any:
+    value = config.get(key)
+    if value is None:
+        raise NotConfiguredError(
+            f"arm '{arm_id}' requires config key '{key}'"
+        )
+    return value
+
+
+def _resolve_callable(value: Any, *, context: str) -> Callable[..., Any]:
+    """Accept a callable directly or a ``module:attr`` dotted path.
+
+    The dotted-path form is what makes injectable clients reachable
+    from the CLI, where config files can only carry strings.
+    """
+    if callable(value):
+        return value
+    if isinstance(value, str) and ":" in value:
+        module_name, _, attr = value.partition(":")
+        try:
+            resolved = getattr(importlib.import_module(module_name), attr)
+        except (ImportError, AttributeError) as exc:
+            raise NotConfiguredError(
+                f"{context}: could not import '{value}' ({exc})"
+            ) from exc
+        if not callable(resolved):
+            raise NotConfiguredError(f"{context}: '{value}' is not callable")
+        return resolved
+    raise NotConfiguredError(
+        f"{context}: expected a callable or a 'module:attr' string"
+    )
+
+
+def _timed_ms(started: float) -> int:
+    return max(0, round((time.perf_counter() - started) * 1000))
+
+
+def _record_from_reply(
+    reply: Any, *, atom_id: str, arm: str, latency_ms: int
+) -> AnswerRecord:
+    """Normalize a client/adapter reply into an AnswerRecord.
+
+    Accepted shapes: a plain string (the answer), or a mapping with
+    ``answer`` plus optional ``prompt_tokens`` / ``completion_tokens``
+    / ``cost_usd`` / ``generation_id`` / ``latency_ms``.
+    """
+    if isinstance(reply, str):
+        return AnswerRecord(
+            atom_id=atom_id, arm=arm, answer=reply, latency_ms=latency_ms
+        )
+    if isinstance(reply, Mapping):
+        answer = reply.get("answer")
+        if not isinstance(answer, str):
+            raise ValueError("client reply mapping must carry a string 'answer'")
+        known = {
+            "answer",
+            "prompt_tokens",
+            "completion_tokens",
+            "cost_usd",
+            "generation_id",
+            "latency_ms",
+        }
+        return AnswerRecord(
+            atom_id=atom_id,
+            arm=arm,
+            answer=answer,
+            latency_ms=reply.get("latency_ms", latency_ms),
+            prompt_tokens=reply.get("prompt_tokens"),
+            completion_tokens=reply.get("completion_tokens"),
+            cost_usd=reply.get("cost_usd"),
+            generation_id=reply.get("generation_id"),
+            extra={key: value for key, value in reply.items() if key not in known},
+        )
+    raise ValueError("client reply must be a string or a mapping with 'answer'")
+
+
+# --- shipped arms ---
+
+
+RAW_LLM_CONFIG = {
+    "model": "model identifier passed through to the client (required)",
+    "client": (
+        "answering client: a callable(question, *, model, system_prompt) or a "
+        "'module:attr' dotted path to one (required)"
+    ),
+    "system_prompt": "optional system prompt prepended by the client",
+}
+
+
+@register_arm(
+    "raw-llm",
+    summary="no-context LLM baseline through a pluggable client (no SDK vendored)",
+    config_keys=RAW_LLM_CONFIG,
+)
+class RawLLMArm:
+    """Direct LLM call, no OKG context — the floor other arms must beat.
+
+    The provider SDK is deliberately not vendored: the ``client``
+    config key injects the call (tests pass a local callable; real use
+    points a dotted path at a thin wrapper around the operator's
+    provider client).
+    """
+
+    name = "raw-llm"
+
+    def __init__(self, config: Mapping[str, Any]):
+        _check_config(config, arm_id=self.name, allowed=RAW_LLM_CONFIG)
+        self.model = _require(config, "model", arm_id=self.name)
+        self.system_prompt = config.get("system_prompt")
+        self._client = _resolve_callable(
+            _require(config, "client", arm_id=self.name),
+            context=f"arm '{self.name}' config key 'client'",
+        )
+
+    def describe(self) -> str:
+        return f"raw LLM baseline (model={self.model}, no retrieval context)"
+
+    def answer(self, atom: QAAtom, ctx: ArmContext) -> AnswerRecord:
+        started = time.perf_counter()
+        reply = self._client(
+            atom.question, model=self.model, system_prompt=self.system_prompt
+        )
+        return _record_from_reply(
+            reply, atom_id=atom.id, arm=self.name, latency_ms=_timed_ms(started)
+        )
+
+
+OKG_MCP_CONFIG = {
+    "deployment": "OKG deployment name the questions target (required)",
+    "dsn": "optional Postgres DSN of the deployment (cost rollups via okg.llm_calls)",
+    "mcp_endpoint": "optional MCP endpoint URL of the deployment",
+    "model": "optional model identifier the deployment's agent should use",
+    "ask_tool": "MCP tool name that answers a question (default 'ask')",
+    "invoke": (
+        "adapter seam: a callable(tool, arguments) -> reply mapping, or a "
+        "'module:attr' dotted path; absent -> NotConfiguredError"
+    ),
+}
+
+
+@register_arm(
+    "okg-mcp",
+    summary="an OKG deployment answering over its MCP tools (live wiring stubbed)",
+    config_keys=OKG_MCP_CONFIG,
+)
+class OKGMCPArm:
+    """Answers via an OKG deployment's MCP tools.
+
+    The adapter seam is ``invoke(tool, arguments) -> reply``: tests and
+    early integrations inject it; the real MCP-session adapter (open an
+    MCP client session against ``mcp_endpoint``, call ``ask_tool`` with
+    the question, map the tool result to the reply shape, and surface
+    the deployment's pinned generation id as ``generation_id``) is
+    deliberately not implemented yet — without ``invoke`` this arm
+    raises :class:`NotConfiguredError`.
+    """
+
+    name = "okg-mcp"
+
+    def __init__(self, config: Mapping[str, Any]):
+        _check_config(config, arm_id=self.name, allowed=OKG_MCP_CONFIG)
+        self.deployment = _require(config, "deployment", arm_id=self.name)
+        self.dsn = config.get("dsn")
+        self.mcp_endpoint = config.get("mcp_endpoint")
+        self.model = config.get("model")
+        self.ask_tool = config.get("ask_tool", "ask")
+        self._invoke = None
+        if config.get("invoke") is not None:
+            self._invoke = _resolve_callable(
+                config["invoke"], context=f"arm '{self.name}' config key 'invoke'"
+            )
+
+    def describe(self) -> str:
+        return f"OKG deployment '{self.deployment}' over MCP (tool '{self.ask_tool}')"
+
+    def answer(self, atom: QAAtom, ctx: ArmContext) -> AnswerRecord:
+        if self._invoke is None:
+            raise NotConfiguredError(
+                f"arm '{self.name}' has no live MCP wiring yet: inject an "
+                "'invoke' callable (or dotted path) that opens an MCP session "
+                f"against the deployment and calls its '{self.ask_tool}' tool"
+            )
+        started = time.perf_counter()
+        reply = self._invoke(self.ask_tool, {"question": atom.question})
+        return _record_from_reply(
+            reply, atom_id=atom.id, arm=self.name, latency_ms=_timed_ms(started)
+        )
+
+
+OPENWEBUI_CONFIG = {
+    "base_url": "OpenWebUI base URL, e.g. https://chat.example.org (required)",
+    "api_key_env": "environment variable holding the API key (required; never a literal)",
+    "model": "model/agent id exposed by the OpenWebUI instance (required)",
+}
+
+
+@register_arm(
+    "openwebui-chat",
+    summary="stub: an OpenWebUI chat deployment answering via its completions API",
+    config_keys=OPENWEBUI_CONFIG,
+)
+class OpenWebUIChatArm:
+    """Stub arm for an OpenWebUI chat frontend.
+
+    Wiring needed to activate: POST ``{base_url}/api/chat/completions``
+    with a bearer token read from ``api_key_env``, a single user
+    message carrying the atom's question, and ``model``; map the reply
+    text and usage fields onto :class:`AnswerRecord`. Until that
+    adapter lands, ``answer`` raises :class:`NotConfiguredError`.
+    """
+
+    name = "openwebui-chat"
+
+    def __init__(self, config: Mapping[str, Any]):
+        _check_config(config, arm_id=self.name, allowed=OPENWEBUI_CONFIG)
+        self.base_url = _require(config, "base_url", arm_id=self.name)
+        self.api_key_env = _require(config, "api_key_env", arm_id=self.name)
+        self.model = _require(config, "model", arm_id=self.name)
+
+    def describe(self) -> str:
+        return f"OpenWebUI chat at {self.base_url} (model={self.model}) [stub]"
+
+    def answer(self, atom: QAAtom, ctx: ArmContext) -> AnswerRecord:
+        raise NotConfiguredError(
+            "arm 'openwebui-chat' is a registered stub: the completions-API "
+            "adapter is not implemented yet (see the class docstring for the "
+            "wiring it needs)"
+        )
+
+
+CODEX_CONFIG = {
+    "command": "coding-agent executable to drive (default 'codex')",
+    "workdir": "working directory the agent runs in (required)",
+    "model": "optional model identifier passed to the agent",
+}
+
+
+@register_arm(
+    "codex",
+    summary="stub: a terminal coding agent answering via non-interactive exec",
+    config_keys=CODEX_CONFIG,
+)
+class CodexArm:
+    """Stub arm for a terminal coding agent (codex-style).
+
+    Wiring needed to activate: run ``{command} exec`` (non-interactive)
+    in ``workdir`` with the atom's question as the prompt, capture the
+    final message as the answer, and parse token usage if the agent
+    reports it. Until that subprocess adapter lands, ``answer`` raises
+    :class:`NotConfiguredError`.
+    """
+
+    name = "codex"
+
+    def __init__(self, config: Mapping[str, Any]):
+        _check_config(config, arm_id=self.name, allowed=CODEX_CONFIG)
+        self.command = config.get("command", "codex")
+        self.workdir = _require(config, "workdir", arm_id=self.name)
+        self.model = config.get("model")
+
+    def describe(self) -> str:
+        return f"coding agent '{self.command}' in {self.workdir} [stub]"
+
+    def answer(self, atom: QAAtom, ctx: ArmContext) -> AnswerRecord:
+        raise NotConfiguredError(
+            "arm 'codex' is a registered stub: the non-interactive exec "
+            "adapter is not implemented yet (see the class docstring for the "
+            "wiring it needs)"
+        )

--- a/python/archi/eval/atoms.py
+++ b/python/archi/eval/atoms.py
@@ -1,0 +1,465 @@
+"""QA atom model + dataset loader for archi.eval.
+
+An **atom** is one QA unit: a question plus the criteria a correct
+answer must meet. Two variants share one class:
+
+- a *static* atom carries literal criteria — deterministic ``checks``
+  (exact / contains / regex) and/or ``gold_facts`` for the injectable
+  LLM-graded mode;
+- a *live-state* atom additionally carries an ``oracle`` recipe (from
+  PR #608): MCP tool calls whose JSON results, selected via RFC 6901
+  JSON pointers, form the expected answer at run time. Its checks may
+  use ``value_from`` (a pointer into the resolved oracle answer)
+  instead of a literal ``value``.
+
+Provenance: the strict field validation style, gold-fact shape
+(``id``/``text``/``required``, at least one required), and contextual
+error messages port PR #596's ``src/evaluation/qa/validation.py``; the
+oracle recipe shape, JSON-pointer validation/resolution, and
+canonical-JSON hashing port PR #608's ``src/evaluation/qa/oracle.py``.
+Changes: the v2 item fields (``time_sensitive``, ``answer_mode``,
+``answer_source``, derived ids) are dropped — atoms are explicit-id
+only, liveness is implied by the presence of ``oracle``; deterministic
+``checks`` are new in v3; datasets load from JSON *or* YAML; the
+``mcp`` SDK types are not imported (invokers hand the engine plain
+JSON payloads); oracle calls' ``server`` is optional because a v3 run
+targets one deployment.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from copy import deepcopy
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+import yaml
+
+SCHEMA_VERSION = "archi-eval-v1"
+CHECK_KINDS = ("exact", "contains", "regex")
+ORACLE_KIND = "mcp"
+
+ATOM_FIELDS = {"id", "question", "tags", "answer", "checks", "gold_facts", "oracle"}
+CHECK_FIELDS = {"kind", "value", "value_from", "case_sensitive"}
+GOLD_FACT_FIELDS = {"id", "text", "required"}
+ORACLE_FIELDS = {"kind", "calls"}
+ORACLE_CALL_FIELDS = {"id", "server", "tool", "arguments", "answer_fields"}
+
+
+class DatasetError(ValueError):
+    """A dataset file failed validation; the message says where and why."""
+
+
+def _fail(context: str, message: str) -> None:
+    raise DatasetError(f"{context}: {message}")
+
+
+def _strict_keys(raw: Dict[str, Any], allowed: set, context: str) -> None:
+    unknown = sorted(set(raw) - allowed)
+    if unknown:
+        _fail(context, f"unknown field(s): {', '.join(unknown)}")
+
+
+def _nonempty_string(value: Any, context: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        _fail(context, "must be a non-empty string")
+    if "\x00" in value:
+        _fail(context, "must not contain NUL characters")
+    return value
+
+
+# --- JSON pointers + canonical JSON (ported from PR #608 oracle.py) ---
+
+
+def validate_json_pointer(pointer: Any, context: str) -> str:
+    """RFC 6901 syntax check: '' or '/...' with only ~0/~1 escapes."""
+    if not isinstance(pointer, str) or (pointer and not pointer.startswith("/")):
+        _fail(context, "must be an RFC 6901 JSON pointer")
+    index = 0
+    while index < len(pointer):
+        if pointer[index] == "~":
+            if index + 1 >= len(pointer) or pointer[index + 1] not in {"0", "1"}:
+                _fail(context, "must be an RFC 6901 JSON pointer")
+            index += 2
+            continue
+        index += 1
+    return pointer
+
+
+def resolve_json_pointer(value: Any, pointer: str) -> Any:
+    validate_json_pointer(pointer, "JSON pointer")
+    current = value
+    if pointer == "":
+        return deepcopy(current)
+    for encoded in pointer[1:].split("/"):
+        token = encoded.replace("~1", "/").replace("~0", "~")
+        if isinstance(current, dict):
+            if token not in current:
+                raise ValueError(f"JSON pointer '{pointer}' does not exist")
+            current = current[token]
+        elif isinstance(current, list):
+            if not token.isdigit() or (len(token) > 1 and token.startswith("0")):
+                raise ValueError(f"JSON pointer '{pointer}' does not exist")
+            index = int(token)
+            if index >= len(current):
+                raise ValueError(f"JSON pointer '{pointer}' does not exist")
+            current = current[index]
+        else:
+            raise ValueError(f"JSON pointer '{pointer}' does not exist")
+    return deepcopy(current)
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":"),
+        allow_nan=False,
+    )
+
+
+def answer_sha256(value: Dict[str, Any]) -> str:
+    """Stable digest of a resolved oracle answer (PR #608 pinning)."""
+    if not isinstance(value, dict) or not value:
+        raise ValueError("answer data must be a non-empty object")
+    return hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()
+
+
+# --- model ---
+
+
+@dataclass(frozen=True)
+class Check:
+    """One deterministic expectation on the answer text.
+
+    Exactly one of ``value`` (literal) / ``value_from`` (JSON pointer
+    into a live atom's resolved oracle answer) is set.
+    """
+
+    kind: str
+    value: Optional[str] = None
+    value_from: Optional[str] = None
+    case_sensitive: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        raw: Dict[str, Any] = {"kind": self.kind, "case_sensitive": self.case_sensitive}
+        if self.value is not None:
+            raw["value"] = self.value
+        if self.value_from is not None:
+            raw["value_from"] = self.value_from
+        return raw
+
+
+@dataclass(frozen=True)
+class GoldFact:
+    """One graded obligation (PR #596's gold atom, renamed: in v3 an
+    'atom' is the QA unit, so the judged facts are gold *facts*)."""
+
+    id: str
+    text: str
+    required: bool
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"id": self.id, "text": self.text, "required": self.required}
+
+
+@dataclass(frozen=True)
+class OracleCall:
+    """One MCP tool call in a live atom's oracle recipe (PR #608)."""
+
+    id: str
+    tool: str
+    arguments: Dict[str, Any] = field(default_factory=dict)
+    answer_fields: Optional[Tuple[Tuple[str, str], ...]] = None
+    server: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        raw: Dict[str, Any] = {
+            "id": self.id,
+            "tool": self.tool,
+            "arguments": deepcopy(self.arguments),
+        }
+        if self.answer_fields is not None:
+            raw["answer_fields"] = dict(self.answer_fields)
+        if self.server is not None:
+            raw["server"] = self.server
+        return raw
+
+
+@dataclass(frozen=True)
+class OracleSpec:
+    kind: str
+    calls: Tuple[OracleCall, ...]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"kind": self.kind, "calls": [call.to_dict() for call in self.calls]}
+
+
+@dataclass(frozen=True)
+class QAAtom:
+    id: str
+    question: str
+    tags: Tuple[str, ...] = ()
+    answer: Optional[str] = None
+    checks: Tuple[Check, ...] = ()
+    gold_facts: Tuple[GoldFact, ...] = ()
+    oracle: Optional[OracleSpec] = None
+
+    @property
+    def is_live(self) -> bool:
+        return self.oracle is not None
+
+    def to_dict(self) -> Dict[str, Any]:
+        raw: Dict[str, Any] = {"id": self.id, "question": self.question}
+        if self.tags:
+            raw["tags"] = list(self.tags)
+        if self.answer is not None:
+            raw["answer"] = self.answer
+        if self.checks:
+            raw["checks"] = [check.to_dict() for check in self.checks]
+        if self.gold_facts:
+            raw["gold_facts"] = [fact.to_dict() for fact in self.gold_facts]
+        if self.oracle is not None:
+            raw["oracle"] = self.oracle.to_dict()
+        return raw
+
+
+# --- validation ---
+
+
+def _validate_check(raw: Any, *, context: str, live: bool) -> Check:
+    if not isinstance(raw, dict):
+        _fail(context, "must be an object")
+    _strict_keys(raw, CHECK_FIELDS, context)
+    kind = raw.get("kind")
+    if kind not in CHECK_KINDS:
+        _fail(f"{context}.kind", f"must be one of: {', '.join(CHECK_KINDS)}")
+    value = raw.get("value")
+    value_from = raw.get("value_from")
+    if (value is None) == (value_from is None):
+        _fail(context, "must set exactly one of 'value' or 'value_from'")
+    if value is not None:
+        value = _nonempty_string(value, f"{context}.value")
+        if kind == "regex":
+            try:
+                re.compile(value)
+            except re.error as exc:
+                _fail(f"{context}.value", f"is not a valid regex: {exc}")
+    else:
+        if not live:
+            _fail(
+                context,
+                "'value_from' is only valid on a live atom (one with an 'oracle')",
+            )
+        validate_json_pointer(value_from, f"{context}.value_from")
+    case_sensitive = raw.get("case_sensitive", True)
+    if not isinstance(case_sensitive, bool):
+        _fail(f"{context}.case_sensitive", "must be a boolean")
+    return Check(
+        kind=kind, value=value, value_from=value_from, case_sensitive=case_sensitive
+    )
+
+
+def _validate_gold_facts(raw: Any, *, context: str) -> Tuple[GoldFact, ...]:
+    # Ported from PR #596 validate_atoms: unique ids, >=1 required.
+    if not isinstance(raw, list) or not raw:
+        _fail(context, "must be a non-empty list")
+    facts = []
+    seen = set()
+    for index, row in enumerate(raw):
+        fact_context = f"{context}[{index}]"
+        if not isinstance(row, dict):
+            _fail(fact_context, "must be an object")
+        _strict_keys(row, GOLD_FACT_FIELDS, fact_context)
+        fact_id = _nonempty_string(row.get("id"), f"{fact_context}.id")
+        text = _nonempty_string(row.get("text"), f"{fact_context}.text")
+        required = row.get("required")
+        if not isinstance(required, bool):
+            _fail(f"{fact_context}.required", "must be a boolean")
+        if fact_id in seen:
+            _fail(context, f"contains duplicate gold fact id '{fact_id}'")
+        seen.add(fact_id)
+        facts.append(GoldFact(id=fact_id, text=text, required=required))
+    if not any(fact.required for fact in facts):
+        _fail(context, "must contain at least one required gold fact")
+    return tuple(facts)
+
+
+def _validate_json_value(value: Any, context: str) -> None:
+    if value is None or isinstance(value, (str, bool, int, float)):
+        return
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            _validate_json_value(item, f"{context}[{index}]")
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                _fail(context, "object keys must be strings")
+            _validate_json_value(item, f"{context}.{key}")
+        return
+    _fail(context, "must contain only JSON values")
+
+
+def _validate_oracle(raw: Any, *, context: str) -> OracleSpec:
+    # Ported from PR #608 parse_oracle_recipe (mcp SDK types dropped;
+    # 'server' optional; 'metadata_fields' not carried over).
+    if not isinstance(raw, dict):
+        _fail(context, "must be an object")
+    _strict_keys(raw, ORACLE_FIELDS, context)
+    if raw.get("kind") != ORACLE_KIND:
+        _fail(f"{context}.kind", f"must be '{ORACLE_KIND}'")
+    raw_calls = raw.get("calls")
+    if not isinstance(raw_calls, list) or not raw_calls:
+        _fail(f"{context}.calls", "must be a non-empty list")
+    calls = []
+    seen = set()
+    for index, row in enumerate(raw_calls):
+        call_context = f"{context}.calls[{index}]"
+        if not isinstance(row, dict):
+            _fail(call_context, "must be an object")
+        _strict_keys(row, ORACLE_CALL_FIELDS, call_context)
+        call_id = _nonempty_string(row.get("id"), f"{call_context}.id")
+        if call_id in seen:
+            _fail(context, f"contains duplicate call id '{call_id}'")
+        seen.add(call_id)
+        tool = _nonempty_string(row.get("tool"), f"{call_context}.tool")
+        arguments = row.get("arguments", {})
+        if not isinstance(arguments, dict):
+            _fail(f"{call_context}.arguments", "must be an object")
+        _validate_json_value(arguments, f"{call_context}.arguments")
+        server = row.get("server")
+        if server is not None:
+            server = _nonempty_string(server, f"{call_context}.server")
+        answer_fields = None
+        if row.get("answer_fields") is not None:
+            raw_fields = row["answer_fields"]
+            if not isinstance(raw_fields, dict) or not raw_fields:
+                _fail(f"{call_context}.answer_fields", "must be a non-empty object")
+            answer_fields = tuple(
+                (
+                    _nonempty_string(name, f"{call_context}.answer_fields key"),
+                    validate_json_pointer(
+                        pointer, f"{call_context}.answer_fields.{name}"
+                    ),
+                )
+                for name, pointer in raw_fields.items()
+            )
+        calls.append(
+            OracleCall(
+                id=call_id,
+                tool=tool,
+                arguments=deepcopy(arguments),
+                answer_fields=answer_fields,
+                server=server,
+            )
+        )
+    return OracleSpec(kind=ORACLE_KIND, calls=tuple(calls))
+
+
+def validate_atom(raw: Any, *, context: str = "atom") -> QAAtom:
+    if not isinstance(raw, dict):
+        _fail(context, "must be an object")
+    _strict_keys(raw, ATOM_FIELDS, context)
+    atom_id = _nonempty_string(raw.get("id"), f"{context}.id")
+    context = f"{context} (id '{atom_id}')"
+    question = _nonempty_string(raw.get("question"), f"{context}.question")
+    raw_tags = raw.get("tags", [])
+    if not isinstance(raw_tags, list):
+        _fail(f"{context}.tags", "must be a list of strings")
+    tags = tuple(
+        _nonempty_string(tag, f"{context}.tags[{index}]")
+        for index, tag in enumerate(raw_tags)
+    )
+    answer = raw.get("answer")
+    if answer is not None:
+        answer = _nonempty_string(answer, f"{context}.answer")
+    oracle = None
+    if raw.get("oracle") is not None:
+        oracle = _validate_oracle(raw["oracle"], context=f"{context}.oracle")
+    raw_checks = raw.get("checks", [])
+    if not isinstance(raw_checks, list):
+        _fail(f"{context}.checks", "must be a list")
+    checks = tuple(
+        _validate_check(
+            row, context=f"{context}.checks[{index}]", live=oracle is not None
+        )
+        for index, row in enumerate(raw_checks)
+    )
+    gold_facts: Tuple[GoldFact, ...] = ()
+    if raw.get("gold_facts") is not None:
+        gold_facts = _validate_gold_facts(
+            raw["gold_facts"], context=f"{context}.gold_facts"
+        )
+    if not checks and not gold_facts:
+        _fail(
+            context,
+            "must define at least one scoring criterion "
+            "('checks' and/or 'gold_facts')",
+        )
+    return QAAtom(
+        id=atom_id,
+        question=question,
+        tags=tags,
+        answer=answer,
+        checks=checks,
+        gold_facts=gold_facts,
+        oracle=oracle,
+    )
+
+
+def validate_atoms(raw_rows: Any) -> Tuple[QAAtom, ...]:
+    if not isinstance(raw_rows, list):
+        raise DatasetError("dataset must contain a list of atoms")
+    if not raw_rows:
+        raise DatasetError("dataset must contain at least one atom")
+    atoms = []
+    seen = set()
+    for index, raw in enumerate(raw_rows, 1):
+        atom = validate_atom(raw, context=f"atom {index}")
+        if atom.id in seen:
+            raise DatasetError(f"dataset contains duplicate atom id '{atom.id}'")
+        seen.add(atom.id)
+        atoms.append(atom)
+    return tuple(atoms)
+
+
+# --- loading ---
+
+
+def load_dataset(path: Path | str) -> Tuple[QAAtom, ...]:
+    """Load and validate a JSON or YAML atom dataset.
+
+    Accepted top-level shapes: a bare list of atoms, or an object with
+    ``atoms`` (list) and an optional ``schema_version`` that must be
+    ``archi-eval-v1`` when present.
+    """
+    path = Path(path)
+    if not path.is_file():
+        raise DatasetError(f"dataset must be an existing file: {path}")
+    suffix = path.suffix.lower()
+    if suffix not in {".json", ".yaml", ".yml"}:
+        raise DatasetError("dataset must use .json, .yaml, or .yml")
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        raise DatasetError("dataset must be UTF-8 encoded") from exc
+    if suffix == ".json":
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise DatasetError(f"invalid JSON dataset: {exc}") from exc
+    else:
+        try:
+            payload = yaml.safe_load(text)
+        except yaml.YAMLError as exc:
+            raise DatasetError(f"invalid YAML dataset: {exc}") from exc
+    if isinstance(payload, dict):
+        _strict_keys(payload, {"schema_version", "atoms"}, "dataset")
+        version = payload.get("schema_version")
+        if version is not None and version != SCHEMA_VERSION:
+            raise DatasetError(
+                f"dataset.schema_version must be '{SCHEMA_VERSION}' (got {version!r})"
+            )
+        payload = payload.get("atoms")
+    return validate_atoms(payload)

--- a/python/archi/eval/cli.py
+++ b/python/archi/eval/cli.py
@@ -1,0 +1,164 @@
+"""CLI for archi.eval: ``python -m archi.eval {list-arms,run}``.
+
+Replaces PR #596's click-based ``archi eval qa`` command group. Changes
+from the original: stdlib ``argparse`` (click is not an archi v3
+dependency), no workspace/phase subcommands (prepare/run/score were v2
+artifact-directory machinery; the v3 engine runs in one pass), and the
+tested configuration is an *arm id + config file* instead of
+agent-config/agent-spec paths.
+
+Usage::
+
+    python -m archi.eval list-arms
+    python -m archi.eval run --arm raw-llm --dataset atoms.yaml \
+        --arm-config raw-llm.yaml [--generation <gen id>] \
+        [--output report.json] [--format md|json]
+
+``--arm`` may repeat to compare arms in one run; ``--arm-config`` files
+match ``--arm`` flags positionally. Config files are JSON or YAML
+objects; callable-valued keys (``client``, ``invoke``) accept
+``module:attr`` dotted paths so injectable clients work from the CLI.
+
+Deliberately not wired here: an LLM grader (atoms with only
+``gold_facts`` report as ``ungraded`` from the CLI until the judge
+wiring lands) and live MCP sessions (datasets with live atoms report
+``oracle_failed`` unless an invoker-bearing arm setup provides one
+programmatically via :func:`archi.eval.engine.run_eval`).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+import yaml
+
+from .arms import NotConfiguredError, create_arm, list_arms
+from .atoms import DatasetError, load_dataset
+from .engine import run_eval
+from .report import build_report, render_markdown
+
+
+class CLIError(Exception):
+    """A user-facing CLI failure; the message is printed to stderr."""
+
+
+def _load_config(path: Optional[str]) -> Dict[str, Any]:
+    if path is None:
+        return {}
+    config_path = Path(path)
+    if not config_path.is_file():
+        raise CLIError(f"arm config must be an existing file: {config_path}")
+    text = config_path.read_text(encoding="utf-8")
+    try:
+        if config_path.suffix.lower() == ".json":
+            payload = json.loads(text)
+        else:
+            payload = yaml.safe_load(text)
+    except (json.JSONDecodeError, yaml.YAMLError) as exc:
+        raise CLIError(f"invalid arm config {config_path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise CLIError(f"arm config {config_path} must contain an object")
+    return payload
+
+
+def _cmd_list_arms(_args: argparse.Namespace) -> int:
+    for entry in list_arms():
+        print(f"{entry.arm_id}: {entry.summary}")
+        for key, description in sorted(entry.config_keys.items()):
+            print(f"    {key}: {description}")
+    return 0
+
+
+def _cmd_run(args: argparse.Namespace) -> int:
+    configs: List[Optional[str]] = list(args.arm_config or [])
+    if len(configs) > len(args.arm):
+        raise CLIError(
+            f"got {len(configs)} --arm-config for {len(args.arm)} --arm"
+        )
+    configs.extend([None] * (len(args.arm) - len(configs)))
+    try:
+        atoms = load_dataset(args.dataset)
+    except DatasetError as exc:
+        raise CLIError(str(exc)) from exc
+    try:
+        arms = [
+            create_arm(arm_id, _load_config(config_path))
+            for arm_id, config_path in zip(args.arm, configs)
+        ]
+    except (KeyError, ValueError, NotConfiguredError) as exc:
+        message = exc.args[0] if exc.args else str(exc)
+        raise CLIError(str(message)) from exc
+    try:
+        run = run_eval(
+            atoms,
+            arms,
+            generation_id=args.generation,
+            dataset=str(args.dataset),
+        )
+    except NotConfiguredError as exc:
+        raise CLIError(str(exc)) from exc
+    report = build_report(run)
+    if args.output:
+        Path(args.output).write_text(
+            json.dumps(report, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+    if args.format == "json":
+        print(json.dumps(report, indent=2, ensure_ascii=False))
+    else:
+        print(render_markdown(report), end="")
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m archi.eval",
+        description="Run the archi QA evaluation over registered arms.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    list_parser = sub.add_parser(
+        "list-arms", help="list registered arms and their config keys"
+    )
+    list_parser.set_defaults(func=_cmd_list_arms)
+
+    run_parser = sub.add_parser("run", help="run a dataset against one or more arms")
+    run_parser.add_argument(
+        "--arm",
+        action="append",
+        required=True,
+        help="registered arm id (repeatable to compare arms)",
+    )
+    run_parser.add_argument(
+        "--dataset", required=True, help="JSON or YAML atom dataset path"
+    )
+    run_parser.add_argument(
+        "--arm-config",
+        action="append",
+        help="JSON/YAML config file for the matching --arm (positional pairing)",
+    )
+    run_parser.add_argument(
+        "--generation",
+        help="explicit OKG generation id pin recorded in the report header",
+    )
+    run_parser.add_argument("--output", help="write the JSON report to this path")
+    run_parser.add_argument(
+        "--format",
+        choices=("md", "json"),
+        default="md",
+        help="stdout format (default: md)",
+    )
+    run_parser.set_defaults(func=_cmd_run)
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        return args.func(args)
+    except CLIError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1

--- a/python/archi/eval/engine.py
+++ b/python/archi/eval/engine.py
@@ -1,0 +1,544 @@
+"""The eval engine: run atoms x arms, score, and collect results.
+
+Scoring modes, in order of trust:
+
+1. **Deterministic checks** (exact / contains / regex) — new in v3,
+   first-class: no judge model, no ambiguity. A live atom's checks may
+   pull their expected value out of the resolved oracle answer via
+   ``value_from`` JSON pointers.
+2. **Graded gold facts** — PR #596's judged mode, reduced to an
+   injectable :class:`Grader` seam (its LLM comparator prompt is *not*
+   wired here). The scoring math is #596's ``score_attempt`` verbatim:
+   ``atom_score = max(0, sum(outcome values)/n)`` with entailed=1,
+   not_mentioned=0, contradicted=-1; ``required_fact_recall``; passed
+   iff every required fact is entailed. Deviation: a #596-legal
+   ``unjudgeable`` outcome scores 0 here instead of KeyError-ing.
+
+Live-state atoms follow PR #608's flow: resolve the oracle *before*
+asking the arm, ask, resolve again *after*, and only score when the
+canonical-JSON sha256 of the resolved answer is unchanged — otherwise
+the result is quarantined as ``answer_changed``; a failing oracle
+quarantines as ``oracle_failed``. The invoker is injectable (tests run
+offline); a run over live atoms without an invoker quarantines them
+instead of crashing.
+
+Result lifecycle statuses (superset of #596's attempt lifecycle plus
+#608's live reasons): ``scored``, ``execution_failed``,
+``evaluation_failed``, ``ungraded``, ``oracle_failed``,
+``answer_changed``.
+
+Generation pinning: the run header records the OKG generation the
+answers were produced against — an explicit pin passed by the caller
+(``--generation`` in the CLI) wins; otherwise the engine collects the
+distinct ``generation_id`` values the arms reported in their
+AnswerRecords, pins a lone value, and flags a conflict when arms
+disagree.
+"""
+from __future__ import annotations
+
+import re
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Mapping, Optional, Protocol, Sequence, Tuple
+
+from .arms import AnswerRecord, Arm, ArmContext, NotConfiguredError
+from .atoms import (
+    Check,
+    GoldFact,
+    OracleCall,
+    OracleSpec,
+    QAAtom,
+    answer_sha256,
+    canonical_json,
+    resolve_json_pointer,
+)
+
+# #596 outcome values, plus unjudgeable -> 0 (see module docstring).
+OUTCOME_VALUES = {
+    "entailed": 1,
+    "not_mentioned": 0,
+    "contradicted": -1,
+    "unjudgeable": 0,
+}
+
+RESULT_STATUSES = (
+    "scored",
+    "execution_failed",
+    "evaluation_failed",
+    "ungraded",
+    "oracle_failed",
+    "answer_changed",
+)
+
+
+# --- graded mode (interface ported from PR #596) ---
+
+
+@dataclass(frozen=True)
+class Judgment:
+    """One graded verdict on one gold fact (PR #596 ``Judgment``)."""
+
+    fact_id: str
+    outcome: str
+    rationale: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "fact_id": self.fact_id,
+            "outcome": self.outcome,
+            "rationale": self.rationale,
+        }
+
+
+class Grader(Protocol):
+    """Injectable judge (PR #596's LLM comparator seam).
+
+    Implementations return exactly one :class:`Judgment` per gold
+    fact. The engine validates that contract and turns violations into
+    ``evaluation_failed`` results rather than trusting the judge.
+    """
+
+    def judge(
+        self, question: str, answer: str, gold_facts: Sequence[GoldFact]
+    ) -> Sequence[Judgment]: ...
+
+
+def _validate_judgments(
+    judgments: Sequence[Judgment], gold_facts: Sequence[GoldFact]
+) -> None:
+    # Ported from #596 validate_judgments: one per fact, none unknown.
+    gold_ids = {fact.id for fact in gold_facts}
+    seen = set()
+    for judgment in judgments:
+        if judgment.outcome not in OUTCOME_VALUES:
+            raise ValueError(f"unsupported judgment outcome '{judgment.outcome}'")
+        if judgment.fact_id not in gold_ids:
+            raise ValueError(
+                f"judgment references unknown gold fact '{judgment.fact_id}'"
+            )
+        if judgment.fact_id in seen:
+            raise ValueError(
+                f"duplicate judgment for gold fact '{judgment.fact_id}'"
+            )
+        seen.add(judgment.fact_id)
+    missing = sorted(gold_ids - seen)
+    if missing:
+        raise ValueError("missing judgment(s) for: " + ", ".join(missing))
+
+
+def score_gold_facts(
+    gold_facts: Sequence[GoldFact], judgments: Sequence[Judgment]
+) -> Dict[str, Any]:
+    """PR #596 ``score_attempt``, on validated judgments."""
+    _validate_judgments(judgments, gold_facts)
+    by_id = {judgment.fact_id: judgment for judgment in judgments}
+    required = [fact for fact in gold_facts if fact.required]
+    entailed_required = sum(
+        1 for fact in required if by_id[fact.id].outcome == "entailed"
+    )
+    value_sum = sum(OUTCOME_VALUES[by_id[fact.id].outcome] for fact in gold_facts)
+    return {
+        "atom_score": max(0.0, value_sum / len(gold_facts)),
+        "required_fact_recall": entailed_required / len(required),
+        "passed": entailed_required == len(required),
+    }
+
+
+# --- deterministic checks (new in v3) ---
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    kind: str
+    expected: str
+    passed: bool
+    source: str  # "literal" or the value_from pointer
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "expected": self.expected,
+            "passed": self.passed,
+            "source": self.source,
+        }
+
+
+def _expected_text(value: Any) -> str:
+    """Render a resolved oracle value for text comparison."""
+    if isinstance(value, str):
+        return value
+    return canonical_json(value)
+
+
+def evaluate_check(
+    check: Check, answer: str, resolved_answer: Optional[Mapping[str, Any]] = None
+) -> CheckResult:
+    if check.value is not None:
+        expected = check.value
+        source = "literal"
+    else:
+        if resolved_answer is None:
+            raise ValueError(
+                "check uses value_from but no resolved oracle answer is available"
+            )
+        expected = _expected_text(
+            resolve_json_pointer(resolved_answer, check.value_from)
+        )
+        source = check.value_from
+    haystack = answer
+    needle = expected
+    if check.kind == "regex":
+        flags = 0 if check.case_sensitive else re.IGNORECASE
+        passed = re.search(needle, haystack, flags) is not None
+    else:
+        if not check.case_sensitive:
+            haystack = haystack.lower()
+            needle = needle.lower()
+        if check.kind == "exact":
+            passed = haystack.strip() == needle.strip()
+        else:  # contains
+            passed = needle in haystack
+    return CheckResult(kind=check.kind, expected=expected, passed=passed, source=source)
+
+
+# --- live oracle resolution (ported from PR #608, mcp SDK dropped) ---
+
+
+class OracleInvoker(Protocol):
+    """Executes one oracle call and returns its JSON payload (a dict).
+
+    The v2 code invoked MCP tools and normalized ``CallToolResult``;
+    here the transport is injected so the engine (and tests) stay
+    offline. A real invoker for the ``okg-mcp`` case opens an MCP
+    session against the target deployment and calls ``call.tool`` with
+    ``call.arguments``.
+    """
+
+    def invoke(self, call: OracleCall) -> Mapping[str, Any]: ...
+
+
+class OracleResolutionError(RuntimeError):
+    def __init__(self, detail: str):
+        super().__init__(detail)
+        self.detail = detail
+
+
+@dataclass(frozen=True)
+class ResolvedOracle:
+    answer: Dict[str, Any]  # call id -> selected data
+    answer_sha256: str
+
+
+def resolve_oracle(spec: OracleSpec, invoker: OracleInvoker) -> ResolvedOracle:
+    answer: Dict[str, Any] = {}
+    for call in spec.calls:
+        try:
+            payload = invoker.invoke(call)
+        except Exception as exc:
+            raise OracleResolutionError(
+                f"oracle call '{call.id}' ({call.tool}) failed: {exc}"
+            ) from exc
+        if not isinstance(payload, Mapping) or not payload:
+            raise OracleResolutionError(
+                f"oracle call '{call.id}' returned a non-object or empty payload"
+            )
+        if call.answer_fields is None:
+            answer[call.id] = dict(payload)
+            continue
+        selected = {}
+        for name, pointer in call.answer_fields:
+            try:
+                selected[name] = resolve_json_pointer(payload, pointer)
+            except ValueError as exc:
+                raise OracleResolutionError(
+                    f"oracle call '{call.id}' field '{name}': {exc}"
+                ) from exc
+        answer[call.id] = selected
+    return ResolvedOracle(answer=answer, answer_sha256=answer_sha256(answer))
+
+
+# --- results ---
+
+
+@dataclass
+class AtomResult:
+    atom_id: str
+    arm: str
+    status: str
+    passed: Optional[bool] = None
+    score: Optional[float] = None
+    check_results: Tuple[CheckResult, ...] = ()
+    judgments: Tuple[Judgment, ...] = ()
+    required_fact_recall: Optional[float] = None
+    record: Optional[AnswerRecord] = None
+    detail: Optional[str] = None
+    live: Optional[Dict[str, Any]] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        raw: Dict[str, Any] = {
+            "atom_id": self.atom_id,
+            "arm": self.arm,
+            "status": self.status,
+        }
+        if self.passed is not None:
+            raw["passed"] = self.passed
+        if self.score is not None:
+            raw["score"] = self.score
+        if self.check_results:
+            raw["check_results"] = [result.to_dict() for result in self.check_results]
+        if self.judgments:
+            raw["judgments"] = [judgment.to_dict() for judgment in self.judgments]
+        if self.required_fact_recall is not None:
+            raw["required_fact_recall"] = self.required_fact_recall
+        if self.record is not None:
+            raw["record"] = self.record.to_dict()
+        if self.detail is not None:
+            raw["detail"] = self.detail
+        if self.live is not None:
+            raw["live"] = self.live
+        return raw
+
+
+@dataclass
+class ArmRun:
+    arm: str
+    description: str
+    results: List[AtomResult] = field(default_factory=list)
+    generation_ids: Tuple[str, ...] = ()
+
+
+@dataclass
+class EvalRun:
+    run_id: str
+    started_at: str
+    finished_at: str
+    dataset: Optional[str]
+    generation_id: Optional[str]
+    generation_conflict: bool
+    arm_runs: List[ArmRun]
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def score_answer(
+    atom: QAAtom,
+    record: AnswerRecord,
+    *,
+    grader: Optional[Grader] = None,
+    resolved_answer: Optional[Mapping[str, Any]] = None,
+) -> AtomResult:
+    """Score one successful answer against one atom's criteria."""
+    assert record.answer is not None
+    check_results = tuple(
+        evaluate_check(check, record.answer, resolved_answer)
+        for check in atom.checks
+    )
+    parts: List[float] = []
+    passed_parts: List[bool] = []
+    if check_results:
+        parts.append(
+            sum(1 for result in check_results if result.passed) / len(check_results)
+        )
+        passed_parts.append(all(result.passed for result in check_results))
+    judgments: Tuple[Judgment, ...] = ()
+    recall: Optional[float] = None
+    graded_skipped = False
+    if atom.gold_facts:
+        if grader is None:
+            graded_skipped = True
+        else:
+            try:
+                judgments = tuple(
+                    grader.judge(atom.question, record.answer, atom.gold_facts)
+                )
+                graded = score_gold_facts(atom.gold_facts, judgments)
+            except Exception as exc:
+                return AtomResult(
+                    atom_id=atom.id,
+                    arm=record.arm,
+                    status="evaluation_failed",
+                    record=record,
+                    check_results=check_results,
+                    detail=f"grader failed: {exc}",
+                )
+            parts.append(graded["atom_score"])
+            passed_parts.append(graded["passed"])
+            recall = graded["required_fact_recall"]
+    if not parts:
+        # Only graded criteria exist and no grader was injected.
+        return AtomResult(
+            atom_id=atom.id,
+            arm=record.arm,
+            status="ungraded",
+            record=record,
+            detail="atom has only gold_facts and no grader was injected",
+        )
+    detail = None
+    if graded_skipped:
+        detail = "gold_facts skipped (no grader injected); scored on checks only"
+    return AtomResult(
+        atom_id=atom.id,
+        arm=record.arm,
+        status="scored",
+        passed=all(passed_parts),
+        score=sum(parts) / len(parts),
+        check_results=check_results,
+        judgments=judgments,
+        required_fact_recall=recall,
+        record=record,
+        detail=detail,
+    )
+
+
+def _run_atom(
+    atom: QAAtom,
+    arm: Arm,
+    ctx: ArmContext,
+    *,
+    grader: Optional[Grader],
+    oracle_invoker: Optional[OracleInvoker],
+) -> AtomResult:
+    resolved: Optional[ResolvedOracle] = None
+    live: Optional[Dict[str, Any]] = None
+    if atom.is_live:
+        if oracle_invoker is None:
+            return AtomResult(
+                atom_id=atom.id,
+                arm=arm.name,
+                status="oracle_failed",
+                detail="live atom but no oracle invoker was injected",
+                live={"phase": "pre_run"},
+            )
+        try:
+            resolved = resolve_oracle(atom.oracle, oracle_invoker)
+        except OracleResolutionError as exc:
+            return AtomResult(
+                atom_id=atom.id,
+                arm=arm.name,
+                status="oracle_failed",
+                detail=exc.detail,
+                live={"phase": "pre_run"},
+            )
+        live = {"pre_run_sha256": resolved.answer_sha256}
+
+    started = time.perf_counter()
+    try:
+        record = arm.answer(atom, ctx)
+    except NotConfiguredError:
+        raise  # setup problem: fail the run, never score it (see arms.py)
+    except Exception as exc:
+        record = AnswerRecord(
+            atom_id=atom.id,
+            arm=arm.name,
+            error=f"{type(exc).__name__}: {exc}",
+            latency_ms=max(0, round((time.perf_counter() - started) * 1000)),
+        )
+    if not record.ok:
+        return AtomResult(
+            atom_id=atom.id,
+            arm=arm.name,
+            status="execution_failed",
+            passed=False,
+            record=record,
+            detail=record.error,
+            live=live,
+        )
+
+    if atom.is_live:
+        # Post-run drift check (PR #608): only score when live state
+        # held still for the whole ask.
+        assert resolved is not None and live is not None
+        try:
+            post = resolve_oracle(atom.oracle, oracle_invoker)
+        except OracleResolutionError as exc:
+            live["phase"] = "post_run"
+            return AtomResult(
+                atom_id=atom.id,
+                arm=arm.name,
+                status="oracle_failed",
+                record=record,
+                detail=exc.detail,
+                live=live,
+            )
+        live["post_run_sha256"] = post.answer_sha256
+        if post.answer_sha256 != resolved.answer_sha256:
+            return AtomResult(
+                atom_id=atom.id,
+                arm=arm.name,
+                status="answer_changed",
+                record=record,
+                detail="live state changed between pre- and post-run oracle "
+                "resolution; result quarantined",
+                live=live,
+            )
+
+    result = score_answer(
+        atom,
+        record,
+        grader=grader,
+        resolved_answer=resolved.answer if resolved is not None else None,
+    )
+    result.live = live
+    return result
+
+
+def run_eval(
+    atoms: Sequence[QAAtom],
+    arms: Sequence[Arm],
+    *,
+    grader: Optional[Grader] = None,
+    oracle_invoker: Optional[OracleInvoker] = None,
+    generation_id: Optional[str] = None,
+    dataset: Optional[str] = None,
+    run_id: Optional[str] = None,
+) -> EvalRun:
+    """Run every atom against every arm and collect scored results."""
+    if not atoms:
+        raise ValueError("run_eval requires at least one atom")
+    if not arms:
+        raise ValueError("run_eval requires at least one arm")
+    run_id = run_id or f"eval-{uuid.uuid4().hex[:12]}"
+    started_at = _utc_now()
+    ctx = ArmContext(run_id=run_id, generation_id=generation_id)
+    arm_runs: List[ArmRun] = []
+    observed: List[str] = []
+    for arm in arms:
+        arm_run = ArmRun(arm=arm.name, description=arm.describe())
+        for atom in atoms:
+            arm_run.results.append(
+                _run_atom(
+                    atom, arm, ctx, grader=grader, oracle_invoker=oracle_invoker
+                )
+            )
+        arm_generations = sorted(
+            {
+                result.record.generation_id
+                for result in arm_run.results
+                if result.record is not None
+                and result.record.generation_id is not None
+            }
+        )
+        arm_run.generation_ids = tuple(arm_generations)
+        for value in arm_generations:
+            if value not in observed:
+                observed.append(value)
+        arm_runs.append(arm_run)
+    conflict = len(observed) > 1 or (
+        generation_id is not None and any(v != generation_id for v in observed)
+    )
+    pinned = generation_id if generation_id is not None else (
+        observed[0] if len(observed) == 1 else None
+    )
+    return EvalRun(
+        run_id=run_id,
+        started_at=started_at,
+        finished_at=_utc_now(),
+        dataset=dataset,
+        generation_id=pinned,
+        generation_conflict=conflict,
+        arm_runs=arm_runs,
+    )

--- a/python/archi/eval/report.py
+++ b/python/archi/eval/report.py
@@ -1,0 +1,212 @@
+"""Report building for archi.eval runs.
+
+Aggregates an :class:`~archi.eval.engine.EvalRun` into per-arm and
+per-atom results with cost + latency rollups, renders them as JSON or
+markdown, and (optionally) sums a deployment's ``okg.llm_calls`` rows
+over the run window for substrate-side cost accounting.
+
+Provenance: the markdown shape (header pins, lifecycle counts, per-item
+sections) and the pass-rate denominators port PR #596's ``scoring.py``
+report half — quality-accounted attempts are ``scored +
+execution_failed`` (an arm that crashes counts against it), while
+quarantined results (``oracle_failed`` / ``answer_changed``, from PR
+#608) and ``ungraded`` ones are excluded from rates and surfaced as
+their own counts. New in v3: token/cost/latency rollups read straight
+off the AnswerRecords, the generation-pin header, and the
+``okg.llm_calls`` helper.
+
+The cost helper's table contract was verified against the okg checkout
+(``src/okg/substrate/db/schema.sql``): ``okg.llm_calls`` with columns
+``ts``, ``deployment_name``, ``caller``, ``model``, ``prompt_tokens``,
+``completion_tokens``, ``total_tokens``, ``cost_usd``, ``latency_ms``,
+``success``, ``generation_id``. If that table moves, update
+``LLM_CALLS_TABLE``/query below and this note.
+"""
+from __future__ import annotations
+
+from collections import Counter
+from statistics import median
+from typing import Any, Callable, Dict, List, Optional
+
+from .engine import RESULT_STATUSES, ArmRun, EvalRun
+
+LLM_CALLS_TABLE = "okg.llm_calls"
+
+
+def _rate(value: Optional[float]) -> str:
+    return "unavailable" if value is None else f"{value:.3f}"
+
+
+def _aggregate_arm(arm_run: ArmRun) -> Dict[str, Any]:
+    counts = Counter(result.status for result in arm_run.results)
+    quality = counts["scored"] + counts["execution_failed"]
+    passed = sum(1 for result in arm_run.results if result.passed)
+    scores = [
+        result.score for result in arm_run.results if result.score is not None
+    ]
+    records = [
+        result.record for result in arm_run.results if result.record is not None
+    ]
+    latencies = [
+        record.latency_ms for record in records if record.latency_ms is not None
+    ]
+    prompt_tokens = [
+        record.prompt_tokens for record in records if record.prompt_tokens is not None
+    ]
+    completion_tokens = [
+        record.completion_tokens
+        for record in records
+        if record.completion_tokens is not None
+    ]
+    costs = [record.cost_usd for record in records if record.cost_usd is not None]
+    return {
+        "arm": arm_run.arm,
+        "description": arm_run.description,
+        "atoms": len(arm_run.results),
+        "status_counts": {
+            status: counts.get(status, 0) for status in RESULT_STATUSES
+        },
+        "passed": passed,
+        "quality_accounted": quality,
+        "pass_rate": passed / quality if quality else None,
+        "mean_score": sum(scores) / len(scores) if scores else None,
+        "latency_ms": {
+            "count": len(latencies),
+            "mean": sum(latencies) / len(latencies) if latencies else None,
+            "p50": median(latencies) if latencies else None,
+            "max": max(latencies) if latencies else None,
+        },
+        "tokens": {
+            "prompt": sum(prompt_tokens) if prompt_tokens else None,
+            "completion": sum(completion_tokens) if completion_tokens else None,
+        },
+        "cost_usd": sum(costs) if costs else None,
+        "generation_ids": list(arm_run.generation_ids),
+        "results": [result.to_dict() for result in arm_run.results],
+    }
+
+
+def build_report(run: EvalRun) -> Dict[str, Any]:
+    """Aggregate a finished run into the canonical report dict."""
+    return {
+        "run_id": run.run_id,
+        "started_at": run.started_at,
+        "finished_at": run.finished_at,
+        "dataset": run.dataset,
+        "generation_id": run.generation_id,
+        "generation_conflict": run.generation_conflict,
+        "arms": [_aggregate_arm(arm_run) for arm_run in run.arm_runs],
+    }
+
+
+def render_markdown(report: Dict[str, Any]) -> str:
+    """Render the report dict as markdown (PR #596 report shape)."""
+    lines = [
+        "# Archi QA Evaluation Report",
+        "",
+        f"- Run: `{report['run_id']}`",
+        f"- Window: `{report['started_at']}` -> `{report['finished_at']}`",
+        f"- Dataset: `{report['dataset'] or 'unavailable'}`",
+        f"- Pinned generation: `{report['generation_id'] or 'unavailable'}`"
+        + (" **(conflict: arms disagree)**" if report["generation_conflict"] else ""),
+        "",
+    ]
+    for arm in report["arms"]:
+        counts = arm["status_counts"]
+        latency = arm["latency_ms"]
+        tokens = arm["tokens"]
+        cost = arm["cost_usd"]
+        lines.extend(
+            [
+                f"## Arm `{arm['arm']}`",
+                "",
+                f"- {arm['description']}",
+                f"- Pass rate: `{_rate(arm['pass_rate'])}` "
+                f"({arm['passed']}/{arm['quality_accounted']} quality-accounted)",
+                f"- Mean score: `{_rate(arm['mean_score'])}`",
+                f"- Statuses: `{ {s: n for s, n in counts.items() if n} }`",
+                f"- Latency ms (mean/p50/max over {latency['count']}): "
+                f"`{latency['mean'] if latency['mean'] is None else round(latency['mean'])}"
+                f" / {latency['p50']} / {latency['max']}`",
+                f"- Tokens prompt/completion: "
+                f"`{tokens['prompt']} / {tokens['completion']}`; "
+                f"cost USD: `{'unavailable' if cost is None else f'{cost:.4f}'}`",
+                (
+                    f"- Generations observed: `{', '.join(arm['generation_ids'])}`"
+                    if arm["generation_ids"]
+                    else "- Generations observed: `none reported`"
+                ),
+                "",
+                "### Per-atom results",
+                "",
+            ]
+        )
+        for result in arm["results"]:
+            passed = result.get("passed")
+            marker = "pass" if passed else ("FAIL" if passed is False else "-")
+            score = result.get("score")
+            rendered_score = "" if score is None else f" score={score:.3f}"
+            detail = result.get("detail")
+            rendered_detail = f" — {detail}" if detail else ""
+            lines.append(
+                f"- `{result['atom_id']}`: {result['status']} "
+                f"[{marker}]{rendered_score}{rendered_detail}"
+            )
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def sum_llm_calls(
+    dsn: str,
+    *,
+    since: str,
+    until: str,
+    deployment: Optional[str] = None,
+    generation_id: Optional[str] = None,
+    connect: Optional[Callable[[str], Any]] = None,
+) -> Dict[str, Any]:
+    """Sum ``okg.llm_calls`` rows for a run window (substrate cost).
+
+    ``since``/``until`` are the run's ``started_at``/``finished_at``
+    (ISO timestamps; the window is ``ts >= since AND ts < until``).
+    ``connect`` is injectable for tests; by default ``psycopg`` is
+    imported lazily — it ships with the okg host environment archi is
+    installed into, and is deliberately not an archi dependency.
+    """
+    if connect is None:
+        try:
+            import psycopg  # okg host dependency; not vendored here
+        except ImportError as exc:  # pragma: no cover - env-specific
+            raise RuntimeError(
+                "sum_llm_calls needs psycopg, which comes with the okg host "
+                "environment; run from an okg-bearing interpreter or inject "
+                "connect="
+            ) from exc
+        connect = psycopg.connect
+    clauses = ["ts >= %s", "ts < %s"]
+    params: List[Any] = [since, until]
+    if deployment is not None:
+        clauses.append("deployment_name = %s")
+        params.append(deployment)
+    if generation_id is not None:
+        clauses.append("generation_id = %s")
+        params.append(generation_id)
+    query = (
+        "SELECT count(*), coalesce(sum(prompt_tokens), 0), "
+        "coalesce(sum(completion_tokens), 0), coalesce(sum(total_tokens), 0), "
+        "coalesce(sum(cost_usd), 0), "
+        "count(*) FILTER (WHERE NOT success) "
+        f"FROM {LLM_CALLS_TABLE} WHERE " + " AND ".join(clauses)
+    )
+    with connect(dsn) as conn:
+        with conn.cursor() as cursor:
+            cursor.execute(query, params)
+            row = cursor.fetchone()
+    return {
+        "calls": row[0],
+        "prompt_tokens": row[1],
+        "completion_tokens": row[2],
+        "total_tokens": row[3],
+        "cost_usd": float(row[4]),
+        "failed_calls": row[5],
+    }

--- a/python/tests/eval/conftest.py
+++ b/python/tests/eval/conftest.py
@@ -1,0 +1,136 @@
+"""Shared fakes for the archi.eval tests: a scripted arm, a scripted
+grader, and a scripted oracle invoker — no network, no okg, no LLM.
+
+Exposed as fixtures (the repo's test tree carries no ``__init__.py``,
+so tests take these as arguments rather than importing them).
+"""
+from pathlib import Path
+
+import pytest
+
+from archi.eval.arms import AnswerRecord
+from archi.eval.atoms import load_dataset
+from archi.eval.engine import Judgment
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+# Answers that satisfy every atom in qa_smoke.yaml, given the fake
+# grader judges everything entailed and the fake oracle reports 3 open
+# downtimes.
+GOOD_ANSWERS = {
+    "cmssw-latest-14x": "CMSSW_14_0_7",
+    "t2-mit-storage": "The site is served by SE01.CMSAF.MIT.EDU.",
+    "gt-name-shape": "140X_dataRun3_Prompt_v4 is active for prompt reco.",
+    "dataset-path": "/JetMET0/Run2024A-v1/RAW",
+    "xrootd-fallback": "On a failed local open the job retries via the "
+    "global xrootd redirector and streams from another site.",
+    "mixed-criteria": "It is a Tier-2 site operated by MIT.",
+    "live-open-downtimes": "There are 3 open downtimes.",
+}
+
+
+class FakeArm:
+    """Deterministic arm answering from a lookup table."""
+
+    def __init__(
+        self,
+        answers=None,
+        *,
+        name="fake",
+        generation_id=None,
+        latency_ms=10,
+        cost_usd=None,
+        prompt_tokens=None,
+        completion_tokens=None,
+    ):
+        self.name = name
+        self.answers = dict(GOOD_ANSWERS if answers is None else answers)
+        self.generation_id = generation_id
+        self.latency_ms = latency_ms
+        self.cost_usd = cost_usd
+        self.prompt_tokens = prompt_tokens
+        self.completion_tokens = completion_tokens
+
+    def describe(self):
+        return "scripted test arm"
+
+    def answer(self, atom, ctx):
+        if atom.id not in self.answers:
+            raise LookupError(f"no scripted answer for {atom.id}")
+        return AnswerRecord(
+            atom_id=atom.id,
+            arm=self.name,
+            answer=self.answers[atom.id],
+            latency_ms=self.latency_ms,
+            generation_id=self.generation_id,
+            cost_usd=self.cost_usd,
+            prompt_tokens=self.prompt_tokens,
+            completion_tokens=self.completion_tokens,
+        )
+
+
+class FakeGrader:
+    """Judges every gold fact with a fixed outcome (default entailed)."""
+
+    def __init__(self, outcome="entailed", overrides=None):
+        self.outcome = outcome
+        self.overrides = overrides or {}
+        self.calls = []
+
+    def judge(self, question, answer, gold_facts):
+        self.calls.append((question, answer))
+        return [
+            Judgment(
+                fact_id=fact.id,
+                outcome=self.overrides.get(fact.id, self.outcome),
+                rationale="scripted",
+            )
+            for fact in gold_facts
+        ]
+
+
+class FakeInvoker:
+    """Oracle invoker returning a scripted payload per tool name."""
+
+    def __init__(self, payloads=None, fail_after=None):
+        self.payloads = payloads or {
+            "archi_gocdb_open_downtimes": {"summary": {"open_count": 3}}
+        }
+        self.calls = 0
+        self.fail_after = fail_after  # fail once call count exceeds this
+
+    def invoke(self, call):
+        self.calls += 1
+        if self.fail_after is not None and self.calls > self.fail_after:
+            raise RuntimeError("oracle backend went away")
+        return self.payloads[call.tool]
+
+
+@pytest.fixture(scope="session")
+def smoke_dataset():
+    return FIXTURES / "qa_smoke.yaml"
+
+
+@pytest.fixture
+def smoke_atoms(smoke_dataset):
+    return load_dataset(smoke_dataset)
+
+
+@pytest.fixture
+def answers():
+    return dict(GOOD_ANSWERS)
+
+
+@pytest.fixture
+def arm_cls():
+    return FakeArm
+
+
+@pytest.fixture
+def grader_cls():
+    return FakeGrader
+
+
+@pytest.fixture
+def invoker_cls():
+    return FakeInvoker

--- a/python/tests/eval/fixtures/qa_smoke.yaml
+++ b/python/tests/eval/fixtures/qa_smoke.yaml
@@ -1,0 +1,79 @@
+# archi.eval smoke dataset — synthetic HEP-flavored atoms for tests.
+# NOT a golden set: the real golden QA sets live in the cms-compops
+# instance repo and have divergent versions to reconcile before import.
+schema_version: archi-eval-v1
+atoms:
+  - id: cmssw-latest-14x
+    question: "Which CMSSW 14_0 release is the latest announced?"
+    tags: [catalog, cmssw]
+    answer: "CMSSW_14_0_7"
+    checks:
+      - kind: exact
+        value: "CMSSW_14_0_7"
+
+  - id: t2-mit-storage
+    question: "What storage element serves T2_US_MIT?"
+    tags: [sites]
+    checks:
+      - kind: contains
+        value: "se01.cmsaf.mit.edu"
+        case_sensitive: false
+
+  - id: gt-name-shape
+    question: "Give one currently active prompt-reco global tag."
+    tags: [conddb]
+    checks:
+      - kind: regex
+        value: "1[34]\\dX_\\w+_v\\d+"
+
+  - id: dataset-path
+    question: "State the full DAS path of the 2024 JetMET0 RAW dataset."
+    tags: [dbs]
+    checks:
+      - kind: contains
+        value: "/JetMET0/Run2024"
+      - kind: regex
+        value: "/RAW$"
+
+  - id: xrootd-fallback
+    question: "Explain what the CMS xrootd fallback mechanism does."
+    tags: [ops, graded]
+    answer: "When a local file open fails, the job retries via the global
+      xrootd redirector to stream the file from another site."
+    gold_facts:
+      - id: A1
+        text: "A failed local file open triggers the fallback."
+        required: true
+      - id: A2
+        text: "The retry goes through the global xrootd redirector."
+        required: true
+      - id: A3
+        text: "The file is streamed from another site."
+        required: false
+
+  - id: mixed-criteria
+    question: "Which tier hosts the T2_US_MIT site and who operates it?"
+    tags: [sites, graded]
+    checks:
+      - kind: contains
+        value: "Tier-2"
+    gold_facts:
+      - id: B1
+        text: "MIT operates the site."
+        required: true
+
+  - id: live-open-downtimes
+    question: "How many GOCDB downtimes are currently open for T2_US_MIT?"
+    tags: [live, gocdb]
+    oracle:
+      kind: mcp
+      calls:
+        - id: c1
+          tool: archi_gocdb_open_downtimes
+          arguments:
+            site: T2_US_MIT
+          answer_fields:
+            count: /summary/open_count
+    checks:
+      - kind: contains
+        value_from: /c1/count

--- a/python/tests/eval/test_arms.py
+++ b/python/tests/eval/test_arms.py
@@ -1,0 +1,149 @@
+"""archi.eval.arms — registry resolution + NotConfigured behavior."""
+import pytest
+
+from archi.eval.arms import (
+    AnswerRecord,
+    ArmContext,
+    NotConfiguredError,
+    create_arm,
+    list_arms,
+)
+from archi.eval.atoms import validate_atom
+
+ATOM = validate_atom(
+    {"id": "q1", "question": "What?", "checks": [{"kind": "exact", "value": "42"}]}
+)
+CTX = ArmContext(run_id="run-test")
+
+
+def test_registry_lists_the_four_shipped_arms():
+    entries = {entry.arm_id: entry for entry in list_arms()}
+    assert set(entries) >= {"raw-llm", "okg-mcp", "openwebui-chat", "codex"}
+    assert "deployment" in entries["okg-mcp"].config_keys
+    assert "client" in entries["raw-llm"].config_keys
+    for entry in entries.values():
+        assert entry.summary
+
+
+def test_unknown_arm_names_the_known_ones():
+    with pytest.raises(KeyError, match="unknown arm 'nope'.*raw-llm"):
+        create_arm("nope")
+
+
+def test_unknown_config_key_rejected():
+    with pytest.raises(ValueError, match="unknown config key.*bogus"):
+        create_arm("raw-llm", {"bogus": 1})
+
+
+def test_raw_llm_requires_model_and_client():
+    with pytest.raises(NotConfiguredError, match="requires config key 'model'"):
+        create_arm("raw-llm", {"client": lambda *a, **k: "x"})
+    with pytest.raises(NotConfiguredError, match="requires config key 'client'"):
+        create_arm("raw-llm", {"model": "m"})
+
+
+def test_raw_llm_with_injected_callable():
+    seen = {}
+
+    def client(question, *, model, system_prompt):
+        seen.update(question=question, model=model, system_prompt=system_prompt)
+        return {
+            "answer": "42",
+            "prompt_tokens": 7,
+            "completion_tokens": 3,
+            "cost_usd": 0.001,
+            "vendor_id": "r-1",
+        }
+
+    arm = create_arm(
+        "raw-llm", {"model": "test-model", "client": client, "system_prompt": "sp"}
+    )
+    record = arm.answer(ATOM, CTX)
+    assert seen == {"question": "What?", "model": "test-model", "system_prompt": "sp"}
+    assert record.answer == "42"
+    assert record.prompt_tokens == 7 and record.completion_tokens == 3
+    assert record.cost_usd == 0.001
+    assert record.extra == {"vendor_id": "r-1"}
+    assert record.latency_ms is not None and record.latency_ms >= 0
+    assert "test-model" in arm.describe()
+
+
+def test_raw_llm_client_string_answer():
+    arm = create_arm(
+        "raw-llm", {"model": "m", "client": lambda q, **kw: "plain answer"}
+    )
+    record = arm.answer(ATOM, CTX)
+    assert record.answer == "plain answer"
+
+
+def test_raw_llm_bad_dotted_path():
+    with pytest.raises(NotConfiguredError, match="could not import"):
+        create_arm("raw-llm", {"model": "m", "client": "no.such.module:client"})
+    with pytest.raises(NotConfiguredError, match="callable or a 'module:attr'"):
+        create_arm("raw-llm", {"model": "m", "client": "not-a-dotted-path"})
+
+
+def test_okg_mcp_without_invoke_raises_not_configured():
+    arm = create_arm("okg-mcp", {"deployment": "cern-team"})
+    assert "cern-team" in arm.describe()
+    with pytest.raises(NotConfiguredError, match="no live MCP wiring"):
+        arm.answer(ATOM, CTX)
+
+
+def test_okg_mcp_adapter_seam():
+    calls = []
+
+    def invoke(tool, arguments):
+        calls.append((tool, arguments))
+        return {"answer": "42", "generation_id": "gen:abc"}
+
+    arm = create_arm(
+        "okg-mcp",
+        {"deployment": "cern-team", "ask_tool": "archi_ask", "invoke": invoke},
+    )
+    record = arm.answer(ATOM, CTX)
+    assert calls == [("archi_ask", {"question": "What?"})]
+    assert record.answer == "42"
+    assert record.generation_id == "gen:abc"
+
+
+def test_okg_mcp_requires_deployment():
+    with pytest.raises(NotConfiguredError, match="requires config key 'deployment'"):
+        create_arm("okg-mcp", {})
+
+
+@pytest.mark.parametrize(
+    "arm_id, config",
+    [
+        (
+            "openwebui-chat",
+            {
+                "base_url": "https://chat.example.org",
+                "api_key_env": "OPENWEBUI_API_KEY",
+                "model": "archi",
+            },
+        ),
+        ("codex", {"workdir": "."}),
+    ],
+)
+def test_stub_arms_construct_then_raise_not_configured(arm_id, config):
+    arm = create_arm(arm_id, config)
+    assert arm.describe()
+    with pytest.raises(NotConfiguredError, match="registered stub"):
+        arm.answer(ATOM, CTX)
+
+
+def test_stub_arms_require_their_config():
+    with pytest.raises(NotConfiguredError, match="requires config key 'base_url'"):
+        create_arm("openwebui-chat", {"api_key_env": "K", "model": "m"})
+    with pytest.raises(NotConfiguredError, match="requires config key 'workdir'"):
+        create_arm("codex", {})
+
+
+def test_answer_record_requires_answer_xor_error():
+    with pytest.raises(ValueError, match="exactly one of answer or error"):
+        AnswerRecord(atom_id="a", arm="x")
+    with pytest.raises(ValueError, match="exactly one of answer or error"):
+        AnswerRecord(atom_id="a", arm="x", answer="y", error="z")
+    record = AnswerRecord(atom_id="a", arm="x", error="boom")
+    assert not record.ok and record.to_dict()["error"] == "boom"

--- a/python/tests/eval/test_atoms.py
+++ b/python/tests/eval/test_atoms.py
@@ -1,0 +1,181 @@
+"""archi.eval.atoms — dataset loading + validation (W5 foundation)."""
+import json
+
+import pytest
+
+from archi.eval.atoms import (
+    DatasetError,
+    answer_sha256,
+    load_dataset,
+    resolve_json_pointer,
+    validate_atom,
+    validate_atoms,
+)
+
+MINIMAL = {
+    "id": "q1",
+    "question": "What?",
+    "checks": [{"kind": "exact", "value": "42"}],
+}
+
+
+def _variant(**overrides):
+    raw = {**MINIMAL, **overrides}
+    return {key: value for key, value in raw.items() if value is not None}
+
+
+def test_smoke_fixture_loads(smoke_dataset):
+    atoms = load_dataset(smoke_dataset)
+    assert len(atoms) == 7
+    by_id = {atom.id: atom for atom in atoms}
+    live = by_id["live-open-downtimes"]
+    assert live.is_live
+    assert live.oracle.calls[0].tool == "archi_gocdb_open_downtimes"
+    assert live.checks[0].value_from == "/c1/count"
+    graded = by_id["xrootd-fallback"]
+    assert [fact.required for fact in graded.gold_facts] == [True, True, False]
+    assert not by_id["cmssw-latest-14x"].is_live
+
+
+def test_json_dataset_round_trip(tmp_path, smoke_dataset):
+    atoms = load_dataset(smoke_dataset)
+    path = tmp_path / "atoms.json"
+    path.write_text(json.dumps([atom.to_dict() for atom in atoms]))
+    reloaded = load_dataset(path)
+    assert [atom.id for atom in reloaded] == [atom.id for atom in atoms]
+    assert reloaded == atoms
+
+
+def test_top_level_object_with_schema_version(tmp_path):
+    path = tmp_path / "atoms.json"
+    path.write_text(
+        json.dumps({"schema_version": "archi-eval-v1", "atoms": [MINIMAL]})
+    )
+    assert load_dataset(path)[0].id == "q1"
+    path.write_text(json.dumps({"schema_version": "other", "atoms": [MINIMAL]}))
+    with pytest.raises(DatasetError, match="schema_version"):
+        load_dataset(path)
+
+
+@pytest.mark.parametrize(
+    "raw, message",
+    [
+        (_variant(id=None), r"atom\.id.*must be a non-empty string"),
+        (_variant(question="  "), r"question.*must be a non-empty string"),
+        (_variant(bogus=1), "unknown field"),
+        (_variant(checks=None, gold_facts=None), "at least one scoring criterion"),
+        (_variant(checks=[{"kind": "fuzzy", "value": "x"}]), "must be one of"),
+        (_variant(checks=[{"kind": "regex", "value": "["}]), "not a valid regex"),
+        (
+            _variant(checks=[{"kind": "exact"}]),
+            "exactly one of 'value' or 'value_from'",
+        ),
+        (
+            _variant(checks=[{"kind": "exact", "value": "a", "value_from": "/b"}]),
+            "exactly one of 'value' or 'value_from'",
+        ),
+        (
+            _variant(checks=[{"kind": "exact", "value_from": "/x"}]),
+            "only valid on a live atom",
+        ),
+        (
+            _variant(checks=[{"kind": "exact", "value": "x", "case_sensitive": 1}]),
+            "case_sensitive.*must be a boolean",
+        ),
+        (_variant(tags="oops"), "tags.*must be a list"),
+        (
+            _variant(gold_facts=[{"id": "A", "text": "t"}]),
+            "required.*must be a boolean",
+        ),
+        (
+            _variant(
+                gold_facts=[
+                    {"id": "A", "text": "t", "required": False},
+                ]
+            ),
+            "at least one required gold fact",
+        ),
+        (
+            _variant(
+                gold_facts=[
+                    {"id": "A", "text": "t", "required": True},
+                    {"id": "A", "text": "u", "required": False},
+                ]
+            ),
+            "duplicate gold fact id",
+        ),
+        (
+            _variant(oracle={"kind": "sql", "calls": []}),
+            "oracle.kind.*must be 'mcp'",
+        ),
+        (
+            _variant(oracle={"kind": "mcp", "calls": []}),
+            "calls.*must be a non-empty list",
+        ),
+        (
+            _variant(
+                oracle={
+                    "kind": "mcp",
+                    "calls": [
+                        {"id": "c1", "tool": "t"},
+                        {"id": "c1", "tool": "u"},
+                    ],
+                }
+            ),
+            "duplicate call id",
+        ),
+        (
+            _variant(
+                oracle={
+                    "kind": "mcp",
+                    "calls": [{"id": "c1", "tool": "t", "answer_fields": {"n": "x"}}],
+                }
+            ),
+            "RFC 6901",
+        ),
+    ],
+)
+def test_validation_errors_are_contextual(raw, message):
+    with pytest.raises(DatasetError, match=message):
+        validate_atom(raw)
+
+
+def test_duplicate_atom_ids_rejected():
+    with pytest.raises(DatasetError, match="duplicate atom id 'q1'"):
+        validate_atoms([MINIMAL, dict(MINIMAL)])
+
+
+def test_dataset_file_errors(tmp_path):
+    with pytest.raises(DatasetError, match="existing file"):
+        load_dataset(tmp_path / "missing.yaml")
+    bad_suffix = tmp_path / "atoms.txt"
+    bad_suffix.write_text("[]")
+    with pytest.raises(DatasetError, match="must use .json, .yaml, or .yml"):
+        load_dataset(bad_suffix)
+    bad_json = tmp_path / "broken.json"
+    bad_json.write_text("{nope")
+    with pytest.raises(DatasetError, match="invalid JSON dataset"):
+        load_dataset(bad_json)
+    empty = tmp_path / "empty.yaml"
+    empty.write_text("[]")
+    with pytest.raises(DatasetError, match="at least one atom"):
+        load_dataset(empty)
+
+
+def test_json_pointer_resolution():
+    payload = {"a": [{"b/c": 1}, {"~d": [10, 20]}]}
+    assert resolve_json_pointer(payload, "/a/0/b~1c") == 1
+    assert resolve_json_pointer(payload, "/a/1/~0d/1") == 20
+    assert resolve_json_pointer(payload, "") == payload
+    for pointer in ("/a/2", "/a/01", "/missing", "/a/0/b~1c/x"):
+        with pytest.raises(ValueError, match="does not exist|invalid"):
+            resolve_json_pointer(payload, pointer)
+
+
+def test_answer_sha256_is_order_insensitive():
+    left = answer_sha256({"c1": {"x": 1, "y": 2}})
+    right = answer_sha256({"c1": {"y": 2, "x": 1}})
+    assert left == right
+    assert left != answer_sha256({"c1": {"x": 1, "y": 3}})
+    with pytest.raises(ValueError):
+        answer_sha256({})

--- a/python/tests/eval/test_cli.py
+++ b/python/tests/eval/test_cli.py
@@ -1,0 +1,244 @@
+"""archi.eval.cli — list-arms and run smoke coverage, offline.
+
+The run path resolves its answering client through the CLI's
+``module:attr`` dotted-path form, pointed at a scripted module written
+into tmp_path — so the real injection mechanism is exercised with no
+network and no provider SDK.
+"""
+import json
+
+import pytest
+
+from archi.eval.cli import main
+
+CLIENT_MODULE = '''
+"""Scripted answering client for the archi.eval CLI tests."""
+LOOKUP = {
+    "Which CMSSW 14_0 release is the latest announced?": "CMSSW_14_0_7",
+    "What storage element serves T2_US_MIT?": "se01.cmsaf.mit.edu",
+}
+
+
+def answer(question, *, model, system_prompt=None):
+    return {
+        "answer": LOOKUP.get(question, "no answer"),
+        "prompt_tokens": 11,
+        "completion_tokens": 5,
+        "cost_usd": 0.0002,
+        "generation_id": "gen:cli",
+    }
+'''
+
+
+@pytest.fixture
+def client_path(tmp_path, monkeypatch):
+    """Write the scripted client module and make it importable."""
+    (tmp_path / "scripted_client.py").write_text(CLIENT_MODULE, encoding="utf-8")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    return "scripted_client:answer"
+
+
+def _write_config(tmp_path, payload, name="arm.json"):
+    path = tmp_path / name
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return str(path)
+
+
+def test_list_arms_prints_ids_and_config_keys(capsys):
+    assert main(["list-arms"]) == 0
+    out = capsys.readouterr().out
+    for arm_id in ("raw-llm", "okg-mcp", "openwebui-chat", "codex"):
+        assert f"{arm_id}:" in out
+    assert "deployment:" in out
+    assert "client:" in out
+
+
+def test_run_with_injected_client_renders_markdown(
+    tmp_path, capsys, smoke_dataset, client_path
+):
+    config = _write_config(tmp_path, {"model": "test-model", "client": client_path})
+    exit_code = main(
+        [
+            "run",
+            "--arm",
+            "raw-llm",
+            "--dataset",
+            str(smoke_dataset),
+            "--arm-config",
+            config,
+            "--generation",
+            "gen:cli",
+        ]
+    )
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "# Archi QA Evaluation Report" in out
+    assert "## Arm `raw-llm`" in out
+    assert "Pinned generation: `gen:cli`" in out
+    # The two questions the scripted client knows pass; the graded-only
+    # and live atoms report ungraded / oracle_failed from the CLI, which
+    # wires neither a judge nor an MCP session.
+    assert "`cmssw-latest-14x`: scored [pass]" in out
+    assert "`xrootd-fallback`: ungraded" in out
+    assert "`live-open-downtimes`: oracle_failed" in out
+
+
+def test_run_json_format_and_output_file(
+    tmp_path, capsys, smoke_dataset, client_path
+):
+    config = _write_config(tmp_path, {"model": "test-model", "client": client_path})
+    output = tmp_path / "report.json"
+    assert (
+        main(
+            [
+                "run",
+                "--arm",
+                "raw-llm",
+                "--dataset",
+                str(smoke_dataset),
+                "--arm-config",
+                config,
+                "--format",
+                "json",
+                "--output",
+                str(output),
+            ]
+        )
+        == 0
+    )
+    printed = json.loads(capsys.readouterr().out)
+    written = json.loads(output.read_text(encoding="utf-8"))
+    assert printed == written
+    (arm,) = written["arms"]
+    assert arm["arm"] == "raw-llm"
+    # Six answered atoms: the live one fails its oracle before the arm
+    # is ever asked, so it contributes no tokens.
+    assert arm["tokens"]["prompt"] == 11 * 6
+    assert written["generation_id"] == "gen:cli"
+
+
+def test_run_two_arms_pairs_configs_positionally(
+    tmp_path, capsys, smoke_dataset, client_path
+):
+    raw_config = _write_config(
+        tmp_path, {"model": "test-model", "client": client_path}
+    )
+    okg_config = _write_config(
+        tmp_path, {"deployment": "cern-team"}, name="okg.json"
+    )
+    assert (
+        main(
+            [
+                "run",
+                "--arm",
+                "raw-llm",
+                "--arm",
+                "okg-mcp",
+                "--dataset",
+                str(smoke_dataset),
+                "--arm-config",
+                raw_config,
+                "--arm-config",
+                okg_config,
+            ]
+        )
+        == 1
+    )
+    # raw-llm resolved fine; okg-mcp has no live wiring, and that is a
+    # setup failure the run refuses to score as zeros.
+    assert "no live MCP wiring" in capsys.readouterr().err
+
+
+def test_run_reports_dataset_errors(tmp_path, capsys, client_path):
+    bad = tmp_path / "bad.yaml"
+    bad.write_text("- id: q1\n", encoding="utf-8")
+    config = _write_config(tmp_path, {"model": "m", "client": client_path})
+    assert (
+        main(
+            [
+                "run",
+                "--arm",
+                "raw-llm",
+                "--dataset",
+                str(bad),
+                "--arm-config",
+                config,
+            ]
+        )
+        == 1
+    )
+    assert "error:" in capsys.readouterr().err
+
+
+def test_run_reports_unknown_arm(capsys, smoke_dataset):
+    assert main(["run", "--arm", "nope", "--dataset", str(smoke_dataset)]) == 1
+    assert "unknown arm 'nope'" in capsys.readouterr().err
+
+
+def test_run_reports_not_configured_stub(tmp_path, capsys, smoke_dataset):
+    config = _write_config(tmp_path, {"workdir": str(tmp_path)})
+    assert (
+        main(
+            [
+                "run",
+                "--arm",
+                "codex",
+                "--dataset",
+                str(smoke_dataset),
+                "--arm-config",
+                config,
+            ]
+        )
+        == 1
+    )
+    assert "registered stub" in capsys.readouterr().err
+
+
+def test_run_rejects_extra_arm_configs(tmp_path, capsys, smoke_dataset):
+    config = _write_config(tmp_path, {"model": "m", "client": "x:y"})
+    assert (
+        main(
+            [
+                "run",
+                "--arm",
+                "raw-llm",
+                "--dataset",
+                str(smoke_dataset),
+                "--arm-config",
+                config,
+                "--arm-config",
+                config,
+            ]
+        )
+        == 1
+    )
+    assert "2 --arm-config for 1 --arm" in capsys.readouterr().err
+
+
+def test_run_reports_missing_config_file(capsys, smoke_dataset, tmp_path):
+    assert (
+        main(
+            [
+                "run",
+                "--arm",
+                "raw-llm",
+                "--dataset",
+                str(smoke_dataset),
+                "--arm-config",
+                str(tmp_path / "absent.json"),
+            ]
+        )
+        == 1
+    )
+    assert "existing file" in capsys.readouterr().err
+
+
+def test_module_entry_point_is_wired():
+    import archi.eval.__main__ as entry
+
+    assert entry.main is main
+
+
+def test_parser_requires_a_subcommand():
+    with pytest.raises(SystemExit):
+        main([])

--- a/python/tests/eval/test_engine.py
+++ b/python/tests/eval/test_engine.py
@@ -1,0 +1,415 @@
+"""archi.eval.engine — scoring correctness + the run loop, offline."""
+import pytest
+
+from archi.eval.arms import NotConfiguredError, create_arm
+from archi.eval.atoms import validate_atom
+from archi.eval.engine import Judgment, evaluate_check, run_eval, score_gold_facts
+
+
+def _atom(**overrides):
+    raw = {
+        "id": "q1",
+        "question": "What?",
+        "checks": [{"kind": "exact", "value": "42"}],
+    }
+    raw.update(overrides)
+    return validate_atom({k: v for k, v in raw.items() if v is not None})
+
+
+def _check(kind, value=None, case_sensitive=True, value_from=None):
+    oracle = None
+    if value_from is not None:
+        oracle = {"kind": "mcp", "calls": [{"id": "c1", "tool": "t"}]}
+    atom = _atom(
+        checks=[
+            {
+                "kind": kind,
+                **({"value": value} if value is not None else {}),
+                **({"value_from": value_from} if value_from is not None else {}),
+                "case_sensitive": case_sensitive,
+            }
+        ],
+        oracle=oracle,
+    )
+    return atom.checks[0]
+
+
+# --- deterministic checks ---
+
+
+@pytest.mark.parametrize(
+    "kind, value, case_sensitive, answer, expected",
+    [
+        ("exact", "42", True, "42", True),
+        ("exact", "42", True, " 42 ", True),  # whitespace-insensitive
+        ("exact", "42", True, "answer: 42", False),
+        ("exact", "ABC", True, "abc", False),
+        ("exact", "ABC", False, "abc", True),
+        ("contains", "needle", True, "hay needle stack", True),
+        ("contains", "needle", True, "hay stack", False),
+        ("contains", "NeedLe", False, "the needle", True),
+        ("contains", "NeedLe", True, "the needle", False),
+        ("regex", r"CMSSW_\d+_\d+_\d+", True, "use CMSSW_14_0_7 now", True),
+        ("regex", r"^exact$", True, "not exact here", False),
+        ("regex", r"tier-2", False, "a Tier-2 site", True),
+        ("regex", r"tier-2", True, "a Tier-2 site", False),
+    ],
+)
+def test_evaluate_check_kinds(kind, value, case_sensitive, answer, expected):
+    result = evaluate_check(_check(kind, value, case_sensitive), answer)
+    assert result.passed is expected
+    assert result.expected == value
+    assert result.source == "literal"
+
+
+def test_evaluate_check_value_from_resolves_and_stringifies():
+    check = _check("contains", value_from="/c1/count")
+    resolved = {"c1": {"count": 3}}
+    result = evaluate_check(check, "There are 3 open downtimes.", resolved)
+    assert result.passed and result.expected == "3" and result.source == "/c1/count"
+    assert not evaluate_check(check, "There are 5.", resolved).passed
+    with pytest.raises(ValueError, match="no resolved oracle answer"):
+        evaluate_check(check, "any", None)
+    with pytest.raises(ValueError, match="does not exist"):
+        evaluate_check(check, "any", {"c1": {}})
+
+
+# --- graded scoring (PR #596 math) ---
+
+
+def _facts(*rows):
+    atom = _atom(
+        checks=None,
+        gold_facts=[
+            {"id": fact_id, "text": f"fact {fact_id}", "required": required}
+            for fact_id, required in rows
+        ],
+    )
+    return atom.gold_facts
+
+
+def _judged(facts, outcomes):
+    return [
+        Judgment(fact_id=fact.id, outcome=outcome, rationale="r")
+        for fact, outcome in zip(facts, outcomes)
+    ]
+
+
+def test_score_gold_facts_all_entailed():
+    facts = _facts(("A1", True), ("A2", False))
+    scored = score_gold_facts(facts, _judged(facts, ["entailed", "entailed"]))
+    assert scored == {
+        "atom_score": 1.0,
+        "required_fact_recall": 1.0,
+        "passed": True,
+    }
+
+
+def test_score_gold_facts_contradiction_clamps_at_zero():
+    facts = _facts(("A1", True), ("A2", False), ("A3", False))
+    scored = score_gold_facts(
+        facts, _judged(facts, ["contradicted", "contradicted", "not_mentioned"])
+    )
+    assert scored["atom_score"] == 0.0  # max(0, -2/3)
+    assert scored["required_fact_recall"] == 0.0
+    assert scored["passed"] is False
+
+
+def test_score_gold_facts_optional_miss_still_passes():
+    facts = _facts(("A1", True), ("A2", False))
+    scored = score_gold_facts(facts, _judged(facts, ["entailed", "not_mentioned"]))
+    assert scored["passed"] is True
+    assert scored["atom_score"] == 0.5
+    assert scored["required_fact_recall"] == 1.0
+
+
+def test_score_gold_facts_unjudgeable_counts_zero_and_fails_required():
+    facts = _facts(("A1", True), ("A2", False))
+    scored = score_gold_facts(facts, _judged(facts, ["unjudgeable", "entailed"]))
+    assert scored["atom_score"] == 0.5
+    assert scored["passed"] is False
+
+
+@pytest.mark.parametrize(
+    "outcomes_by_id, message",
+    [
+        ({"A1": "entailed"}, "missing judgment"),
+        ({"A1": "entailed", "A2": "entailed", "AX": "entailed"}, "unknown gold fact"),
+        ({"A1": "maybe", "A2": "entailed"}, "unsupported judgment outcome"),
+    ],
+)
+def test_score_gold_facts_judgment_contract(outcomes_by_id, message):
+    facts = _facts(("A1", True), ("A2", False))
+    judgments = [
+        Judgment(fact_id=fact_id, outcome=outcome, rationale="r")
+        for fact_id, outcome in outcomes_by_id.items()
+    ]
+    with pytest.raises(ValueError, match=message):
+        score_gold_facts(facts, judgments)
+
+
+def test_score_gold_facts_duplicate_judgment_rejected():
+    facts = _facts(("A1", True))
+    judgments = _judged(facts, ["entailed"]) + _judged(facts, ["entailed"])
+    with pytest.raises(ValueError, match="duplicate judgment"):
+        score_gold_facts(facts, judgments)
+
+
+# --- the run loop over the smoke fixture ---
+
+
+def test_run_eval_all_pass(smoke_atoms, arm_cls, grader_cls, invoker_cls):
+    grader = grader_cls()
+    run = run_eval(
+        smoke_atoms,
+        [arm_cls(generation_id="gen:test")],
+        grader=grader,
+        oracle_invoker=invoker_cls(),
+        dataset="qa_smoke.yaml",
+    )
+    assert len(run.arm_runs) == 1
+    results = {result.atom_id: result for result in run.arm_runs[0].results}
+    assert len(results) == 7
+    assert all(result.status == "scored" for result in results.values())
+    assert all(result.passed for result in results.values())
+    live = results["live-open-downtimes"]
+    assert live.live["pre_run_sha256"] == live.live["post_run_sha256"]
+    assert run.generation_id == "gen:test"
+    assert run.generation_conflict is False
+    # The two atoms carrying gold facts actually consulted the grader.
+    assert len(grader.calls) == 2
+
+
+def test_run_eval_failing_answers_score_false(
+    smoke_atoms, arm_cls, grader_cls, invoker_cls, answers
+):
+    answers.update(
+        {
+            "cmssw-latest-14x": "CMSSW_15_0_0",  # exact miss
+            "dataset-path": "/JetMET0/Run2024A-v1/AOD",  # one of two checks
+        }
+    )
+    run = run_eval(
+        smoke_atoms,
+        [arm_cls(answers)],
+        grader=grader_cls(),
+        oracle_invoker=invoker_cls(),
+    )
+    results = {result.atom_id: result for result in run.arm_runs[0].results}
+    assert results["cmssw-latest-14x"].passed is False
+    assert results["cmssw-latest-14x"].score == 0.0
+    partial = results["dataset-path"]
+    assert partial.passed is False and partial.score == 0.5
+    assert results["t2-mit-storage"].passed is True
+
+
+def test_run_eval_mixed_criteria_combines_checks_and_grading(
+    smoke_atoms, arm_cls, grader_cls, invoker_cls
+):
+    grader = grader_cls(overrides={"B1": "contradicted"})
+    run = run_eval(
+        smoke_atoms, [arm_cls()], grader=grader, oracle_invoker=invoker_cls()
+    )
+    results = {result.atom_id: result for result in run.arm_runs[0].results}
+    mixed = results["mixed-criteria"]
+    assert mixed.status == "scored"
+    assert mixed.passed is False  # checks pass, required fact contradicted
+    assert mixed.score == 0.5  # mean(check part 1.0, graded part 0.0)
+    assert mixed.required_fact_recall == 0.0
+
+
+def test_run_eval_without_grader_marks_graded_only_atom_ungraded(
+    smoke_atoms, arm_cls, invoker_cls
+):
+    run = run_eval(smoke_atoms, [arm_cls()], oracle_invoker=invoker_cls())
+    results = {result.atom_id: result for result in run.arm_runs[0].results}
+    assert results["xrootd-fallback"].status == "ungraded"
+    assert results["xrootd-fallback"].passed is None
+    mixed = results["mixed-criteria"]
+    assert mixed.status == "scored" and "skipped" in mixed.detail
+    assert mixed.passed is True  # checks-only pass
+
+
+def test_run_eval_grader_blowup_is_evaluation_failed(
+    smoke_atoms, arm_cls, invoker_cls
+):
+    class ExplodingGrader:
+        def judge(self, question, answer, gold_facts):
+            raise RuntimeError("judge unavailable")
+
+    run = run_eval(
+        smoke_atoms,
+        [arm_cls()],
+        grader=ExplodingGrader(),
+        oracle_invoker=invoker_cls(),
+    )
+    results = {result.atom_id: result for result in run.arm_runs[0].results}
+    assert results["xrootd-fallback"].status == "evaluation_failed"
+    assert "judge unavailable" in results["xrootd-fallback"].detail
+
+
+def test_run_eval_arm_exception_is_execution_failed(
+    smoke_atoms, arm_cls, grader_cls, invoker_cls, answers
+):
+    answers.pop("gt-name-shape")
+    run = run_eval(
+        smoke_atoms,
+        [arm_cls(answers)],
+        grader=grader_cls(),
+        oracle_invoker=invoker_cls(),
+    )
+    results = {result.atom_id: result for result in run.arm_runs[0].results}
+    failed = results["gt-name-shape"]
+    assert failed.status == "execution_failed"
+    assert failed.passed is False
+    assert "LookupError" in failed.record.error
+
+
+def test_run_eval_not_configured_propagates(smoke_atoms):
+    arm = create_arm("codex", {"workdir": "."})
+    with pytest.raises(NotConfiguredError):
+        run_eval(smoke_atoms, [arm])
+
+
+# --- live-state atoms (PR #608 flow) ---
+
+
+def test_live_atom_without_invoker_is_oracle_failed(
+    smoke_atoms, arm_cls, grader_cls
+):
+    run = run_eval(smoke_atoms, [arm_cls()], grader=grader_cls())
+    results = {result.atom_id: result for result in run.arm_runs[0].results}
+    live = results["live-open-downtimes"]
+    assert live.status == "oracle_failed"
+    assert live.live == {"phase": "pre_run"}
+    assert results["cmssw-latest-14x"].status == "scored"  # others unaffected
+
+
+def test_live_atom_pre_run_oracle_failure_skips_the_arm(
+    smoke_atoms, arm_cls, grader_cls, invoker_cls
+):
+    class CountingArm(arm_cls):
+        def __init__(self):
+            super().__init__()
+            self.asked = []
+
+        def answer(self, atom, ctx):
+            self.asked.append(atom.id)
+            return super().answer(atom, ctx)
+
+    arm = CountingArm()
+    run = run_eval(
+        smoke_atoms,
+        [arm],
+        grader=grader_cls(),
+        oracle_invoker=invoker_cls(fail_after=0),
+    )
+    results = {result.atom_id: result for result in run.arm_runs[0].results}
+    assert results["live-open-downtimes"].status == "oracle_failed"
+    assert "oracle backend went away" in results["live-open-downtimes"].detail
+    assert "live-open-downtimes" not in arm.asked
+
+
+def test_live_atom_post_run_failure_quarantines(
+    smoke_atoms, arm_cls, grader_cls, invoker_cls
+):
+    run = run_eval(
+        smoke_atoms,
+        [arm_cls()],
+        grader=grader_cls(),
+        oracle_invoker=invoker_cls(fail_after=1),  # pre-run ok, post-run fails
+    )
+    results = {result.atom_id: result for result in run.arm_runs[0].results}
+    live = results["live-open-downtimes"]
+    assert live.status == "oracle_failed"
+    assert live.live["phase"] == "post_run"
+    assert live.record is not None  # the answer is kept for inspection
+
+
+def test_live_atom_drift_is_answer_changed(
+    smoke_atoms, arm_cls, grader_cls, invoker_cls
+):
+    class DriftingInvoker(invoker_cls):
+        def invoke(self, call):
+            self.calls += 1
+            return {"summary": {"open_count": 3 if self.calls == 1 else 4}}
+
+    run = run_eval(
+        smoke_atoms,
+        [arm_cls()],
+        grader=grader_cls(),
+        oracle_invoker=DriftingInvoker(),
+    )
+    results = {result.atom_id: result for result in run.arm_runs[0].results}
+    live = results["live-open-downtimes"]
+    assert live.status == "answer_changed"
+    assert live.passed is None
+    assert live.live["pre_run_sha256"] != live.live["post_run_sha256"]
+
+
+def test_live_atom_scores_against_resolved_value(
+    smoke_atoms, arm_cls, grader_cls, invoker_cls, answers
+):
+    answers["live-open-downtimes"] = "About 7 are open."
+    run = run_eval(
+        smoke_atoms,
+        [arm_cls(answers)],
+        grader=grader_cls(),
+        oracle_invoker=invoker_cls(),
+    )
+    results = {result.atom_id: result for result in run.arm_runs[0].results}
+    live = results["live-open-downtimes"]
+    assert live.status == "scored" and live.passed is False
+    assert live.check_results[0].expected == "3"
+
+
+# --- generation pinning ---
+
+
+def test_generation_pin_explicit_flag_wins(
+    smoke_atoms, arm_cls, grader_cls, invoker_cls
+):
+    run = run_eval(
+        smoke_atoms,
+        [arm_cls(generation_id="gen:a")],
+        grader=grader_cls(),
+        oracle_invoker=invoker_cls(),
+        generation_id="gen:pinned",
+    )
+    assert run.generation_id == "gen:pinned"
+    assert run.generation_conflict is True  # explicit pin != observed
+
+
+def test_generation_conflict_across_arms(
+    smoke_atoms, arm_cls, grader_cls, invoker_cls
+):
+    run = run_eval(
+        smoke_atoms,
+        [
+            arm_cls(generation_id="gen:a", name="arm-a"),
+            arm_cls(generation_id="gen:b", name="arm-b"),
+        ],
+        grader=grader_cls(),
+        oracle_invoker=invoker_cls(),
+    )
+    assert run.generation_id is None
+    assert run.generation_conflict is True
+    assert run.arm_runs[0].generation_ids == ("gen:a",)
+    assert run.arm_runs[1].generation_ids == ("gen:b",)
+
+
+def test_generation_absent_when_arms_report_none(
+    smoke_atoms, arm_cls, grader_cls, invoker_cls
+):
+    run = run_eval(
+        smoke_atoms, [arm_cls()], grader=grader_cls(), oracle_invoker=invoker_cls()
+    )
+    assert run.generation_id is None
+    assert run.generation_conflict is False
+
+
+def test_run_eval_requires_atoms_and_arms(smoke_atoms, arm_cls):
+    with pytest.raises(ValueError, match="at least one atom"):
+        run_eval([], [arm_cls()])
+    with pytest.raises(ValueError, match="at least one arm"):
+        run_eval(smoke_atoms, [])

--- a/python/tests/eval/test_report.py
+++ b/python/tests/eval/test_report.py
@@ -1,0 +1,212 @@
+"""archi.eval.report — aggregation, markdown render, cost rollups."""
+import pytest
+
+from archi.eval.engine import run_eval
+from archi.eval.report import build_report, render_markdown, sum_llm_calls
+
+
+def _report(smoke_atoms, arm, grader_cls, invoker_cls):
+    run = run_eval(
+        smoke_atoms,
+        [arm],
+        grader=grader_cls(),
+        oracle_invoker=invoker_cls(),
+        generation_id="gen:pin",
+        dataset="qa_smoke.yaml",
+        run_id="eval-fixed",
+    )
+    return build_report(run)
+
+
+def test_report_header_and_arm_rollup(
+    smoke_atoms, arm_cls, grader_cls, invoker_cls
+):
+    report = _report(
+        smoke_atoms,
+        arm_cls(
+            generation_id="gen:pin",
+            latency_ms=40,
+            cost_usd=0.002,
+            prompt_tokens=100,
+            completion_tokens=25,
+        ),
+        grader_cls,
+        invoker_cls,
+    )
+    assert report["run_id"] == "eval-fixed"
+    assert report["dataset"] == "qa_smoke.yaml"
+    assert report["generation_id"] == "gen:pin"
+    assert report["generation_conflict"] is False
+    (arm,) = report["arms"]
+    assert arm["arm"] == "fake"
+    assert arm["atoms"] == 7
+    assert arm["status_counts"]["scored"] == 7
+    assert arm["passed"] == 7 and arm["quality_accounted"] == 7
+    assert arm["pass_rate"] == 1.0
+    assert arm["mean_score"] == 1.0
+    assert arm["latency_ms"] == {"count": 7, "mean": 40, "p50": 40, "max": 40}
+    assert arm["tokens"] == {"prompt": 700, "completion": 175}
+    assert arm["cost_usd"] == pytest.approx(0.014)
+    assert arm["generation_ids"] == ["gen:pin"]
+    assert len(arm["results"]) == 7
+
+
+def test_report_quality_denominator_excludes_quarantined(
+    smoke_atoms, arm_cls, answers
+):
+    # No oracle invoker: the live atom quarantines as oracle_failed and
+    # must not dilute the pass rate; a missing scripted answer becomes
+    # execution_failed and must count against it (PR #596 semantics);
+    # no grader: the graded-only atom is ungraded, also excluded.
+    answers.pop("live-open-downtimes")
+    answers.pop("gt-name-shape")
+    run = run_eval(smoke_atoms, [arm_cls(answers)])
+    report = build_report(run)
+    (arm,) = report["arms"]
+    assert arm["status_counts"] == {
+        "scored": 4,
+        "execution_failed": 1,
+        "evaluation_failed": 0,
+        "ungraded": 1,
+        "oracle_failed": 1,
+        "answer_changed": 0,
+    }
+    assert arm["quality_accounted"] == 5  # scored + execution_failed
+    assert arm["passed"] == 4
+    assert arm["pass_rate"] == pytest.approx(0.8)
+    assert arm["cost_usd"] is None  # nothing reported cost
+    assert arm["tokens"] == {"prompt": None, "completion": None}
+
+
+def test_report_multi_arm_comparison(
+    smoke_atoms, arm_cls, grader_cls, invoker_cls, answers
+):
+    answers["cmssw-latest-14x"] = "wrong"
+    run = run_eval(
+        smoke_atoms,
+        [arm_cls(name="arm-good"), arm_cls(answers, name="arm-bad")],
+        grader=grader_cls(),
+        oracle_invoker=invoker_cls(),
+    )
+    report = build_report(run)
+    by_arm = {arm["arm"]: arm for arm in report["arms"]}
+    assert by_arm["arm-good"]["pass_rate"] == 1.0
+    assert by_arm["arm-bad"]["pass_rate"] == pytest.approx(6 / 7)
+
+
+def test_markdown_render(smoke_atoms, arm_cls, grader_cls, invoker_cls):
+    report = _report(
+        smoke_atoms, arm_cls(generation_id="gen:pin"), grader_cls, invoker_cls
+    )
+    text = render_markdown(report)
+    assert text.startswith("# Archi QA Evaluation Report")
+    assert "`eval-fixed`" in text
+    assert "Pinned generation: `gen:pin`" in text
+    assert "## Arm `fake`" in text
+    assert "`cmssw-latest-14x`: scored [pass] score=1.000" in text
+    assert "conflict" not in text
+
+
+def test_markdown_flags_generation_conflict(
+    smoke_atoms, arm_cls, grader_cls, invoker_cls
+):
+    run = run_eval(
+        smoke_atoms,
+        [
+            arm_cls(generation_id="gen:a", name="arm-a"),
+            arm_cls(generation_id="gen:b", name="arm-b"),
+        ],
+        grader=grader_cls(),
+        oracle_invoker=invoker_cls(),
+    )
+    text = render_markdown(build_report(run))
+    assert "(conflict: arms disagree)" in text
+
+
+def test_markdown_marks_failures_and_details(smoke_atoms, arm_cls, answers):
+    answers["cmssw-latest-14x"] = "CMSSW_15_0_0"
+    run = run_eval(smoke_atoms, [arm_cls(answers)])
+    text = render_markdown(build_report(run))
+    assert "`cmssw-latest-14x`: scored [FAIL] score=0.000" in text
+    assert "`live-open-downtimes`: oracle_failed [-]" in text
+    assert "no oracle invoker" in text
+
+
+# --- okg.llm_calls cost helper (fake connection; the table contract is
+# verified against the okg checkout's schema.sql, see report.py) ---
+
+
+class FakeCursor:
+    def __init__(self, log):
+        self.log = log
+
+    def execute(self, query, params):
+        self.log.append((query, list(params)))
+
+    def fetchone(self):
+        return (12, 3400, 890, 4290, 0.0421, 1)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class FakeConnection:
+    def __init__(self, log):
+        self.log = log
+
+    def cursor(self):
+        return FakeCursor(self.log)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def test_sum_llm_calls_query_and_sums():
+    log = []
+    totals = sum_llm_calls(
+        "postgresql://example/db",
+        since="2026-08-24T10:00:00+00:00",
+        until="2026-08-24T10:05:00+00:00",
+        deployment="cern-team",
+        generation_id="gen:pin",
+        connect=lambda dsn: FakeConnection(log),
+    )
+    assert totals == {
+        "calls": 12,
+        "prompt_tokens": 3400,
+        "completion_tokens": 890,
+        "total_tokens": 4290,
+        "cost_usd": pytest.approx(0.0421),
+        "failed_calls": 1,
+    }
+    (query, params) = log[0]
+    assert "FROM okg.llm_calls" in query
+    assert "ts >= %s" in query and "ts < %s" in query
+    assert "deployment_name = %s" in query
+    assert "generation_id = %s" in query
+    assert params == [
+        "2026-08-24T10:00:00+00:00",
+        "2026-08-24T10:05:00+00:00",
+        "cern-team",
+        "gen:pin",
+    ]
+
+
+def test_sum_llm_calls_optional_filters_omitted():
+    log = []
+    sum_llm_calls(
+        "postgresql://example/db",
+        since="a",
+        until="b",
+        connect=lambda dsn: FakeConnection(log),
+    )
+    (query, params) = log[0]
+    assert "deployment_name" not in query
+    assert "generation_id" not in query
+    assert params == ["a", "b"]


### PR DESCRIPTION
## Credit

**This evaluation work is Antonio Battaglia's** — PRs #596 and #608 are his (with fixes from Austin Swinney in #608). The atom model, gold-fact judging and its scoring math, dataset validation, report shape, and the live-state oracle flow all come from that work; the arm registry is the v3 restructuring. Because neither PR merged and both were written against the removed v2 `src/` tree, the code is re-homed here rather than carried as his commits — his authorship is recorded in the `Co-Authored-By` trailers of the port commits and named in `docs/eval.md`. If Antonio would rather land this as his own PR against `archi_v3`, this branch should defer to that.

## What this changes

Adds `python/archi/eval/` — an evaluation framework that runs the same questions against **arms** (one arm = one answering configuration: the chatbot, an agent driving OKG MCP tools, a coding agent, a raw-LLM baseline) and produces a comparable, generation-pinned report. Ports the substance of the two open v2-era PRs — **#596** (atom engine + gold-fact judging) and **#608** (MCP-backed live-state QA) — re-homed into the v3 distribution and restructured around the arm registry. PACT change `pact/changes/w5-eval-foundation/` (task gated).

## Behavior before → after

- Before: no evaluation in the v3 line; #596/#608 sat unmerged against the removed v2 tree, each measuring one configuration.
- After: `python -m archi.eval list-arms` describes every registered arm and its config keys; `python -m archi.eval run --arm <id> --dataset <path>` scores a dataset and reports pass rate, latency, tokens and cost, pinned to the generation the answers came from. Datasets are YAML/JSON QA atoms validated with contextual errors; deterministic checks (`exact`/`contains`/`regex`) and gold-fact judging both score; live-state atoms resolve expected values from an MCP oracle and quarantine when live state drifts mid-run.

## What's real vs deliberately stubbed

- Working now: `raw-llm` (client injected — no vendored SDK, no network in tests), the full engine/scoring/report path, and the `okg-mcp` adapter seam.
- Registered but unwired: `okg-mcp` live session, `openwebui-chat`, `codex` — each declares its config schema and raises `NotConfiguredError`, which the engine does *not* catch, so a setup mistake fails the run instead of silently scoring zeros.
- Untouched by design: the two divergent cms-compops golden sets (they live in the instance repo and need a maintainer decision before conversion). Tests use a small fixture dataset.

## Notes

- **No new dependency.** YAML via the existing `pyyaml`; everything else stdlib. `psycopg` is imported lazily (injectable) inside the `okg.llm_calls` cost helper, matching the "okg is a host dependency" stance. The cost table was verified against the okg schema — columns match, no adaptation needed.
- `docs/eval.md` covers the arm concept, how to add an arm, dataset format, and what is stubbed and why.

## Open questions for the maintainer (in `docs/eval.md` too)

1. Mixed-criteria atoms (both `checks` and `gold_facts`) currently score the mean of both parts and pass only if both pass — equal weighting is a guess.
2. Pass-rate denominator excludes quarantined live results, which flatters an arm whose live atoms all quarantine; want a minimum-coverage warning?
3. A judge verdict of `unjudgeable` scores 0 (same as `not_mentioned`), making "can't tell" indistinguishable from "omitted" — alternative is treating it as evaluation failure.
4. `exact` is whitespace-trimmed equality — short-form atoms only, or normalize further?
5. `okg-mcp` assumes one answering tool (`ask_tool`, default `ask`) taking `{"question": ...}` — need the real entry point before live wiring, and whether the generation id returns in the tool result.

## How I verified

- `/work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests -q` → **350 passed** (96 in `python/tests/eval`; baseline was 254). Guards green: no v2 imports, no operator paths, wheel builds and ships `archi/eval/*`.
- CLI exercised outside pytest: `list-arms` output verified, and a scored `run` over the fixture dataset with a scripted client (report rendered, generation auto-pinned from records).
- `okg pact gate task-done w5-eval-foundation task.w5-eval-foundation` → holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjTTnEB9pAsrLdLsMFtUzL
