### PR TITLE
pact: backfill the four unrecorded work packages (W0, W3, W4, W10)

### DIFF
--- a/pact/changes/w0-ratify-and-pin/pact.yaml
+++ b/pact/changes/w0-ratify-and-pin/pact.yaml
@@ -1,0 +1,81 @@
+pact_version: 4
+target_pact_version: 4
+change:
+  id: w0-ratify-and-pin
+  title: 'W0: ratify the ADR, adopt PACT, file the asks, pin the repos'
+  status: proposal
+  rationale: 'Invariant 1 says one PACT change per work package; W0 shipped without
+    one, so the wave that adopted PACT is itself unrecorded in the ledger. This backfills
+    it. Recorded retroactively and honestly: three of the ADR''s four done-clauses
+    now hold, and the fourth is not ours to close. OPEN CLAUSE: R1-R3 owners and dates
+    are unassigned (maintainer''s).'
+  root_cause: Small nontrivial change whose intent, task, acceptance, and proof fit
+    the PACT fast path.
+  tier: 1
+  method_metadata:
+    pact_shape: fast_path
+    fast_path: Compact PACT for small nontrivial work. Upgrade when scope, risk, hierarchy,
+      formal proof, graph evidence, or review complexity increases.
+  affected_areas: []
+  affected_code: []
+requirements:
+- id: req.w0-ratify-and-pin
+  title: 'W0: ratify the ADR, adopt PACT, file the asks, pin the repos'
+  statement: 'The ADR is merged and is the program''s reference; PACT is adopted (pact/project.yaml,
+    the interim archi-pact ledger, openspec archived); the five asks have upstream
+    issue links (okg#1179-#1185, plus #1282/#1283/#1284 for porting frictions); and
+    the suite runs in CI on archi_v3. The remaining ADR clause, owners and dates for
+    R1-R3, is a maintainer assignment and is recorded here as open rather than silently
+    dropped.'
+  evidence_policy:
+    required:
+    - executed_test
+  scenarios:
+  - id: scn.w0-ratify-and-pin.fast-path
+    title: Fast-path work is verified
+    given:
+    - a small nontrivial change fits one requirement
+    when:
+    - the declared verification runs
+    then:
+    - the requirement has executed proof before completion
+    and: []
+  acceptance:
+  - id: acc.w0-ratify-and-pin
+    description: docs/adr/0001-archi-v3-program-spec.md present on archi_v3; pact/project.yaml
+      present with the archi-pact projection; the asks resolvable as okg#1179-#1185;
+      a green CI run on archi_v3 covering the full suite.
+    evidence:
+    - executed_test
+tasks:
+- id: task.w0-ratify-and-pin
+  title: 'W0: ratify the ADR, adopt PACT, file the asks, pin the repos'
+  status: todo
+  verification: gh run view (CI green on archi_v3) + docs/adr/0001-archi-v3-program-spec.md
+    and pact/project.yaml on trunk
+  requirements:
+  - req.w0-ratify-and-pin
+  evidence: []
+  environment: []
+dependencies: []
+test_plan:
+- id: test.req-w0-ratify-and-pin.backfill
+  requirement: req.w0-ratify-and-pin
+  test_id: python/tests
+  evidence:
+  - pytest
+formal: []
+waivers: []
+evidence:
+- id: ev.executed-test.req-w0-ratify-and-pin.20260825T015917752351Z
+  kind: executed_test
+  status: pass
+  refs:
+  - req.w0-ratify-and-pin
+  artifact: python/tests
+  command: gh run view 32799269515
+  summary: "CI on archi_v3 is green (run 32799269515: tests (python 3.12) 326 passed,\
+    \ substrate-free checks 3 passed) \u2014 this was W0's last unmet mechanical clause.\
+    \ ADR merged on archi_v3; pact/project.yaml present; asks resolve to okg#1179-#1185."
+  data:
+    attached_at: '2026-08-25T01:59:17.752378+00:00'

--- a/pact/changes/w10-v2-teardown/pact.yaml
+++ b/pact/changes/w10-v2-teardown/pact.yaml
@@ -1,0 +1,83 @@
+pact_version: 4
+target_pact_version: 4
+change:
+  id: w10-v2-teardown
+  title: 'W10: delete the v2 application from the v3 line'
+  status: proposal
+  rationale: 'Backfills the unrecorded W10 wave. The deletions executed as PR #611
+    without a PACT change and without the LOC delta the ADR and section 10 both require;
+    that number is recorded here. The wave stays open because its done-clause is the
+    section 14 cutover, which does not hold. OPEN BY DESIGN: deletions done; cutover
+    conditions unmet (W7 parity delegated, W9 unstarted).'
+  root_cause: Small nontrivial change whose intent, task, acceptance, and proof fit
+    the PACT fast path.
+  tier: 1
+  method_metadata:
+    pact_shape: fast_path
+    fast_path: Compact PACT for small nontrivial work. Upgrade when scope, risk, hierarchy,
+      formal proof, graph evidence, or review complexity increases.
+  affected_areas: []
+  affected_code: []
+requirements:
+- id: req.w10-v2-teardown
+  title: 'W10: delete the v2 application from the v3 line'
+  statement: 'The superseded v2 application is removed from the archi_v3 line: src/
+    (including data_manager), configs/, tests/, examples/, scripts/, requirements/,
+    the root build files, the v2 CI workflows and the accidentally-committed profiles/w1-scratch.
+    LOC DELTA (the ADR asks for it per PR and #611 did not report it): 433 files changed,
+    39 insertions, 106,475 deletions. v2 continues to serve live deployments from
+    main until cutover. The wave is NOT done: section 14''s cutover conditions require
+    W7 parity - which the maintainer has handed to the comp-ops team - and the W9
+    chat migration, which has not started.'
+  evidence_policy:
+    required:
+    - executed_test
+  scenarios:
+  - id: scn.w10-v2-teardown.fast-path
+    title: Fast-path work is verified
+    given:
+    - a small nontrivial change fits one requirement
+    when:
+    - the declared verification runs
+    then:
+    - the requirement has executed proof before completion
+    and: []
+  acceptance:
+  - id: acc.w10-v2-teardown
+    description: The v3 branch line contains no v2 application code (guarded by python/tests/test_packaging.py::test_v2_tree_removed)
+      AND the section 14 cutover conditions hold.
+    evidence:
+    - executed_test
+tasks:
+- id: task.w10-v2-teardown
+  title: 'W10: delete the v2 application from the v3 line'
+  status: todo
+  verification: pytest python/tests/test_packaging.py -q (v2 tree absent) + section
+    14 cutover conditions (W7 parity, W9 chat) - currently unmet
+  requirements:
+  - req.w10-v2-teardown
+  evidence: []
+  environment: []
+dependencies: []
+test_plan:
+- id: test.req-w10-v2-teardown.backfill
+  requirement: req.w10-v2-teardown
+  test_id: python/tests
+  evidence:
+  - pytest
+formal: []
+waivers: []
+evidence:
+- id: ev.executed-test.req-w10-v2-teardown.20260825T015920482878Z
+  kind: executed_test
+  status: pass
+  refs:
+  - req.w10-v2-teardown
+  artifact: python/tests/test_packaging.py
+  command: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests/test_packaging.py
+    -q
+  summary: 'test_v2_tree_removed asserts src/, setup.py and configs/ are absent from
+    the v3 line. LOC delta of the teardown (PR #611): 433 files, +39 / -106475. Cutover
+    conditions (section 14) remain unmet by design.'
+  data:
+    attached_at: '2026-08-25T01:59:20.482904+00:00'

--- a/pact/changes/w3-hep-schemas/pact.yaml
+++ b/pact/changes/w3-hep-schemas/pact.yaml
@@ -1,0 +1,79 @@
+pact_version: 4
+target_pact_version: 4
+change:
+  id: w3-hep-schemas
+  title: 'W3: HEP schema slices and deployment bridges'
+  status: proposal
+  rationale: >-
+    Backfills the unrecorded W3 wave, and records that its ADR
+    done-clause is FALSE AS WRITTEN rather than quietly re-scoping it. The
+    clause reads: 'the cern-team bundle and the comp-ops instance compose the
+    same files without divergence.' They do not, and cannot today.
+    OPEN BY DESIGN: the ADR done-clause is false as written; see docs/okg-alignment.md.
+  root_cause: Small nontrivial change whose intent, task, acceptance, and proof fit
+    the PACT fast path.
+  tier: 1
+  method_metadata:
+    pact_shape: fast_path
+    fast_path: Compact PACT for small nontrivial work. Upgrade when scope, risk, hierarchy,
+      formal proof, graph evidence, or review complexity increases.
+  affected_areas: []
+  affected_code: []
+requirements:
+- id: req.w3-hep-schemas
+  title: 'W3: HEP schema slices and deployment bridges'
+  statement: >-
+    The schema slices shipped: archi/schemas/operations.yaml and
+    sources.yaml plus schemas/bridges/, deployment-scoped, every class and
+    narrowing single-defined, shipping inside the wheel. The composition
+    clause does NOT hold: the wheel's bridges/operations.yaml cannot be copied
+    verbatim into any instance, because its narrowings lack
+    optional_when_subtypes_missing and catalog load then fails with
+    bridge_subtype_unknown (first failure: documentation_page_references_dataset,
+    child subtype dataset). Both consumers therefore hand-prune, and prune
+    DIFFERENTLY - the cern-team demo keeps only cmssw_release_supersedes_release,
+    while cms-compops prunes the five narrowings owned by the ticket/service/code
+    modules. That is divergence twice over. The fix has precedent in our own
+    tree (bridges/sources.yaml already flags the MONIT narrowings) and is filed
+    upstream as part of okg#1179; this change stays OPEN until a packaged bridge
+    composes without hand-editing.
+  evidence_policy:
+    required:
+    - executed_test
+  scenarios:
+  - id: scn.w3-hep-schemas.fast-path
+    title: Fast-path work is verified
+    given:
+    - a small nontrivial change fits one requirement
+    when:
+    - the declared verification runs
+    then:
+    - the requirement has executed proof before completion
+    and: []
+  acceptance:
+  - id: acc.w3-hep-schemas
+    description: >-
+      A packaged bridge composes on both the cern-team bundle and the
+      cms-compops instance with no hand-pruning, and okg catalog load is green
+      on both from the wheel's files as shipped.
+    evidence:
+    - executed_test
+tasks:
+- id: task.w3-hep-schemas
+  title: 'W3: HEP schema slices and deployment bridges'
+  status: todo
+  verification: "okg catalog load --apply on both consumers using the wheel's bridges/operations.yaml unmodified (currently fails with bridge_subtype_unknown)"
+  requirements:
+  - req.w3-hep-schemas
+  evidence: []
+  environment: []
+dependencies: []
+test_plan:
+- id: test.req-w3-hep-schemas.backfill
+  requirement: req.w3-hep-schemas
+  test_id: python/tests
+  evidence:
+  - pytest
+formal: []
+waivers: []
+evidence: []

--- a/pact/changes/w4-playbooks/pact.yaml
+++ b/pact/changes/w4-playbooks/pact.yaml
@@ -1,0 +1,83 @@
+pact_version: 4
+target_pact_version: 4
+change:
+  id: w4-playbooks
+  title: 'W4: port and de-site-ify the CMS playbooks'
+  status: proposal
+  rationale: 'Backfills the unrecorded W4 wave. The playbooks shipped and one of the
+    ADR''s three done-clauses is evidenced; the other two were never implemented or
+    never run, and are recorded here as open rather than assumed. OPEN CLAUSES: skill_bundle_hash
+    pinning unimplemented; doctor check never run.'
+  root_cause: Small nontrivial change whose intent, task, acceptance, and proof fit
+    the PACT fast path.
+  tier: 1
+  method_metadata:
+    pact_shape: fast_path
+    fast_path: Compact PACT for small nontrivial work. Upgrade when scope, risk, hierarchy,
+      formal proof, graph evidence, or review complexity increases.
+  affected_areas: []
+  affected_code: []
+requirements:
+- id: req.w4-playbooks
+  title: 'W4: port and de-site-ify the CMS playbooks'
+  statement: 'The CMS playbooks are ported and de-site-ified (21 in skills/, symlinked
+    into bundles/cern-team/skills/ and materialised into the wheel), skill_triggers
+    is wired per bundle, and no playbook carries site markers, hostnames or secrets
+    - that last clause is test-enforced. Two ADR clauses do NOT hold: bundle install
+    does not pin a skill_bundle_hash (the mechanism is okg''s; nothing in this repo
+    sets it), and okg doctor --check agent-skills has never been run against an instance.
+    This change stays OPEN until both are either satisfied or consciously dropped
+    from the wave definition.'
+  evidence_policy:
+    required:
+    - executed_test
+  scenarios:
+  - id: scn.w4-playbooks.fast-path
+    title: Fast-path work is verified
+    given:
+    - a small nontrivial change fits one requirement
+    when:
+    - the declared verification runs
+    then:
+    - the requirement has executed proof before completion
+    and: []
+  acceptance:
+  - id: acc.w4-playbooks
+    description: python/tests/test_skills.py green (playbook set, trigger references,
+      no site markers) AND a bundle install that pins skill_bundle_hash AND okg doctor
+      --check agent-skills green on an instance.
+    evidence:
+    - executed_test
+tasks:
+- id: task.w4-playbooks
+  title: 'W4: port and de-site-ify the CMS playbooks'
+  status: todo
+  verification: pytest python/tests/test_skills.py -q (passing) + okg doctor --check
+    agent-skills on a live instance (never run)
+  requirements:
+  - req.w4-playbooks
+  evidence: []
+  environment: []
+dependencies: []
+test_plan:
+- id: test.req-w4-playbooks.backfill
+  requirement: req.w4-playbooks
+  test_id: python/tests
+  evidence:
+  - pytest
+formal: []
+waivers: []
+evidence:
+- id: ev.executed-test.req-w4-playbooks.20260825T015919131561Z
+  kind: executed_test
+  status: pass
+  refs:
+  - req.w4-playbooks
+  artifact: python/tests/test_skills.py
+  command: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests/test_skills.py
+    -q
+  summary: Playbook set, trigger references and the no-site-markers/hostnames/secrets
+    clause are test-enforced and green. The skill_bundle_hash and doctor clauses remain
+    unmet and are stated in the requirement.
+  data:
+    attached_at: '2026-08-25T01:59:19.131587+00:00'

--- a/pact/changes/w4-playbooks/pact.yaml
+++ b/pact/changes/w4-playbooks/pact.yaml
@@ -4,12 +4,12 @@ change:
   id: w4-playbooks
   title: 'W4: port and de-site-ify the CMS playbooks'
   status: proposal
-  rationale: 'Backfills the unrecorded W4 wave. The playbooks shipped and one of the
-    ADR''s three done-clauses is evidenced; the other two were never implemented or
-    never run, and are recorded here as open rather than assumed. OPEN CLAUSES: skill_bundle_hash
-    pinning unimplemented; doctor check never run.'
-  root_cause: Small nontrivial change whose intent, task, acceptance, and proof fit
-    the PACT fast path.
+  rationale: 'Backfills the unrecorded W4 wave. The playbooks shipped and one of the ADR''s
+    three done-clauses is evidenced; the other two were never implemented or never run, and
+    are recorded here as open rather than assumed. OPEN CLAUSES: skill_bundle_hash pinning
+    unimplemented; doctor check never run.'
+  root_cause: Small nontrivial change whose intent, task, acceptance, and proof fit the PACT
+    fast path.
   tier: 1
   method_metadata:
     pact_shape: fast_path
@@ -20,14 +20,20 @@ change:
 requirements:
 - id: req.w4-playbooks
   title: 'W4: port and de-site-ify the CMS playbooks'
-  statement: 'The CMS playbooks are ported and de-site-ified (21 in skills/, symlinked
-    into bundles/cern-team/skills/ and materialised into the wheel), skill_triggers
-    is wired per bundle, and no playbook carries site markers, hostnames or secrets
-    - that last clause is test-enforced. Two ADR clauses do NOT hold: bundle install
-    does not pin a skill_bundle_hash (the mechanism is okg''s; nothing in this repo
-    sets it), and okg doctor --check agent-skills has never been run against an instance.
-    This change stays OPEN until both are either satisfied or consciously dropped
-    from the wave definition.'
+  statement: 'The CMS playbooks are ported and de-site-ified (21 in skills/, symlinked into
+    bundles/cern-team/skills/ and materialised into the wheel), skill_triggers is wired per
+    bundle, and no playbook carries site markers, hostnames or secrets - that clause is test-enforced
+    and green. The other two ADR clauses are MIS-SPECIFIED rather than merely unmet, established
+    by running them. (1) ''bundle install materializes playbooks with skill_bundle_hash pinned'':
+    the hash is computed by okg from the instance''s skills_dir during `okg deployment release`
+    (deployment_release.py:308), which further requires a release.channel the instance does
+    not declare. It is an instance release-lifecycle step, never a distribution or bundle-install
+    one, so no work in this repo can satisfy the clause as worded; skills/README.md claimed
+    otherwise and has been corrected. (2) ''okg doctor --check agent-skills green'': the check
+    RUNS green against the comp-ops instance, but it inspects the okg checkout''s own agent
+    tooling skills (root = the okg repo, 18 skills, targets claude-code and codex), not a
+    deployment''s playbooks - green and irrelevant. This change stays OPEN until the wave
+    definition is re-specified against mechanisms that actually measure playbooks.'
   evidence_policy:
     required:
     - executed_test
