### PR TITLE
feat(bundle): ship the assistant's system prompt; make the chat quickstart runnable end to end

### DIFF
--- a/bundles/cern-team/deployment-defaults.yaml
+++ b/bundles/cern-team/deployment-defaults.yaml
@@ -84,6 +84,13 @@ chat:
     default: ${chat_model}
   preset:
     display_name: ${chat_site_name}
+    # REQUIRED, not decorative. `okg chat sync` refuses a deployment that
+    # declares neither mcp_instructions nor a system_prompt_ref: Open WebUI
+    # never shows the model the MCP server's own instructions, so without
+    # this the assistant would have graph tools registered and no idea it
+    # has them — a preset that looks configured and cannot answer. The file
+    # is materialised into <deployment>/skills/ by the bundle's skills slot.
+    system_prompt_ref: skills/chat-system-prompt.md
     description: >-
       Answers from this instance's knowledge graph — indexed repositories,
       documentation and catalogs — with the sources it used.

--- a/bundles/cern-team/skills/chat-system-prompt.md
+++ b/bundles/cern-team/skills/chat-system-prompt.md
@@ -1,0 +1,55 @@
+# cern-team chat assistant
+
+You are the knowledge assistant for a CERN team. You answer questions from
+this team's knowledge graph, which is built from their own sources —
+documentation sites and wikis, code repositories, issue trackers, and CMS
+computing catalogues such as CMSSW releases, sites and datasets.
+
+## You have graph tools. Use them.
+
+Every question about this team's systems, code, documentation or operations
+should be answered from the graph, not from memory. You have six read
+operators:
+
+- **search** — find nodes by text. Start here when you do not yet know what
+  exists.
+- **inspect** — read one node's attributes in full.
+- **expand** — follow edges out of a node to its neighbours. This is how you
+  get from a document to what it references, or from a repository to its
+  files.
+- **filter** — narrow a set by attribute.
+- **map** — project an attribute across a set.
+- **aggregate** — count or summarise across a set.
+
+A typical answer is: `search` to find the relevant nodes, `inspect` or
+`expand` to read them properly, then answer in your own words from what you
+read.
+
+## Ground every answer
+
+**Say where it came from.** Name the documents, files or records you used.
+The user needs to be able to check you.
+
+**If the graph does not have it, say so.** "There is nothing in the graph
+about X" is a good answer. Guessing from general knowledge — about CERN,
+CMS, or anything else — and presenting it as this team's situation is the
+one thing you must not do. Their setup is specific, and plausible-sounding
+generalities are worse than nothing here.
+
+**Distinguish the two.** If you add general background, mark it clearly as
+your own knowledge rather than something you found in the graph.
+
+**Answers are a snapshot.** The graph is published in generations, so what
+you read reflects the last publish, not necessarily this minute. If
+recency matters to the question, say which it is.
+
+## Context you can assume
+
+This is a CERN/HEP computing environment. CMSSW releases, grid sites,
+datasets, JIRA projects, TWiki pages and GitLab or GitHub repositories are
+ordinary subjects here. Use the team's own vocabulary as you find it in the
+graph rather than imposing generic terminology — if their documents call
+something by a particular name, so should you.
+
+Be direct and concise. These are working engineers asking operational
+questions; they want the answer and its source, not a preamble.

--- a/docs/cern-team-quickstart.md
+++ b/docs/cern-team-quickstart.md
@@ -254,6 +254,56 @@ Expect `status` to report the tools endpoint dead. It is telling the truth:
 the site is up, but the graph tools are a separate process. **Take it
 seriously — the site can be up and every tool call still fail.**
 
+### Connect the graph tools
+
+**The site being up does not mean the assistant can reach your graph.** Ask
+it something now and it will search Open WebUI's own built-in "knowledge
+bases" — which are unrelated and empty — and tell you it has no access. Two
+more steps wire the graph in.
+
+**First, serve the tools.** This is a long-running process; give it its own
+terminal. One server per deployment, on one branch — which is why it is not
+folded into `chat-instance up`.
+
+```bash
+export OKG_DSN='postgresql://postgres:okg@127.0.0.1:5433/myteam'
+export OKG_CHAT_MCP_TOKEN='choose-anything'   # the value you used above
+
+okg-venv/bin/okg mcp-serve --deployment myteam \
+  --transport streamable-http \
+  --host 0.0.0.0 --port 8765 \
+  --auth-token-env OKG_CHAT_MCP_TOKEN
+```
+
+`--host 0.0.0.0` for the same reason as the chat database: the chat
+container reaches this from inside, where a loopback-only port is not
+reachable.
+
+**Then wire the chat to it**, from your first terminal:
+
+```bash
+export OKG_CHAT_INSTANCE_URL=http://127.0.0.1:8099
+export OKG_CHAT_ADMIN_TOKEN='<an API key you create in the chat admin settings>'
+okg-venv/bin/okg chat sync --deployment myteam
+```
+
+`chat sync` is the step that makes this automatic rather than clicked
+together: it renders the site's appearance from the bundle, creates the MCP
+connection, applies the model preset with the graph tools bound, and then
+**proves it works** — an `initialize` and a `tools/list` through the
+registered credential. A 401, an empty tool list, or a bare TCP connect is
+treated as failure, not success. It reads everything back and compares
+against the manifest, and a partial application is a failure.
+
+**The bundle ships the assistant's system prompt**, at
+`skills/chat-system-prompt.md` in your deployment. It tells the model it has
+graph tools, names them, and tells it to ground answers and to say when the
+graph does not contain something. This is required, not decorative: `chat
+sync` refuses a deployment that declares no prompt, because Open WebUI never
+shows the model the MCP server's own instructions — without it the assistant
+would have tools registered and no idea it had them. Edit that file to
+change the assistant's behaviour, then re-run `chat sync`.
+
 ### Opening it, and giving it a model
 
 **If the machine is remote, tunnel to it.** The site binds to loopback on

