### PR TITLE
fix(schemas): make the operations bridge compose on every consumer (closes W3's false clause)

### DIFF
--- a/docs/cern-team-demo.md
+++ b/docs/cern-team-demo.md
@@ -100,31 +100,25 @@ mkdir -p "$DEP"/schemas/bridges
 cp "$SITE"/schemas/bridges/sources.yaml "$DEP"/schemas/bridges/sources.yaml
 ```
 
-**Do not copy `schemas/bridges/operations.yaml` verbatim** — friction
-found live: the wheel's full operations bridge references subtypes
-owned by substrate modules this bundle does not compose (`dataset`,
-`ticket`, `service`, `repo_starter`, `git_graph`, ...) and its
-narrowings lack `optional_when_subtypes_missing`, so
-`okg catalog load` fails with `bridge_subtype_unknown`
-(first failure: narrowing `documentation_page_references_dataset`,
-child subtype `dataset`). Write a pruned bridge instead; the
-cern-team connectors need exactly one narrowing beyond
-`bridges/sources.yaml`:
+**Copy `schemas/bridges/operations.yaml` verbatim too** — as of the
+portable-bridge fix it composes on this bundle unmodified:
 
-```yaml
-# $DEP/schemas/bridges/operations.yaml
-classes:
-  EdgeNarrowings:
-    description: Archi operations edge narrowings (pruned).
-    annotations:
-      okg_edge_narrowings: "true"
-    attributes:
-      cmssw_release_supersedes_release:
-        annotations:
-          edge_archetype: supersedes
-          src_subtypes: CMSSWRelease
-          dst_subtypes: CMSSWRelease
+```bash
+cp "$SITE"/schemas/bridges/operations.yaml "$DEP"/schemas/bridges/operations.yaml
 ```
+
+This step used to be a hand-written prune. The wheel's operations bridge
+references subtypes owned by substrate modules this bundle does not
+compose (`dataset`, `ticket`, `service`, `repo`, `source_file`, ...) and
+its narrowings lacked `optional_when_subtypes_missing`, so
+`okg catalog load` failed with `bridge_subtype_unknown` (first failure:
+narrowing `documentation_page_references_dataset`, child subtype
+`dataset`). Both this bundle and the comp-ops instance therefore carried
+their own, *differently* pruned copies. The shipped file now flags
+exactly the narrowings whose endpoints vary by consumer, so the composer
+skips those and keeps the rest strict — an accidentally dropped module
+still fails loudly. Regression-tested for both consumers in
+`python/tests/test_bridge_portability.py`.
 
 (Also inherited from W1: narrowings placed outside `schemas/bridges/`
 are silently ignored and only fail at ingest as

--- a/docs/okg-alignment.md
+++ b/docs/okg-alignment.md
@@ -170,8 +170,8 @@ narrowings; install profiles (`OKG_PROFILES_DIR` cascade) for bundles; the close
 | #1184 automation accounting | Matches our kill criterion (defer until >1 real automation) | ADR §7 ask 4 |
 | #1185 end-to-end proof | **Our `cern-team` bundle install demo is this proof** — an external, wheel-installed distribution driven end to end on a SubMIT host. Coordinate before building a synthetic consumer | W1 seam proof (done); demo lands with the bundle work |
 
-**Packaged bridges cannot compose anywhere as shipped — a #1179 blocker with
-two independent instances in our tree.** Copying the wheel's
+**Packaged bridges now compose as shipped — fixed on our side, and the fix is
+worth copying.** (Previously reported here as a #1179 blocker.) Copying the wheel's
 `schemas/bridges/operations.yaml` verbatim fails `okg catalog load` with
 `bridge_subtype_unknown`, because its narrowings lack
 `optional_when_subtypes_missing` and therefore require every referenced subtype
@@ -185,10 +185,18 @@ modules" (`cms-compops docs/bring-up.md:63-67`). **The fix already has
 precedent in our own tree** — `schemas/bridges/sources.yaml` flags exactly this
 case for the MONIT narrowings. Ask, unchanged from the demo's friction log:
 packaged bridges should flag cross-module narrowings
-`optional_when_subtypes_missing`, or ship split per family. Until then a
-distribution cannot ship a bridge that composes on an arbitrary instance, which
-also bears on the sealed-artifact packaging design — a materialised payload that
-still needs hand-pruning at install is not artifact-only.
+`optional_when_subtypes_missing`, or ship split per family. **We have now done
+the former in our own bridge and it works**: flagging only the narrowings whose
+endpoints vary by consumer (18 of 88, covering `Dataset`, `Ticket`, `Service`,
+`Endpoint`, `Repo`, `SourceFile`, `Comment`) makes one shipped file compose
+verbatim for both the cern-team trio and the comp-ops module set — 168 and 201
+narrowings respectively, the latter identical to what its hand-pruned copy
+produced, with lint still clean. Everything both consumers guarantee stays
+strict, so a module dropped by accident still fails loudly rather than silently
+composing fewer narrowings (the okg#1282 hazard). **Suggested for the packaged
+substrate bridges too** — this removes a manual install step and strengthens the
+artifact-only story, since a materialised payload that still needs hand-pruning
+at install is not artifact-only.
 
 Additional substrate friction found while porting, not yet in any issue:
 narrowings outside `schemas/bridges/` silently ignored (lint green, ingest-time

--- a/docs/outbound/DRAFT-okg-deployments-cms-scope-bugs.md
+++ b/docs/outbound/DRAFT-okg-deployments-cms-scope-bugs.md
@@ -1,0 +1,101 @@
+# DRAFT — not sent. For the okg-deployments/cms maintainers.
+
+**Status: draft only.** Filing this on another team's repository is the
+maintainer's call, not an agent's. Nothing here has been sent.
+
+**Subject:** connectors can claim a complete scope after silently losing
+input, which deletes good records
+
+---
+
+## Why we are writing
+
+While porting your `cms/` connectors into the Archi v3 distribution we ran an
+adversarial review over the ported code. It found one recurring defect class
+that destroys data, and **most of the findings apply unchanged to the copies
+still running in `okg-deployments/cms`** — we diffed against `main@f33a9c4`
+and recorded, per finding, whether the bug is shared. We have fixed them on
+our side; you have not been told, and the code is live for your team.
+
+We have **not** run your deployment. Everything below is read from your code
+plus reproductions we wrote against our port, which is line-comparable with
+yours. Treat trigger frequency as our inference, not measurement.
+
+## The failure mode
+
+The substrate deletes records that are missing from a *completed* scope
+(`missing_from_completed_scope`). A connector that loses part of its input —
+a swallowed exception, a truncating cap, an empty API response, a schema
+drift — and still reports `completed_scope=True` therefore tells the
+substrate that everything it did not emit no longer exists. The next
+reconcile retracts those records.
+
+The dangerous property is that every one of these paths reports **healthy**.
+There is no error, no partial status, no warning: an ingest that quietly lost
+90% of its input looks exactly like a successful one.
+
+## What we found in code shared with you
+
+Blockers — silent data loss without an upstream outage:
+
+| Where | What happens |
+|---|---|
+| `cms_sources/hypernews.py` | A per-forum listing failure is swallowed (`except Exception: continue`) while the run reports ok and complete. The failed forum's threads are retracted. |
+| `cms_sources/hypernews.py` | A *total* fetch failure writes an empty `records.json` and claims ok/complete — retract-all — and every later run then replays that poisoned empty cache, so the source never self-heals. |
+| `cms_sources/monit.py` | The rucio-dataset live page cache is keyed on a date-free fingerprint and never invalidated. After one successful run, later runs replay the cached pages with zero HTTP and still claim a complete scope: day 2 publishes day 1's datasets stamped with day 2's date. |
+
+Majors — the same class, narrower triggers:
+
+- `cms_sources/monit.py`: partial OpenSearch responses (`timed_out`, failed
+  shards) accepted as complete; terms-aggregation caps truncate silently
+  (`sum_other_doc_count` never read); a zero-bucket result claims a complete
+  *empty* scope, so an index rename or a stalled pipeline retracts everything.
+- `cms_sources/docs.py`: `max_pages` truncates the sitemap frontier before
+  crawling, then claims a complete scope; non-HTML sitemap entries (PDFs) are
+  regex-stripped into mojibake pages.
+- `cms_sources/jira.py`: the parsed record count is never cross-checked
+  against `meta.json`'s `record_count`, so a truncated-but-valid cache — a
+  fetcher that died mid-pagination — ingests as complete.
+- `cms_sources/siteconf.py`: a token that lost group visibility gets an
+  HTTP-200 empty project list, reported ok and complete → retract-all.
+- `cms_sources/cric.py`: an error-shaped responsibilities payload is read as
+  "no responsibilities" under a complete scope.
+- **Systemic**: item-level parse loops across cmssw / conddb / dbs / dqm /
+  gocdb / wmstats / indico / hypernews silently skip records that are not
+  dicts or lack an expected key. One upstream key rename turns a full cache
+  into zero records with a healthy, complete-scope run.
+
+Minor, same file lineage: truncating caps in `cmssw.py` (`limit`),
+`hypernews.py` (`max_threads`), `siteconf.py` (`max_projects`); `conddb.py`'s
+change probe missing `cmssw_records_path`; `gocdb.py` mis-parsing
+scheme-prefixed endpoints; `indico.py` chunk-id collisions across events;
+`cms_sources/alias.py` case-folding collapsing case-distinct dataset ids.
+
+Not a scope bug but shared and worth knowing: the anonymizer's default email
+pattern leaves the local part behind on real-world addresses
+(`john.doe+ops@cern.ch` → `john.doe+`), so names survive redaction.
+
+## The discipline we applied
+
+Never claim `completed_scope` when any enumerated input failed, was
+truncated, or parsed to nothing from non-empty input. Emitting partial data
+with `completed_scope=False` is fine — claiming completeness is not. Note
+`PREFLIGHT_STATUSES` has no `degraded`; we used the existing partial-crawl
+idiom (`endpoint_failed` + records still emitted + no scope claim).
+
+## Reproductions
+
+Every finding has a regression test that **fails on the pre-fix code**, which
+is the cheapest way for you to confirm a given bug exists in your copy: the
+tests are written against the ported connectors, which are line-comparable
+with yours. See `python/tests/sources/` and `python/tests/tools/` in
+`archi-physics/archi@archi_v3`, and the per-finding writeups in
+`pact/archive/circleback-fixes/notes-{catalogs,live,enrichment}.md`, which
+record for each item whether it is shared with canonical.
+
+## What we are asking
+
+Nothing, beyond awareness. You may want the fixes, or your own; you may
+decide some triggers cannot occur in your deployment. We would rather you
+make that call knowing than not. If it is useful we can open PRs against
+`okg-deployments/cms` with the fixes and their tests — say the word.

--- a/docs/outbound/DRAFT-okg-pact-reporting-defects.md
+++ b/docs/outbound/DRAFT-okg-pact-reporting-defects.md
@@ -1,0 +1,70 @@
+# DRAFT — not sent. Two PACT reporting defects for the okg maintainers.
+
+**Status: draft only.** Filing is the maintainer's call; nothing has been sent.
+
+Both are reporting bugs, not logic bugs — the underlying state machine was
+right every time. They are filed together because they share a failure mode:
+**a view that disagrees with the state it is reporting on**, which is worse
+than no view at all. In one working day these two produced four wrong
+statements about programme state across two independent agent sessions, each
+of which had to be corrected by a third check against the artifact.
+
+## 1. `--format=review-queue` lists retired changes as awaiting a decision
+
+`okg pact view --format=review-queue` reported "3 change(s) awaiting a
+decision", and all three were `state: retired`. A retired change cannot await
+a decision.
+
+Observed on our interim ledger deployment with three changes retired by an
+operator's `okg pact decide --verdict approve`. Two sessions reading the same
+command minutes apart drew opposite conclusions about whether the queue was
+empty — one reported "all approved, queue empty", the other "three awaiting
+approval". Both were reading the tool correctly.
+
+Reliable alternative, for anyone hitting this: `okg pact view <id>
+--format=status` per change reports `state` truthfully, and
+`--format=list --status all` agrees with it.
+
+## 2. `evidence_gaps: []` while `derived_state.reason` says gaps remain
+
+The same status payload can contain:
+
+```yaml
+evidence_gaps: []
+missing_evidence: []
+derived_state:
+  state: in_progress
+  reason: "tasks terminal but evidence gaps remain"
+```
+
+Both gap lists empty, and the reason says gaps remain. There is no way to
+find the cause from any view — we had to call `manifest_condition()` and
+`staleness_report()` directly against the manifest to learn that
+`evidence_satisfied` was false because the **scope-drift guard** had revoked
+every requirement's evidence: a merge had touched the declared scope after the
+evidence was recorded, so it stopped counting (`review.py:146-165`).
+
+The guard is correct and, we think, well designed — evidence that predates a
+change to the scope it covers *should* stop counting. The defect is purely
+that the reason string promises a gap list which the gap fields do not
+contain, so the operator is told there is a problem and given nothing to act
+on. Surfacing the revocation — the requirement ids, the `code_changed_at`, the
+evidence ids revoked — would have turned a two-session diagnosis into one
+command.
+
+## A consequence worth stating, if it is not already tracked
+
+Because the guard is scope-based, **any change touching a path revokes the
+evidence of every other open change whose declared scope covers that path**.
+The widest-scoped change in a programme therefore accrues a re-evidencing bill
+that grows with every unrelated merge, and can be blocked indefinitely by
+other people's work. That is defensible behaviour, but it makes leaving
+changes open expensive in a way nothing currently warns about. A hint in the
+status output — "N requirements' evidence revoked by commits since
+<timestamp>" — would make the cost visible while it is still cheap to pay.
+
+## Environment
+
+okg `dev` @ `f5ec3b58d`, PACT v4, external consumer repo
+(`archi-physics/archi@archi_v3`) with the interim `archi-pact` ledger
+deployment. Both reproduced repeatedly across a working day.

--- a/python/archi/schemas/bridges/operations.yaml
+++ b/python/archi/schemas/bridges/operations.yaml
@@ -142,6 +142,7 @@ classes:
           edge_archetype: references
           src_subtypes: DocumentationPage
           dst_subtypes: Dataset
+          optional_when_subtypes_missing: 'true'
 
       documentation_page_references_workflow:
         annotations:
@@ -197,6 +198,7 @@ classes:
           edge_archetype: references
           src_subtypes: ForumThread
           dst_subtypes: Dataset
+          optional_when_subtypes_missing: 'true'
 
       forum_thread_references_workflow:
         annotations:
@@ -259,6 +261,7 @@ classes:
           edge_archetype: references
           src_subtypes: MeetingMinutes
           dst_subtypes: Dataset
+          optional_when_subtypes_missing: 'true'
 
       meeting_minutes_references_workflow:
         annotations:
@@ -307,6 +310,7 @@ classes:
           edge_archetype: references
           src_subtypes: Document
           dst_subtypes: Dataset
+          optional_when_subtypes_missing: 'true'
 
       document_references_workflow:
         annotations:
@@ -339,24 +343,28 @@ classes:
           edge_archetype: references
           src_subtypes: SoftwareRepository
           dst_subtypes: Repo
+          optional_when_subtypes_missing: 'true'
 
       service_exposes_infrastructure_service:
         annotations:
           edge_archetype: exposes
           src_subtypes: Service
           dst_subtypes: InfrastructureService
+          optional_when_subtypes_missing: 'true'
 
       infrastructure_service_exposes_endpoint:
         annotations:
           edge_archetype: exposes
           src_subtypes: InfrastructureService
           dst_subtypes: Endpoint
+          optional_when_subtypes_missing: 'true'
 
       jira_issue_references_ticket:
         annotations:
           edge_archetype: references
           src_subtypes: JiraIssue
           dst_subtypes: Ticket
+          optional_when_subtypes_missing: 'true'
 
       jira_issue_references_site:
         description: JIRA issue inherits site mentions from its text chunks.
@@ -399,6 +407,7 @@ classes:
           edge_archetype: references
           src_subtypes: JiraIssue
           dst_subtypes: Dataset
+          optional_when_subtypes_missing: 'true'
 
       jira_issue_references_workflow:
         description: JIRA issue inherits workflow mentions from its text chunks.
@@ -419,6 +428,7 @@ classes:
           edge_archetype: has_comment
           src_subtypes: JiraIssue
           dst_subtypes: Comment
+          optional_when_subtypes_missing: 'true'
 
       jira_issue_affects_site:
         annotations:
@@ -473,18 +483,21 @@ classes:
           edge_archetype: consumes
           src_subtypes: Workflow
           dst_subtypes: Dataset
+          optional_when_subtypes_missing: 'true'
 
       workflow_produces_dataset:
         annotations:
           edge_archetype: produces
           src_subtypes: Workflow
           dst_subtypes: Dataset
+          optional_when_subtypes_missing: 'true'
 
       dataset_derived_from_dataset:
         annotations:
           edge_archetype: derives_from
           src_subtypes: Dataset
           dst_subtypes: Dataset
+          optional_when_subtypes_missing: 'true'
 
       document_derived_from_source_file:
         description: A parsed Document derives from its filesystem source file (doc-corpus).
@@ -492,6 +505,7 @@ classes:
           edge_archetype: derived_from
           src_subtypes: Document
           dst_subtypes: SourceFile
+          optional_when_subtypes_missing: 'true'
 
       # storage_endpoint_hosts_dataset / site_hosts_dataset: see
       # archi/schemas/bridges/sources.yaml (single definition, landed
@@ -544,18 +558,21 @@ classes:
           edge_archetype: references
           src_subtypes: DataCertification
           dst_subtypes: Dataset
+          optional_when_subtypes_missing: 'true'
 
       transfer_job_consumes_dataset:
         annotations:
           edge_archetype: consumes
           src_subtypes: TransferJob
           dst_subtypes: Dataset
+          optional_when_subtypes_missing: 'true'
 
       transfer_job_produces_dataset:
         annotations:
           edge_archetype: produces
           src_subtypes: TransferJob
           dst_subtypes: Dataset
+          optional_when_subtypes_missing: 'true'
 
       # site_hosts_transfer_job / transfer_site_to_site /
       # site_hosts_monitoring_snapshot: see
@@ -579,6 +596,7 @@ classes:
           edge_archetype: references
           src_subtypes: DocumentChunk
           dst_subtypes: Dataset
+          optional_when_subtypes_missing: 'true'
 
       chunk_references_workflow:
         annotations:

--- a/python/tests/test_bridge_portability.py
+++ b/python/tests/test_bridge_portability.py
@@ -1,0 +1,99 @@
+"""The shipped bridges must compose verbatim on every consumer.
+
+W3's done-clause is "the cern-team bundle and the comp-ops instance compose the
+same files without divergence". Before this test both consumers hand-pruned
+`bridges/operations.yaml` -- and pruned *differently* -- because narrowings
+whose endpoint subtypes come from modules a consumer does not load raised
+`bridge_subtype_unknown` at catalog load.
+
+`optional_when_subtypes_missing: 'true'` makes the composer skip such a
+narrowing instead of failing (modules_compose.py: the row is never appended, so
+it never reaches `_validate_narrowing_subtypes`). It is applied ONLY to
+narrowings whose endpoints genuinely vary between consumers; everything whose
+subtypes both consumers guarantee stays strict, so a module dropped by accident
+still fails loudly rather than silently composing fewer narrowings.
+"""
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytest.importorskip("okg")
+from okg.substrate.catalog.modules_compose import (  # noqa: E402
+    _pascal_to_snake,
+    compose_catalog,
+)
+
+SCHEMAS = Path(__file__).resolve().parents[1] / "archi" / "schemas"
+
+# The two real consumers of the wheel's schema slices.
+CERN_TEAM_MODULES = ["document_starter", "person", "extraction"]
+COMPOPS_MODULES = ["document_starter", "person", "extraction", "dataset", "repo_starter"]
+
+
+def _compose(modules: list[str]):
+    tmp = Path(tempfile.mkdtemp())
+    try:
+        dep = tmp / "probe"
+        (dep / "schemas" / "bridges").mkdir(parents=True)
+        for name in ("operations.yaml", "sources.yaml"):
+            shutil.copy(SCHEMAS / name, dep / "schemas" / name)
+            shutil.copy(SCHEMAS / "bridges" / name, dep / "schemas" / "bridges" / name)
+        (dep / "deployment.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "name": "probe",
+                    "postgres": {"dsn": "postgresql://unused/probe"},
+                    "schema_dir": "schemas",
+                    "modules": modules,
+                }
+            )
+        )
+        return compose_catalog(dep)
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+@pytest.mark.parametrize(
+    "modules,label",
+    [(CERN_TEAM_MODULES, "cern-team"), (COMPOPS_MODULES, "cms-compops")],
+)
+def test_shipped_bridges_compose_unmodified(modules, label):
+    """No hand-pruning: the wheel's files as shipped, for both module sets."""
+    composed = _compose(modules)
+    assert composed.narrowings, f"{label} composed no narrowings"
+
+
+def test_compops_superset_gains_narrowings():
+    """The consumer that loads more modules gets strictly more narrowings --
+    proving the flag skips only what is genuinely absent rather than dropping
+    narrowings wholesale."""
+    cern = _compose(CERN_TEAM_MODULES)
+    compops = _compose(COMPOPS_MODULES)
+    assert len(compops.narrowings) > len(cern.narrowings)
+    assert set(cern.subtypes) <= set(compops.subtypes)
+
+
+def test_flag_is_scoped_to_varying_endpoints_only():
+    """Everything both consumers guarantee stays strict, so an accidentally
+    dropped module still fails loudly (the okg#1282 hazard: a silently skipped
+    narrowing surfaces later as an ingest-time ProducerPolicyViolation)."""
+    guaranteed = set(_compose(CERN_TEAM_MODULES).subtypes) & set(
+        _compose(COMPOPS_MODULES).subtypes
+    )
+    doc = yaml.safe_load((SCHEMAS / "bridges" / "operations.yaml").read_text())
+    over_flagged = []
+    for name, attr in doc["classes"]["EdgeNarrowings"]["attributes"].items():
+        ann = attr.get("annotations", {})
+        if not ann.get("optional_when_subtypes_missing"):
+            continue
+        endpoints = [
+            e.strip()
+            for e in f"{ann.get('src_subtypes','')},{ann.get('dst_subtypes','')}".split(",")
+            if e.strip()
+        ]
+        if all(_pascal_to_snake(e) in guaranteed for e in endpoints):
+            over_flagged.append(name)
+    assert not over_flagged, f"flag applied where both consumers guarantee the subtypes: {over_flagged}"

--- a/skills/README.md
+++ b/skills/README.md
@@ -10,7 +10,11 @@ paths, credentials, and deployment names were removed while the CMS domain
 content — which is the product — was kept intact. An instance wires them in
 through its `deployment.yaml`: `skills_dir` points at the installed copy of
 this directory, `skill_triggers` maps question intents to skills (the shipped
-default mapping is `skill-triggers.yaml` alongside this file), and the bundle
-install pins the exact content via `skill_bundle_hash`. Agents read skills;
+default mapping is `skill-triggers.yaml` alongside this file). Content pinning
+via `skill_bundle_hash` is **not** done by the bundle install, contrary to what
+this file used to claim: the hash is computed by okg from the instance's
+`skills_dir` when an operator runs `okg deployment release`, which additionally
+requires a `release.channel` in the instance manifest. It is an instance
+release-lifecycle step, not a distribution one. Agents read skills;
 they have no write path to them — any runtime skill-write tool is rejected by
 construction (ADR 0001, invariant 11).


### PR DESCRIPTION
## What this changes

W3's done-clause is *"the cern-team bundle and the comp-ops instance compose the same files without divergence"*. It was false: neither consumer could copy the wheel's `schemas/bridges/operations.yaml`, so both carried hand-pruned copies — and pruned **differently**. This makes the shipped file compose for both, unmodified.

## Behavior before → after

- Before: `okg catalog load` failed with `bridge_subtype_unknown` on any narrowing whose endpoint subtype came from a module the consumer doesn't load. cern-team's runbook said *"do not copy verbatim"* and hand-wrote a one-narrowing bridge; cms-compops committed a copy with the ticket/service/code narrowings pruned.
- After: one shipped file, copied verbatim by both. cern-team composes 168 narrowings, cms-compops 201.

## How the fix is scoped, and why that matters

`optional_when_subtypes_missing: 'true'` makes the composer skip a narrowing whose endpoints aren't composed instead of raising. I applied it to **18 of 88** narrowings — exactly those whose endpoints vary between consumers (`Dataset`, `Ticket`, `Service`, `Endpoint`, `Repo`, `SourceFile`, `Comment`), computed from the intersection of what both module sets actually compose rather than by eye.

Everything both consumers guarantee stays **strict**. That is deliberate: blanket-flagging would trade a loud compose-time error for silent omission, and a silently skipped narrowing resurfaces later as an ingest-time `ProducerPolicyViolation` — the okg#1282 hazard. `test_flag_is_scoped_to_varying_endpoints_only` fails if anyone over-applies it later.

The pattern isn't new: `bridges/sources.yaml` already used it for the MONIT narrowings. It had been applied to one bridge and not the other.

## Findings

- **This was ours to fix, not an okg#1179 ask.** Both sessions had been treating it as something to request upstream. The mechanism was already in our own tree.
- **Still worth sending upstream as a suggestion**, now with evidence: the same flag would let okg's own packaged bridges compose by default. Recorded in the #1179 row of `docs/okg-alignment.md`, reframed from blocker to fixed-here-and-copyable.
- **W3's clause becomes satisfiable.** PR #626 records it as false; that entry should be updated when both land — the divergence it describes is now gone.

## How I verified

- Read `modules_compose.py` to confirm the flag's semantics before building: the flagged row is never appended, so it never reaches `_validate_narrowing_subtypes`. My first patch attempt was wrong (my snake-case conversion mangled `CMSSWRelease`); reverted and redone with okg's own `_pascal_to_snake`.
- Composed both module sets from the shipped files: **before** — cern-team fails on `documentation_page_references_dataset`, cms-compops fails on `service_exposes_infrastructure_service` (different first failures, i.e. the divergence); **after** — both compose.
- **On the live comp-ops instance**: replaced its pruned copy with the shipped file, re-claimed and loaded → `narrowing_count: 201`, *identical to the pruned copy*, `deployment lint` still zero blocker/warning. Pushed as `cms-compops@archi_v3` `6977440`.
- `pytest python/tests -q` → **330 passed** (326 + 4 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjTTnEB9pAsrLdLsMFtUzL