@@ -43,17 +49,17 @@ requirements:
     and: []
   acceptance:
   - id: acc.w4-playbooks
-    description: python/tests/test_skills.py green (playbook set, trigger references,
-      no site markers) AND a bundle install that pins skill_bundle_hash AND okg doctor
-      --check agent-skills green on an instance.
+    description: python/tests/test_skills.py green (playbook set, trigger references, no site
+      markers) AND a bundle install that pins skill_bundle_hash AND okg doctor --check agent-skills
+      green on an instance.
     evidence:
     - executed_test
 tasks:
 - id: task.w4-playbooks
   title: 'W4: port and de-site-ify the CMS playbooks'
   status: todo
-  verification: pytest python/tests/test_skills.py -q (passing) + okg doctor --check
-    agent-skills on a live instance (never run)
+  verification: pytest python/tests/test_skills.py -q (passing) + okg doctor --check agent-skills
+    on a live instance (never run)
   requirements:
   - req.w4-playbooks
   evidence: []
@@ -76,8 +82,8 @@ evidence:
   artifact: python/tests/test_skills.py
   command: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests/test_skills.py
     -q
-  summary: Playbook set, trigger references and the no-site-markers/hostnames/secrets
-    clause are test-enforced and green. The skill_bundle_hash and doctor clauses remain
-    unmet and are stated in the requirement.
+  summary: Playbook set, trigger references and the no-site-markers/hostnames/secrets clause
+    are test-enforced and green. The skill_bundle_hash and doctor clauses remain unmet and
+    are stated in the requirement.
   data:
     attached_at: '2026-08-25T01:59:19.131587+00:00'


