### PR TITLE
ci: run the v3 suite on archi_v3 (ADR §14)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,98 @@
+# CI for the v3 distribution (ADR §14: CI on archi_v3 from day one).
+#
+# SECURITY — read before editing. This repository is PUBLIC and the okg
+# substrate is PRIVATE. The tests import okg, so the job needs a token
+# (OKG_REPO_TOKEN, a fine-grained PAT scoped read-only to the private fork
+# lucalavezzo/okg). A secret exposed to a pull_request run from a fork is
+# readable by anyone who can open a PR, so:
+#
+#   * the job is guarded on the head repo being this repository, and
+#   * `pull_request` is used rather than `pull_request_target`, which would
+#     run untrusted code with access to secrets by design.
+#
+# A fork PR therefore reports "skipped", not "passed": no green tick is
+# claimed for tests that never ran. A maintainer re-runs it from a branch in
+# this repo before merge.
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches: [archi_v3]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    name: tests (python 3.12)
+    runs-on: ubuntu-latest
+    # Fork PRs cannot see OKG_REPO_TOKEN. Skip rather than fail, and never
+    # fall back to a partial run that could read as full coverage.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@v4
+
+      # Pinned deliberately: the package targets 3.12, and black cannot parse
+      # the f-strings in three connectors under anything older -- that is what
+      # made the §10 definition of done look broken.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install okg (private substrate, pinned)
+        env:
+          OKG_REPO_TOKEN: ${{ secrets.OKG_REPO_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${OKG_REPO_TOKEN}" ]; then
+            echo "::error::OKG_REPO_TOKEN is not available; refusing to run a partial suite"
+            exit 1
+          fi
+          # The pin is the commit archi is tested against; see
+          # docs/okg-alignment.md, which states the drift from okg dev.
+          python -m pip install --upgrade pip
+          pip install "okg @ git+https://x-access-token:${OKG_REPO_TOKEN}@github.com/lucalavezzo/okg@f5ec3b58d"
+
+      - name: Install archi with dev extras
+        run: pip install -e "./python[dev]"
+
+      - name: Tests
+        run: python -m pytest python/tests -q
+
+      # Report-only. The tree predates any formatter: black would reformat 58
+      # files and isort ~47, and the connectors are kept line-comparable with
+      # the frozen canonical okg-deployments/cms copies so upstream bug reports
+      # cite matching lines. Enforcing would destroy that. Flip
+      # continue-on-error to false to enforce, once a reformat is agreed.
+      - name: Format check (report-only)
+        continue-on-error: true
+        working-directory: python
+        run: |
+          echo "::group::black"
+          black --check --diff . || true
+          echo "::endgroup::"
+          echo "::group::isort"
+          isort --check-only --diff . || true
+          echo "::endgroup::"
+
+  # The two tests that do not import okg, so they run for anyone -- including
+  # fork PRs that the guarded job skips. Small on purpose: it is a smoke check
+  # that the repo is coherent, not a substitute for the suite.
+  no-substrate:
+    name: substrate-free checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install pytest pyyaml
+      - name: Alignment page and comp-ops lint baseline
+        run: |
+          python -m pytest \
+            python/tests/test_alignment_page.py \
+            python/tests/test_compops_lint_recheck.py -q


### PR DESCRIPTION
## What this changes

Adds CI to the v3 branch line. It had none — only `deploy-docs.yml`, gated on `main` — so every "326 passed" to date came from one shell on one host, while ADR §14 requires CI on `archi_v3` from day one and W0's done-clause requires PACT gates in CI. Stacks on #623 (needs the dev extra it adds).

## Behavior before → after

- Before: no workflow ran on `archi_v3` pushes or PRs.
- After: two jobs. **tests** installs okg from the pinned private fork and runs the full suite on Python 3.12; **substrate-free checks** runs the two tests that don't import okg, so fork PRs still get a signal.

## Security shape (this repo is public, okg is private)

The suite imports okg, so it needs `OKG_REPO_TOKEN`. A secret exposed to a fork PR is readable by anyone who can open one, so:

- the job is guarded on `github.event.pull_request.head.repo.full_name == github.repository`;
- it uses `pull_request`, never `pull_request_target` — that variant runs untrusted code with secrets by design;
- a fork PR **skips** rather than passing, so no green tick is claimed for tests that never ran;
- the install step **fails loudly if the token is absent** instead of degrading into a partial suite that reads as full coverage.

## Decisions encoded, both reversible in one line

- **Python pinned to 3.12.** The package targets 3.12 and black cannot parse the f-strings in `jira.py:465`, `hypernews.py:528`, `indico.py:443` under anything older — that is what made the §10 DoD look broken.
- **black and isort report-only** (`continue-on-error: true`). The tree predates any formatter: black would reformat 58 files, isort flags ~47. The connectors are deliberately kept line-comparable with the frozen canonical `okg-deployments/cms` copies — ~85% of the circle-back bugs were shared with them, and upstream reports cite matching lines. Enforcing now would destroy that. **If you want enforcement instead, flip `continue-on-error` to `false` and merge a reformat commit first** — the relayed instruction was ambiguous between "report-only is fine" and "reformat", so this takes the conservative option.

## Findings

- The relayed claim that only two test files avoid okg is **correct** — I verified it rather than taking it on report: `test_alignment_page.py` and `test_compops_lint_recheck.py` pass under a Python with no okg installed (3 passed). That is why the unguarded job is small; there is no meaningful larger unguarded lane to build.
- The format step runs with `working-directory: python`, so it does not depend on a repo-root `pyproject.toml` — the file W10 deleted, whose absence is what makes a local commit-time lint pass error `No pyproject.toml found`.
- **Not verified by me:** that `OKG_REPO_TOKEN` can read `lucalavezzo/okg` at `f5ec3b58d`. I have no access to the token or the fork; that half was verified by the session that set it up. The first run on this PR is the real test.

## How I verified

- `yaml.safe_load` on the workflow; guard expression inspected.
- `python3 -m pytest python/tests/test_alignment_page.py python/tests/test_compops_lint_recheck.py -q` under a Python where `import okg` raises → **3 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjTTnEB9pAsrLdLsMFtUzL