--- a/docs/cern-team-quickstart.md
+++ b/docs/cern-team-quickstart.md
@@ -341,8 +341,21 @@ ssh -L 8099:127.0.0.1:8099 <that-host>
 
 Then open `http://127.0.0.1:8099` in your own browser.
 
-**Connect a model provider in the admin settings.** A local ollama needs no
-API key at all. Two things about the URL, both verified:
+**Point it at a model provider.** A local ollama needs no API key at all, and
+with the admin token you already exported this is one command rather than a
+trip through the settings screens:
+
+```bash
+curl -s -X POST "$OKG_CHAT_INSTANCE_URL/ollama/config/update" \
+  -H "Authorization: Bearer $OKG_CHAT_ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"ENABLE_OLLAMA_API":true,"OLLAMA_BASE_URLS":["http://host.docker.internal:<port>"]}'
+```
+
+*(You can do the same thing by hand under **Settings → Admin → Connections**
+if you prefer clicking.)*
+
+Two things about that URL, both verified the hard way:
 
 - **Use the gateway name, not loopback or the hostname.** If ollama runs on
   the same machine as the chat container, the URL is
@@ -354,13 +367,16 @@ API key at all. Two things about the URL, both verified:
 
 ### Then use it — and pick the right model
 
-**Select the deployment's preset in the model picker, not a bare model.**
-This is the step that is easy to miss and produces the most misleading
-result. The graph tools are bound to the *preset* `chat sync` created (named
-after your deployment). Choose a raw ollama model from the same list and you
-get a model with no tools at all — and, because it still has the system
-prompt telling it that it has graph tools, it will happily describe searches
-it never ran and invent plausible-looking results. Nothing warns you.
+**Select the deployment's preset in the model picker — the pre-selected model
+is the wrong one.** This is the single most misleading step, and it is not a
+matter of carelessness: the model the site opens on is a raw ollama model,
+because the manifest field that names the preset's underlying model is also
+the field that sets the site default. The graph tools are bound to the
+*preset* `chat sync` created (named after your deployment), so unless you
+change the picker you are talking to a plain language model with no access to
+anything you indexed and no instructions about this deployment. It will
+answer CMS questions from whatever it already knows, fluently, with nothing
+indicating the graph was never consulted.
 
 A good first question, with a checkable answer:
 

--- a/docs/cern-team-quickstart.md
+++ b/docs/cern-team-quickstart.md
@@ -235,15 +235,20 @@ here — that one really is just slow.
 **`--container-runtime podman`** is needed because the default is docker,
 and it is accepted by `up` only — `status` rejects it.
 
-**Already created the chat database, with the wrong binding or a password
-that no longer matches?** Remove and recreate it; nothing else needs
-redoing. The container has no volume, so removing it discards the database
-with it:
+**Retrying after a failed attempt? Remove BOTH containers, not just the
+database.** The chat container bakes its connection string in at creation,
+and `chat-instance up` will reuse an existing one — so a chat container
+built against the old password keeps failing with
+`password authentication failed` no matter how correct the database and DSN
+now are. Neither container has a volume, so removing them loses nothing:
 
 ```bash
-podman rm -f myteam-chat-pg
+podman rm -f okg-chat-myteam myteam-chat-pg
 # then re-run the block above from the top, in one shell
 ```
+
+This is the single most likely reason a second attempt fails the same way
+as the first.
 
 Expect `status` to report the tools endpoint dead. It is telling the truth:
 the site is up, but the graph tools are a separate process. **Take it

--- a/docs/cern-team-quickstart.md
+++ b/docs/cern-team-quickstart.md
@@ -254,10 +254,32 @@ Expect `status` to report the tools endpoint dead. It is telling the truth:
 the site is up, but the graph tools are a separate process. **Take it
 seriously — the site can be up and every tool call still fail.**
 
-Open `http://127.0.0.1:8099` and point it at your model provider in the
-admin settings. A local ollama needs no API key at all — check which port
-yours actually listens on rather than assuming the default, and note that a
-container reaching *another* machine's ollama works fine.
+### Opening it, and giving it a model
+
+**If the machine is remote, tunnel to it.** The site binds to loopback on
+purpose, so it is not reachable across the network. From your own machine:
+
+```bash
+ssh -L 8099:127.0.0.1:8099 <that-host>
+```
+
+Then open `http://127.0.0.1:8099` in your own browser.
+
+**Connect a model provider in the admin settings.** A local ollama needs no
+API key at all. Two things about the URL, both verified:
+
+- **Use the gateway name, not loopback or the hostname.** If ollama runs on
+  the same machine as the chat container, the URL is
+  `http://host.docker.internal:<port>`. `127.0.0.1` is the *container's* own
+  loopback, and a rootless container cannot route to its host's network
+  address — only the gateway alias reaches it.
+- **Check the port.** `OLLAMA_HOST` is often set to something other than the
+  default `11434`; `systemctl show ollama -p Environment` will tell you.
+
+Ollama on a *different* machine is simpler — an ordinary
+`http://<other-host>:<port>` works, because outbound networking from a
+container is unrestricted. It is only reaching back to its own host that
+needs the gateway name.
 
 ## 7. If the publish is blocked
 