### PR DESCRIPTION
## What this changes

Invariant 1 says one PACT change per work package. W0, W3, W4 and W10 shipped without one — including W0, the wave that *adopted PACT* — so four waves were invisible in the ledger. This records them, with each ADR done-clause checked against reality rather than assumed. Ledger only; no code.

## Behavior before → after

- Before: the ledger held W1, W2, W6, W7 and the circle-back fixes. Four waves had no change at all, so their done-clauses were neither satisfied nor tracked, and one of them was quietly false.
- After: four changes recorded, three carrying real evidence. **None is gated done, because none of them is.**

## Findings, most severe first

- **W3's done-clause is false as written, and is now recorded as false rather than re-scoped.** It reads "the cern-team bundle and the comp-ops instance compose the same files without divergence". They cannot: the wheel's `schemas/bridges/operations.yaml` fails `okg catalog load` with `bridge_subtype_unknown` when copied verbatim (its narrowings lack `optional_when_subtypes_missing`; first failure `documentation_page_references_dataset` → `dataset`), so **both consumers hand-prune — and prune differently**: the cern-team demo keeps only `cmssw_release_supersedes_release`, cms-compops prunes the five ticket/service/code narrowings. Divergence twice over. Stays open; the fix is filed under okg#1179 and already has precedent in our own `bridges/sources.yaml`.
- **W4 has two unmet clauses that were never flagged**: nothing in this repo pins a `skill_bundle_hash`, and `okg doctor --check agent-skills` has never been run against an instance. The third clause (no hostnames or secrets in playbooks) is test-enforced and green.
- **W10 shipped without the LOC delta the ADR requires per PR** — recorded here: 433 files, +39 / −106,475. It stays open because its done-clause is the §14 cutover, needing W7 parity (delegated to the comp-ops team) and W9 chat (not started).
- **W0 is one clause from done**: ADR merged, PACT adopted, asks filed as okg#1179–#1185, and CI now green on `archi_v3` (run 32799269515) — that was its last mechanical clause. Only R1–R3 ownership remains, which is a maintainer assignment, so it is recorded open rather than dropped.

## How I verified

- Each done-clause read from `docs/adr/0001-archi-v3-program-spec.md` (§9 W0/W3/W4/W10) and checked against the repo: `grep` for `skill_bundle_hash` (absent outside the ADR), `okg doctor --check agent-skills` (exists upstream, never run here), the two divergent pruned bridges, and the #611 diffstat.
- Evidence attached where it genuinely exists: CI run for W0, `test_skills.py` for W4, `test_packaging.py::test_v2_tree_removed` for W10.
- All four manifests validate (`okg pact view --format=manifest`); `pytest python/tests -q` → 326 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjTTnEB9pAsrLdLsMFtUzL