### PR TITLE
docs+chore: alignment page refresh, PACT retirements recorded, §10 DoD made runnable

### DIFF
--- a/docs/okg-alignment.md
+++ b/docs/okg-alignment.md
@@ -20,8 +20,15 @@ reimplementation of OKG services.
 
 ## Current state (update this section when it changes)
 
-*Last updated 2026-08-21, archi branch `archi_v3` @ `728739e6` (PR #610 merged),
-tested against okg `dev` @ `f5ec3b58d` (2026-08-18).*
+*Last updated 2026-08-24, archi branch `archi_v3` @ `81dbdb6b` (PRs #610, #611,
+#616, #617 merged), tested against okg `dev` @ `f5ec3b58d` (2026-08-18).*
+
+**Pin drift, flagged deliberately:** okg `dev` is now `03470e2b4` — **210 commits
+ahead of the pin we have actually validated against**. Per this page's own
+re-audit-on-bump rule that is an open exposure, not a claim of compatibility:
+until we re-pin and re-run, treat every statement below as verified against
+`f5ec3b58d` only. It matters more than usual while #1181 (the connector/enricher
+SDK) is open, because we still import ten private `okg.substrate` symbols.
 
 **Sync channel: okg#1178** (established 2026-08-19; surface-change heads-ups land
 there). Re-pin validation 2026-08-19 against the strict registry-admission schema
@@ -29,9 +36,13 @@ there). Re-pin validation 2026-08-19 against the strict registry-admission schem
 cmssw-releases, jira, docsite) lint clean, ingest OK, and publish — **zero
 refusals**; full test suite 199/199 on the new pin. okg#1006 is merged into `dev`
 (2026-08-13): chat, MCP HTTP auth, and principal mapping are now landed premises —
-Archi's W9 targets `dev`, and multi-user instances are unblocked pending #1183's
-per-bundle chat surface (#1275). Our substrate frictions are now okg #1282 / #1283 /
-#1284; our import surface is CI-gated on the okg side
+Archi's W9 targets `dev`. **Upstream state re-verified 2026-08-24:** #1275 (the
+chat/console slices) is **merged** — the remaining W9 dependency is its parent
+#1183, still open. Of our three filed frictions, **#1283 (`output_scope_summary`
+hand-duplication) is closed upstream**; #1282 (narrowings outside
+`schemas/bridges/` silently ignored — the real bug of the three) and #1284 (no
+`partial` SourceHealth status) remain open. Our import surface is CI-gated on the
+okg side
 (`tests/substrate/contracts/test_external_import_surface.py`). D11 (shared ontology
 modules in the wheel) is planned against the deployment-product packaging wave
 (digest-pinned distribution assets), not an env-var override.


### PR DESCRIPTION
## What this changes

Three docs/config corrections on the trunk, no behavior change to the distribution. (1) Brings `docs/okg-alignment.md` — the page the OKG side reads to stay in sync with us (okg#1178) — back in line with reality. (2) Records three PACT retirements the maintainer's approvals produced. (3) Makes ADR §10's definition of done actually runnable and stops committing generated PACT locks.

## Behavior before → after

- Before: the alignment page described okg#1275 as an open blocker, listed #1283 among live frictions, and stated a pin with no indication of how far `dev` had moved. `python/pyproject.toml` declared no dev extra and no lint config, so the mandated `black --check .` / `isort --check .` could not be run at all; `python/uv.lock` was missing `pyyaml`. Five `pact.yaml.lock` files were tracked against the repo's own rule.
- After: upstream states corrected with the pin drift stated as an explicit exposure; the three retired changes moved to `pact/archive/`; the dev tooling is declared and the lock refreshed; PACT locks untracked and ignored.

## Findings, most severe first (each verified here, not taken on report)

- **okg `dev` is 210 commits ahead of the pin we have actually validated against** (`03470e2b4` vs `f5ec3b58d`). The page's own rule is re-audit-on-bump, so this is now stated as an open exposure rather than left to imply compatibility — it matters while okg#1181 (the SDK) is open and we still import ten private `okg.substrate` symbols.
- **The §10 definition of done is currently failing, not just unrunnable.** With the tools finally declared, `black --check` wants to reformat **58 files** and `isort --check` flags ~47. I deliberately did **not** reformat them: that would be a review-hostile diff across merged code and would break the deliberate line-level parity we keep with the frozen canonical `okg-deployments/cms` copies. This needs a maintainer decision — accept a one-time formatting commit, or amend the DoD.
- **Black cannot parse three connector files** (`jira.py:465`, `hypernews.py:528`, `indico.py:443` — "f-string expression part cannot include a backslash") because it runs under a pre-3.12 interpreter while the package targets 3.12. A tooling-environment mismatch, not a code defect.
- **Something in the local environment runs a lint pass from the repo root on commit and now errors `No pyproject.toml found in current directory or any parent directory`** — because W10 (PR #611) deleted the root `pyproject.toml`. Whatever invokes it needs pointing at `python/`.
- **okg#1275 is merged**, not pending; the remaining W9 dependency is its parent #1183 (open). **okg#1283 is closed**; #1282 (the real bug of the three) and #1284 remain open.
- **The PACT review-queue view is unreliable:** `okg pact view --format=review-queue` reports "3 change(s) awaiting a decision" and those three are `state: retired`. Retired changes should not appear in a review queue.
- Program state recorded per the standing alignment policy: #616 (W7 bookkeeping) and #617 (circle-back fixes — 3 blockers + 15 majors, suite 326) merged, including the two substrate items routed to okg#1178 rather than patched locally (`SourceRun.record_set` never provided, the likely root cause of the deletion-semantics finding they are triaging; and the enricher derived-edge lifecycle). **W5 (evaluation) is parked** by maintainer decision, stated so upstream W5-dependent planning doesn't assume delivery.

## Notes on the PACT archival

`circleback-fixes`, `w6-cern-team-bundle` and `w7-compops-instance` are `state: retired` in the ledger, and the CLI moved their directories out of `pact/changes/`; this commit records that move (the tracked `pact/archive/w1-prove-the-seam` is the precedent). Their manifests' `status: proposal` line is left untouched because the CLI does not flip it — lifecycle lives in the ledger, `pact.yaml` carries intent. **`w2-consolidate-hep-sources` is deliberately not archived: the ledger still reports it `state: in_progress`, i.e. not approved.**

## How I verified

- `gh api repos/mitdbg/okg/issues/{1275,1283,1282,1284,1183,1181}` for every upstream state claim; `git rev-list --count f5ec3b58d..origin/dev` → 210 against a fresh fetch.
- `okg pact view --format=list --status all` for each change's real state before moving any directory.
- `pytest python/tests -q` → **326 passed**; `pytest python/tests/test_alignment_page.py -q` → 2 passed (the import-surface drift guard).
- `uv lock` regenerated the lock; `requires-dist` now carries `pyyaml` plus the dev extra.

Stale-state credit: the parallel assessment session flagged the #1275/#1283 states, the pin drift, the undeclared dev tooling and the tracked locks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjTTnEB9pAsrLdLsMFtUzL