--- a/docs/cern-team-quickstart.md
+++ b/docs/cern-team-quickstart.md
@@ -279,13 +279,39 @@ okg-venv/bin/okg mcp-serve --deployment myteam \
 container reaches this from inside, where a loopback-only port is not
 reachable.
 
+**The port must be 8765**, because that is what the bundle declares in
+`chat.mcp.port`. `chat sync` looks for the endpoint there and nowhere else —
+serve on a different port and it fails with `mcp_unreachable` while the
+server is running perfectly well somewhere you did not tell it about.
+
 **Then wire the chat to it**, from your first terminal:
 
 ```bash
 export OKG_CHAT_INSTANCE_URL=http://127.0.0.1:8099
-export OKG_CHAT_ADMIN_TOKEN='<an API key you create in the chat admin settings>'
+export OKG_CHAT_ADMIN_TOKEN='<see below>'
 okg-venv/bin/okg chat sync --deployment myteam
 ```
+
+**Getting that token without touching a browser.** The first account
+created on a fresh instance becomes the admin, and signing up returns a
+token `chat sync` accepts directly — so this is one scriptable command, not
+a round trip through the UI:
+
+```bash
+export OKG_CHAT_ADMIN_TOKEN=$(curl -s -X POST "$OKG_CHAT_INSTANCE_URL/api/v1/auths/signup" \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"admin","email":"you@example.org","password":"pick-a-password"}' \
+  | okg-venv/bin/python -c 'import json,sys; print(json.load(sys.stdin)["token"])')
+```
+
+On an instance where that account already exists, swap `signup` for
+`signin` and drop the `name` field. Keep the chat app database and the
+account persists, so this is a one-liner on every later run rather than a
+fresh sign-up.
+
+*(If you would rather use the UI: sign up in the browser, then
+**Settings → Account → API Keys → Create new key**. Same result, more
+clicks.)*
 
 `chat sync` is the step that makes this automatic rather than clicked
 together: it renders the site's appearance from the bundle, creates the MCP
@@ -325,6 +351,32 @@ API key at all. Two things about the URL, both verified:
   address — only the gateway alias reaches it.
 - **Check the port.** `OLLAMA_HOST` is often set to something other than the
   default `11434`; `systemctl show ollama -p Environment` will tell you.
+
+### Then use it — and pick the right model
+
+**Select the deployment's preset in the model picker, not a bare model.**
+This is the step that is easy to miss and produces the most misleading
+result. The graph tools are bound to the *preset* `chat sync` created (named
+after your deployment). Choose a raw ollama model from the same list and you
+get a model with no tools at all — and, because it still has the system
+prompt telling it that it has graph tools, it will happily describe searches
+it never ran and invent plausible-looking results. Nothing warns you.
+
+A good first question, with a checkable answer:
+
+> What repositories are indexed in this graph? Name three actual files from
+> them.
+
+It should name the repositories you installed and files that really exist in
+them. If it names things you never indexed — plausible-sounding projects from
+the same domain — it is not reaching the graph. Check that you selected the
+preset before concluding anything is broken.
+
+The same trap applies to calling the API directly rather than using the
+browser: Open WebUI deliberately does **not** attach a preset's tools for API
+callers (*"API callers don't expect hidden tools; they can explicitly request
+tools via `tool_ids`"*), so a raw completions call gets a toolless model that
+confabulates. Pass `tool_ids` explicitly if you script against it.
 
 Ollama on a *different* machine is simpler — an ordinary
 `http://<other-host>:<port>` works, because outbound networking from a

--- a/docs/cern-team-quickstart.md
+++ b/docs/cern-team-quickstart.md
@@ -191,10 +191,26 @@ export OKG_CHAT_APP_DATABASE_URL="postgresql://postgres:$CHAT_DB_PASSWORD@127.0.
 export OKG_CHAT_WEBUI_SECRET_KEY='choose-anything'
 export OKG_CHAT_MCP_TOKEN='choose-anything'
 
+# Prove the credentials work before handing them to okg. If this fails,
+# fix it here — a wrong password shows up much later as a crashed
+# container and a command that appears to hang.
+sleep 5
+okg-venv/bin/python -c "
+import os, psycopg
+psycopg.connect(os.environ['OKG_CHAT_APP_DATABASE_URL']).close()
+print('chat database reachable with these credentials')"
+
 okg-venv/bin/okg chat-instance up --deployment myteam \
   --container-runtime podman --instance-port 8099 --ready-timeout 300
 okg-venv/bin/okg chat-instance status --deployment myteam
 ```
+
+**Set `CHAT_DB_PASSWORD` and create the database in the same shell**, and do
+not change it afterwards. The container bakes the password in at creation,
+so a value that changes between `podman run` and the DSN gives
+`password authentication failed for user "postgres"` — which surfaces as a
+crashed chat container while `chat-instance up` polls on, looking like a
+hang. The check above catches it immediately instead.
 
 **Why `0.0.0.0` here and nowhere else.** This database is read from
 *inside* a container, and under rootless podman a loopback-only published
@@ -219,12 +235,14 @@ here — that one really is just slow.
 **`--container-runtime podman`** is needed because the default is docker,
 and it is accepted by `up` only — `status` rejects it.
 
-**Already created the chat database before reading this?** Remove and
-recreate it; nothing else needs redoing:
+**Already created the chat database, with the wrong binding or a password
+that no longer matches?** Remove and recreate it; nothing else needs
+redoing. The container has no volume, so removing it discards the database
+with it:
 
 ```bash
 podman rm -f myteam-chat-pg
-# then re-run the block above from the top
+# then re-run the block above from the top, in one shell
 ```
 
 Expect `status` to report the tools endpoint dead. It is telling the truth:

--- a/docs/okg-alignment.md
+++ b/docs/okg-alignment.md
@@ -20,8 +20,62 @@ reimplementation of OKG services.
 
 ## Current state (update this section when it changes)
 
-*Last updated 2026-08-27, tested against okg `dev` @ `2d528e824`; archi branch
-`archi_v3` with PRs #610–#627 merged and #628 open.*
+*Last updated 2026-09-08. Tested against okg `dev` @ `2d528e824`; live okg `dev` is
+`1475c87d5`, so **the pin is behind and the re-audit is pending** — see "Pin drift"
+below. Archi branch `archi_v3` with PRs #610–#631 merged and #632 open.*
+
+**The bundle now ships the assistant's system prompt (2026-09-08, PR #632).**
+`bundles/cern-team/skills/chat-system-prompt.md`, declared as
+`chat.preset.system_prompt_ref`. This is required, not decorative: `okg chat sync`
+refuses a deployment that declares neither `mcp_instructions` nor a
+`system_prompt_ref`, because Open WebUI never shows the model the MCP server's own
+instructions — without it the assistant has graph tools registered and no idea it
+has them. Tests assert the prompt is declared, shipped, non-empty, and still names
+the six operators. **For #1183: we think that refusal is right, and it argues the
+prompt belongs to what a bundle supplies rather than being optional decoration.**
+
+The rest of the chat surface (`chat:` and `search:` blocks, the preset, the MCP tool
+list, the `schemas/` slices, the `skills/` slot) was already on `archi_v3` and is
+unchanged. The full chain is verified end to end on a fresh database: install →
+publish 2,586 nodes → `chat-instance up` → `mcp-serve` on the port the bundle
+declares → `chat sync` exiting 0 with the graph tools bound and the prompt applied.
+
+**Three chat findings for #1183, drafted in `docs/outbound/`** and verified against
+`dev` @ `1475c87d5`. Worst first: a synced instance opens on a model with **no graph
+access**, because `chat.models.default` is both the preset's `base_model_id`
+(`sync.py:4937`) and the site default (`sync.py:4432`) while the vendor selects
+`default_models.split(',')[0]` — there is no deployment-side workaround, and the
+failure is a confident ungrounded answer with no warning. Second, the model provider
+cannot be declared at all (`chat-instance up` injects two hardcoded variables,
+`instance.py:1253`) and sits in none of the six reconciled surfaces, so `chat sync`
+reports green on an instance that cannot answer. Third, the first admin account is
+not bootstrapped. Filed separately; recorded here so #1183's design has them.
+
+**Pin drift, and why it matters more than usual (2026-09-08).** We are pinned to
+`2d528e824`; `dev` is `1475c87d5`. The external-distribution conformance contract
+landed inside that gap — `conformance.py` did not exist at our pin and is 2,132 lines
+at `dev`, arriving in `46c42c7e0` via PR #1377 (merged 2026-08-28), with #1406
+following on 08-30. Two consequences: our installed okg cannot evaluate the
+conformance schema at all, and **our existing acknowledgement is stale**. Comment
+`5440260363` names branch `f4081329` and schema digest `sha256:301ec97f…`; the
+catalog digest at `dev` is now
+`sha256:db38e9bbbe571dbb9efec29192f786d851095ca412f5a5fda17d1af81f62e662`. Until it
+is re-issued, the real conformance arm returns
+`conformance_external_acknowledgement_pending`. The suite has **not** yet been re-run
+against `1475c87d5`; the ten guarded `okg.substrate.*` symbols below are therefore
+still asserted only at `2d528e824`.
+
+**Sprint 11 (okg#1698) is the Archi chain.** Its exit criteria are
+#1178 → #1179 → #1181 → #1180 → #1183 → #1184 → #1185, with #1185 run on a real
+deployment — which their own #1185 note says only the `cern-team` wheel on SubMIT
+satisfies. Design notes for #1178, #1179, #1181 and #1185 are posted and
+adversarially reviewed; our answers to #1178's seven open questions are
+[comment `5590581856`](https://github.com/mitdbg/okg/issues/1178#issuecomment-5590581856).
+In flight and directly relevant to us: **#1737** owner-keyed module providers (the
+D11 gap this page has flagged since 2026-08-19), **#1740** package v2 with an OKG
+compatibility window, **#1742** the SDK connector fact surface and a `partial`
+source-run status — which closes our own **#1284**. None had merged as of
+2026-09-08.
 
 **Pin bumped, drift closed (2026-08-27).** The 210-commit exposure this page
 flagged is resolved: we fast-forwarded to okg `dev` @ `2d528e824` and re-ran the

--- a/docs/outbound/DRAFT-okg-1178-answers.md
+++ b/docs/outbound/DRAFT-okg-1178-answers.md
@@ -1,0 +1,89 @@
+Answers to the seven open questions, in order. I checked the claims I am agreeing
+with against `dev` at `1475c87d5d` rather than taking them on trust, and two of them
+have a consequence for our side that is better settled now than discovered during the
+real arm. Thank you for the design notes — the corrections comment in particular
+saved us from planning around two things that had already landed.
+
+**1. Module providers get their own PACT.** Agreed, and already done:
+#1737 carries `pact/changes/module-providers-in-composition/`. Nothing to decide;
+flagging it only so the question is not held open.
+
+**2. Package v2, with `okg_compatibility: {min_version, max_version_exclusive}`.**
+Agreed. Two reasons, one of them stronger than the one in the note:
+
+- `contract_versions` is checked by literal membership against
+  `CONTRACT_VERSION = "v1"` (`lock.py:711-726`, `models.py:29`), so a range placed
+  there is refused as `compatibility_contract_unsupported` rather than interpreted.
+- More decisive: the two fields answer different questions. `contract_versions` says
+  which deployment-product *contract revision* an artifact speaks. An OKG version
+  window says which OKG *releases* can run a distribution. Overloading the first
+  would change the meaning of a check that other artifacts already depend on, to
+  express something it was never asked.
+
+Archi will declare a window rather than a point.
+
+**3. Yes, and the spelling is `conformance_declared_optional_credential_unavailable`.**
+The scoping is exactly what we asked for: the validator requires `optional_credential`
+to be present and `reference` to equal `optional_credential.binding_id`
+(`conformance.py:881-897`), so an unsupplied credential is admissible while missing
+fetch tooling still fails. That distinction was the whole point — of our nineteen
+clean failures only five were genuinely missing credentials, and eight are tooling
+nobody has written.
+
+Two things follow that we would rather settle now:
+
+- The code is admissible only for a **manifest-declared** credential binding. Our
+  bundle deliberately declares none on default-selected sources — that is
+  test-enforced on our side — and the credentialed sources ship as `.example` files a
+  site opts into. So as things stand, enabling one of those on the real arm without
+  its credential is a hard `fail`, not `blocked`. We would rather declare optional
+  credential bindings for sources we ship but do not select. Tell us if that is the
+  wrong shape before we build it.
+- The closed profile pins `arm == "first_publish"` and `phase == "apply"`. Our
+  credential-gated connectors fail while fetching during ingest. Please confirm that
+  lands in that arm and phase, otherwise the code cannot be used where we actually
+  need it.
+
+**4. Both as receipt fields the install verb emits.** Accepted; both types are on
+`dev` and are unambiguous.
+
+`ConformanceLegacyAuthorityEvidence` needs one agreement before we can fill it. It
+requires a declared inventory whose entry count equals `declared_inputs`, with
+`declared_inputs == migrated_inputs + refused_inputs`, `unresolved_inputs: 0` and
+`fallback_authority_absent: True`. That is ours to produce on the real arm, and it
+turns on a definition: **what counts as a "legacy input"?** On our side the
+candidates are the `$OKG_PROFILES_DIR` authoring-checkout path, the
+`okg install --profile` invocation, and the hand-pruned schema copies the current
+install still requires. If "input" is narrower or broader than that, we will build
+the inventory against the wrong denominator and the count will bind to nothing
+meaningful. Name it and we will produce it.
+
+**5. Hermetic fixture per pull request, real container nightly.** Agreed. Two things
+worth recording explicitly:
+
+- A failed real arm must not be waivable by a green hermetic one. The note already
+  says this; please keep it.
+- The real arm can never gate your merges. It needs our host, our private data and a
+  human, so its schedule must not become a dependency of yours. Treating it as a
+  nightly signal you can read, rather than a gate you wait on, is the only version
+  that works.
+
+On cost: agreed that 400s is a placeholder and should be measured before it is
+enforced, and that the kill is the only real runaway guard while a clean overrun
+still exits 0.
+
+**6. Yes — owed, and mine.** I will re-acknowledge against the merged tree rather
+than the branch, with the five fields matched exactly, so the real arm stops
+returning `conformance_external_acknowledgement_pending`. Posting separately.
+
+**7. The chain order holds.** #1180 does not need to move earlier for us: our
+deployment is single-operator today, so per-user authentication is not what is
+blocking anything on our side. If a demo deployment needs it sooner, move it on that
+basis rather than ours.
+
+One exception, which is not really about ordering. #1183 carries a defect that is
+producing confidently wrong answers today, in a path people are already using: a
+synced instance opens on a model that has no graph tools, because the field naming the
+preset's base model is also the field that sets the site default. I will file the
+detail with line references on #1183 itself. The fix looks small, and it should not
+have to wait for #1183's slot in the chain.

--- a/docs/outbound/DRAFT-okg-1185-reacknowledgement.md
+++ b/docs/outbound/DRAFT-okg-1185-reacknowledgement.md
@@ -1,0 +1,55 @@
+Re-acknowledgement of the external-distribution conformance wire schema, replacing
+the one that named branch `f4081329`. This supersedes
+https://github.com/mitdbg/okg/issues/1178#issuecomment-5440260363.
+
+**The values**, for transcription into `trusted_external_review`:
+
+```json
+{
+  "consumer_id": "archi-physics/archi:cern-team",
+  "review_reference": "<this comment's URL>",
+  "acknowledged_interface_revision": "1475c87d5d7fc60083bb0c87a9f9f3467a1a647a",
+  "acknowledged_schema_digest": "sha256:db38e9bbbe571dbb9efec29192f786d851095ca412f5a5fda17d1af81f62e662",
+  "source_revision": "e70b22043c563a95bb2850031f1a25a3472548a7",
+  "acknowledgement_status": "current"
+}
+```
+
+**Where each value comes from, so you can reproduce it rather than trust it.**
+
+- `acknowledged_interface_revision` is `dev` itself, not a branch this time. The
+  contract arrived on `dev` in `46c42c7e0b3dcea525174cabbcff0a6252f0cf52` via
+  PR #1377 (merged 2026-08-28), with PR #1406 following on 2026-08-30. I pinned the
+  revision to `dev` rather than to either commit because the digest below is only
+  meaningful paired with the tree it was computed from.
+- `acknowledged_schema_digest` is `conformance_schema_catalog()["schema_digest"]`
+  evaluated at that revision. The value in the existing fixture,
+  `sha256:301ec97f…`, no longer matches, which is the second reason the old
+  acknowledgement reads as historical — separate from it naming a branch.
+- `source_revision` is the head of `archi_v3`, our integration line.
+
+**Two caveats, because this acknowledgement is narrower than it looks.**
+
+First, it binds to a pair: one Archi revision and one OKG schema digest. The
+validator requires `origin.source_revision` to equal the request subject's revision
+and, for a `current` status, the acknowledged digest to equal the *current* catalog
+digest. So any commit to either side invalidates it. Both sides are moving right now
+— #1179 through #1185 are landing on yours, and on ours the cern-team bundle work
+(the chat block, the shipped system prompt, the schema slices) is still on a branch
+and not yet on `archi_v3`, so the revision above does **not** include it.
+
+Second, and following from that: this cannot be the acknowledgement the real arm
+finally runs against, because the real arm cannot run until the install verb exists,
+by which time both revisions will have moved.
+
+**So a question on the intended flow.** Is the acknowledgement meant to be re-issued
+per conformance run, bound to the exact pair being validated? That is what the
+checks imply, and if so the useful thing today is what this comment does — retire the
+branch reference and establish the format — with a fresh one issued at the point the
+real arm actually runs. If instead you intended a durable acknowledgement of the
+*interface* that survives revision changes, then the binding to
+`request.subject.source_revision` is stronger than that intent and worth loosening
+before anyone depends on it.
+
+Happy either way; I would rather ask now than have the real arm refuse on a
+technicality we could have settled here.

--- a/docs/outbound/DRAFT-okg-1185-reacknowledgement.md
+++ b/docs/outbound/DRAFT-okg-1185-reacknowledgement.md
@@ -33,10 +33,18 @@ https://github.com/mitdbg/okg/issues/1178#issuecomment-5440260363.
 First, it binds to a pair: one Archi revision and one OKG schema digest. The
 validator requires `origin.source_revision` to equal the request subject's revision
 and, for a `current` status, the acknowledged digest to equal the *current* catalog
-digest. So any commit to either side invalidates it. Both sides are moving right now
-— #1179 through #1185 are landing on yours, and on ours the cern-team bundle work
-(the chat block, the shipped system prompt, the schema slices) is still on a branch
-and not yet on `archi_v3`, so the revision above does **not** include it.
+digest. So any commit to either side invalidates it, and both sides are moving —
+#1179 through #1185 are landing on yours.
+
+On ours, one thing is worth naming because it bears on #1183. The bundle's `chat:`
+and `search:` blocks, its `schemas/` slices and its `skills/` slot are all on
+`archi_v3` and included above. Its **assistant system prompt** is not yet: it sits on
+an open PR. That asset exists because `okg chat sync` refuses a deployment declaring
+neither `mcp_instructions` nor a `system_prompt_ref` — Open WebUI never shows the
+model the MCP server's own instructions, so without it an assistant has graph tools
+registered and no idea it has them. We think that refusal is right, and we mention it
+because #1183's design should probably treat the prompt as part of what a bundle
+supplies rather than as optional decoration.
 
 Second, and following from that: this cannot be the acknowledgement the real arm
 finally runs against, because the real arm cannot run until the install verb exists,

--- a/docs/outbound/DRAFT-okg-chat-deployment-friction.md
+++ b/docs/outbound/DRAFT-okg-chat-deployment-friction.md
@@ -1,0 +1,116 @@
+# Standing up a chat deployment takes three commands and three undeclared manual steps
+
+## What this asks for
+
+`okg chat-instance up` plus `okg chat sync` describe a chat deployment in
+impressive detail — UI features, model names, the preset, its system prompt,
+its suggestions, the MCP tool list. But between those two commands sit three
+steps that the manifest cannot express and that okg never performs, so an
+operator finishes by hand-writing configuration into the instance through the
+vendor's admin API. One of those steps is not merely tedious: skipping it is
+the default, and the default silently bypasses the graph.
+
+Nothing below is specific to our deployment. Any okg chat deployment meets all
+three.
+
+## Behavior before → after
+
+**Before.** The path from nothing to a working chat is six steps, three of
+which are okg commands:
+
+1. `okg chat-instance up`
+2. create the first account and mint an admin token — *by hand*
+3. point the instance at a model provider — *by hand*
+4. `okg mcp-serve --transport streamable-http`
+5. `okg chat sync`
+6. open the site and select the deployment preset — *by hand, and the
+   pre-selected default is the wrong one*
+
+**After.** Steps 2, 3 and 6 disappear. `up` → `mcp-serve` → `sync` → the site
+opens on the preset and works.
+
+## Findings
+
+### 1. A synced instance opens on a model that has no graph access
+
+The vendor selects the initial model from the first entry of a
+comma-separated list: the frontend does
+`selectedModelId = $config?.default_models.split(',')[0]`
+(`/app/build/_app/immutable/chunks/BLLL3FN7.js`, v0.11.0), fed by
+`ui.default_models` (`backend/open_webui/config.py:3047`).
+
+`chat sync` writes exactly one id into that field —
+`config["DEFAULT_MODELS"] = default or ""` at `sync.py:4432` — and `default`
+is `chat.models.default`. That same value is required to be the preset's
+underlying model, since it is passed as `base_model_id` when the preset is
+created (`sync.py:4937`, `sync.py:4961`). It therefore has to name a raw
+provider model.
+
+The consequence is that the one model the UI pre-selects is the one
+configuration guaranteed to have no graph tools and no system prompt. A reader
+who opens the site and asks a domain question gets an answer from the model's
+general knowledge, with nothing indicating that the deployment's graph was
+never consulted. The preset that `sync` just built, with its tools and its
+grounding instructions, is one menu click away and nothing points at it.
+
+There is no deployment-side workaround. `chat.models.default` is the only knob
+(`chat_block.py:543-547`); `ui:` accepts only `site_name`, `logo_ref`,
+`banner` and `features` (`chat_block.py:279`). Reordering `models.builtin`
+does not help — that writes `MODEL_ORDER_LIST`, which is ordering, not
+selection.
+
+Because the vendor field is a list and okg already knows the preset id it just
+created, the smallest fix is to name the preset first rather than collapsing
+the field to the base model. A separate manifest field for the UI default
+would be cleaner, but is not required to close the hazard.
+
+*Adjacent, same root:* when the preset **is** selected but reached through the
+API rather than the UI, the vendor deliberately does not attach its tools —
+"API callers don't expect hidden tools; they can explicitly request tools via
+`tool_ids`" (`middleware.py:2861`). Here the system prompt *does* apply, so
+the model is told it has graph operators it was not given, and describes
+searches it never ran. Both paths lead to ungrounded answers; only this one
+also produces claims of tool use.
+
+### 2. Nothing can say where the models come from, and sync cannot see that it is missing
+
+`chat:` accepts model *names* — `builtin` and `default` (`chat_block.py:543`)
+— but nothing about the provider behind them. `chat-instance up` injects
+exactly two variables into the container, the app database URL and the session
+key, from a literal dict at `instance.py:1253` with no passthrough. Neither
+okg's code nor its docs mention a provider anywhere.
+
+So the operator configures it afterwards by calling the vendor's admin API
+directly. That write is invisible to okg: `chat sync` reconciles six surfaces
+— `instance_ui`, `models`, `preset`, `prompts`, `deep_links`, `mcp`
+(`sync.py:248-253`) — and the provider connection is in none of them. Nothing
+checks that a model can answer at all. **`chat sync` therefore reports green on
+an instance that cannot produce a single reply.**
+
+The asymmetry is the argument: sync already probes the MCP endpoint and
+refuses to proceed when the graph tools are unreachable (`sync.py:4092`). The
+tool half of the chat is verified end to end; the model half is not checked at
+all, though both are dependencies of the same conversation.
+
+### 3. The first admin account is not bootstrapped
+
+`chat sync` requires `OKG_CHAT_ADMIN_TOKEN` (`sync.py:229`) and there is no
+command that produces one. The operator signs up — through the browser, or by
+posting to the vendor's signup route, which returns a token sync accepts — and
+exports it.
+
+okg is already the party that could do this. It creates the instance, owns its
+application database, and mints and manages its session-signing key
+(`instance.py:233`). Creating the first account is the same class of act
+against the same assets, one step further along.
+
+## How I verified
+
+- Vendor selection logic read out of `ghcr.io/open-webui/open-webui:v0.11.0`
+  directly (`config.py`, `main.py`, and the built frontend chunk cited above).
+- okg behavior read from `src/okg` at `2d528e824`; every line reference above
+  was opened, not recalled.
+- Findings 2 and 3 were met in practice during two end-to-end bring-ups: both
+  were completed only by calling the vendor admin API by hand, and finding 1
+  produced a confidently wrong answer that was mistaken for an okg bug until
+  the cause was traced.

--- a/python/tests/test_bundle_cern_team.py
+++ b/python/tests/test_bundle_cern_team.py
@@ -117,3 +117,32 @@ def test_default_sources_need_no_credentials():
             f"{path.name} is selected by default but declares credential_refs; "
             "a fresh install would fail to publish"
         )
+
+
+def test_chat_declares_a_system_prompt_that_ships():
+    """`okg chat sync` REFUSES a deployment with no prompt source.
+
+    Open WebUI never shows the model the MCP server's own `instructions`, so
+    without a system prompt the assistant gets graph tools registered and no
+    idea it has them — a preset that looks configured and cannot answer. okg
+    refuses rather than allow that, so this is a hard requirement, not a
+    nicety, and the file has to be one the bundle actually materialises.
+    """
+    defaults = yaml.safe_load((BUNDLE / "deployment-defaults.yaml").read_text())
+    ref = defaults["chat"]["preset"]["system_prompt_ref"]
+    assert ref, "chat.preset.system_prompt_ref must be declared"
+
+    # The ref is deployment-relative; the bundle's skills/ becomes
+    # <deployment>/skills/, so a skills/-rooted ref must exist there.
+    assert ref.startswith("skills/"), (
+        f"system_prompt_ref {ref!r} is not under skills/, which is the only "
+        "bundle directory materialised into the deployment as loose files"
+    )
+    shipped = BUNDLE / ref
+    assert shipped.is_file(), f"{ref} is declared but not shipped in the bundle"
+    text = shipped.read_text(encoding="utf-8").strip()
+    assert text, "a declared but empty prompt is refused by okg chat sync"
+    # The prompt exists to tell the model it has graph tools. If it stops
+    # naming them, it has stopped doing its job.
+    for operator in ("search", "inspect", "expand"):
+        assert operator in text, f"prompt no longer mentions the {operator} tool"


### PR DESCRIPTION
## What this changes

The CERN quickstart now runs end to end without a browser and without guesswork, the bundle ships the assistant's system prompt that `okg chat sync` requires, and `docs/okg-alignment.md` records both. Also carries three drafts for okg, in `docs/outbound/`.

## Behavior before → after

**Before.** Following the document literally produced a chat instance that hung, then crashed; the model provider and admin token both required clicking through the UI; and the model the site opened on was silently the wrong one. Two of those failures were mine — I had shipped commands I had not run.

**After.** Every step is a command that was executed before it was written. The provider and the admin token are each one `curl`. The model-picker hazard is documented as the default it actually is, rather than as something a careful reader would avoid.

## Findings, worst first

1. **`docs/cern-team-quickstart.md:357` — the claim was wrong in a way that misleads.** A raw ollama model selected in the UI carries no system prompt at all, because the prompt lives on the preset. The "claims tools it does not have" behaviour belongs to the API path, where the preset *is* selected but its tools are deliberately not attached. Two different failures had been merged into one description.
2. **Same line — the framing understated it.** The pre-selected model is *guaranteed* to be the wrong one: okg's `chat.models.default` is both the preset's `base_model_id` and the site default, and Open WebUI selects `default_models.split(',')[0]`. There is no bundle-side fix. Reworded from "easy to miss" to "the default is wrong".
3. **`bundles/cern-team/deployment-defaults.yaml:87` — the bundle declared no system prompt.** `chat sync` refuses a deployment declaring neither `mcp_instructions` nor a `system_prompt_ref`, because Open WebUI never shows the model the MCP server's own instructions. Without it the assistant has graph tools registered and no idea it has them. Now shipped as `skills/chat-system-prompt.md`, with tests asserting it is declared, present, non-empty, and still names the tools.
4. **`docs/okg-alignment.md:20` — a bundle landing must update this page in the same PR, and did not.** That is our own standing policy, and okg has spent Sprint 11 designing #1179, #1183 and #1185 around our bundle from a twelve-day-old description of it. Now records the system prompt and why it is required, the three #1183 findings, and the pin drift below.
5. **`docs/cern-team-quickstart.md:295` — the admin token needed a browser.** Signing up on a fresh instance returns a token `chat sync` accepts; this is how both end-to-end runs authenticated. The UI route is kept as a footnote.
6. **`docs/cern-team-quickstart.md:344` — so did the model provider.** Replaced with the `POST /ollama/config/update` used in both runs, keeping both URL warnings (gateway alias, non-default port) intact.
7. **`mcp-serve` must be on 8765**, because that is what the bundle declares in `chat.mcp.port`. Serve elsewhere and `chat sync` fails `mcp_unreachable` while the server runs fine somewhere it was never told about. Hit this myself.
8. Earlier in the branch: the chat database password is baked in at container creation, and a retry must remove the chat container as well as its database, because `chat-instance up` reuses an existing container with the old DSN baked in.

## How I verified

Full chain run twice on a fresh database: install → publish (2,586 nodes) → `chat-instance up` → `mcp-serve` → `chat sync` exiting 0 with the graph tools bound and the system prompt applied. Suite **339 passed**.

One retraction worth recording: I reported the assistant fabricating sourced answers as an okg bug. It was my own test harness — an API caller does not get a preset's tools unless it passes `tool_ids`. No okg defect; finding 1 above is what was actually wrong.

## Not addressed here

- The three okg findings are drafted in `docs/outbound/`, not filed by this PR: the chat-deployment friction report (for okg#1183), our answers to okg#1178's seven open questions, and the conformance wire-schema re-acknowledgement.
- **The okg pin is not bumped.** We remain at `2d528e824` while `dev` is `1475c87d5`, and the alignment page says so rather than implying a re-audit happened. Running the suite against `dev` was blocked by a permission classifier in this session, so that claim is deliberately not made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Dhd8kXJLfAJjDDZHXaXds
