### PR TITLE
Add separate Ollama and vLLM provider types for concurrent local models

### DIFF
--- a/docs/docs/models_providers.md
+++ b/docs/docs/models_providers.md
@@ -4,7 +4,7 @@ Archi uses a **provider-based architecture** for LLM access. Each provider wraps
 
 ## Provider Architecture
 
-All providers extend the `BaseProvider` abstract class and are registered in a global provider registry. The system supports six provider types:
+All providers extend the `BaseProvider` abstract class and are registered in a global provider registry. The system supports eight provider types:
 
 | Provider | Type | API Key Env Var | Default Model | LangChain Backend |
 |----------|------|----------------|---------------|-------------------|
@@ -13,11 +13,15 @@ All providers extend the `BaseProvider` abstract class and are registered in a g
 | Google Gemini | `gemini` | `GOOGLE_API_KEY` | `gemini-2.0-flash` | `ChatGoogleGenerativeAI` |
 | OpenRouter | `openrouter` | `OPENROUTER_API_KEY` | `anthropic/claude-3.5-sonnet` | `ChatOpenAI` (custom base URL) |
 | CERN LiteLLM | `cern_litellm` | `CERN_LITELLM_API_KEY` | Configured via YAML | `ChatOpenAI` (CERN LLM Gateway) |
-| Local (Ollama/vLLM) | `local` | N/A | Dynamic (fetched from server) | `ChatOllama` or `ChatOpenAI` |
+| Local (generic) | `local` | N/A | Dynamic (fetched from server) | `ChatOllama` or `ChatOpenAI`, per `mode` |
+| Ollama | `ollama` | N/A | Dynamic (fetched from server) | `ChatOllama` |
+| vLLM / OpenAI-compatible | `vllm` | N/A | Configured via YAML | `ChatOpenAI` (custom base URL) |
+
+`local`, `ollama`, and `vllm` all share the same underlying implementation and `local_mode` dispatch (see below), but `ollama` and `vllm` are registered as distinct provider types with their own config block. That's what lets a single service run both at once — see [Running Ollama and vLLM together](#running-ollama-and-vllm-together).
 
 ### Key Concepts
 
-- **`ProviderType`**: An enum of supported provider names (`OPENAI`, `ANTHROPIC`, `GEMINI`, `OPENROUTER`, `LOCAL`, `CERN_LITELLM`).
+- **`ProviderType`**: An enum of supported provider names (`OPENAI`, `ANTHROPIC`, `GEMINI`, `OPENROUTER`, `LOCAL`, `OLLAMA`, `VLLM`, `CERN_LITELLM`).
 - **`ProviderConfig`**: A dataclass holding provider settings — type, API key, base URL, enabled state, models list, and extra kwargs.
 - **`ModelInfo`**: Describes a model's capabilities — context window, tool support, streaming support, vision support, and max output tokens.
 - **Provider Registry**: Providers are lazily registered at first use. Factory functions (`get_provider`, `get_model`) handle instantiation and caching.
@@ -130,6 +134,30 @@ The `local` provider supports two modes:
 - **`openai_compat`**: Uses `ChatOpenAI` with a custom base URL. Suitable for vLLM, LM Studio, or other OpenAI-compatible servers.
 
 > **Note:** For GPU setup with local models, see [Advanced Setup & Deployment](advanced_setup_deploy.md#running-llms-locally-on-your-gpus).
+
+### Running Ollama and vLLM together
+
+`default_provider`/`default_model` only select a single model, and a single `providers.local` block only has one `mode` — so a service can't point `local` at both Ollama and vLLM at the same time. To use both concurrently in one service, configure them under the separate `ollama` and `vllm` provider keys and reference each by name in `models`:
+
+```yaml
+services:
+  chat_app:
+    providers:
+      ollama:
+        base_url: http://localhost:11434
+        models:
+          - llama3.2
+      vllm:
+        base_url: http://localhost:8000/v1
+        models:
+          - my-vllm-model
+    pipelines:
+      required:
+        chat_pipeline: react
+      # ...
+```
+
+In the pipeline's `models.required`/`models.optional`, reference models as `"<provider>/<model>"`, e.g. `"ollama/llama3.2"` and `"vllm/my-vllm-model"`. Each is resolved to its own provider instance, so requests to the Ollama-backed model and the vLLM-backed model can run side by side against two different local servers. `local` remains available as a generic single-mode provider for backward compatibility, and can still be combined with `ollama` and/or `vllm` if needed.
 
 ---
 

--- a/src/archi/pipelines/agents/base_react.py
+++ b/src/archi/pipelines/agents/base_react.py
@@ -957,7 +957,8 @@ class BaseReActAgent:
         extra = {}
         try:
             provider_type = ProviderType(provider_key)
-            if provider_type == ProviderType.LOCAL and cfg.get("mode"):
+            local_types = (ProviderType.LOCAL, ProviderType.OLLAMA, ProviderType.VLLM)
+            if provider_type in local_types and cfg.get("mode"):
                 extra["local_mode"] = cfg.get("mode")
         except Exception:
             pass

--- a/src/archi/providers/__init__.py
+++ b/src/archi/providers/__init__.py
@@ -75,14 +75,16 @@ def _ensure_providers_registered() -> None:
     from src.archi.providers.anthropic_provider import AnthropicProvider
     from src.archi.providers.gemini_provider import GeminiProvider
     from src.archi.providers.openrouter_provider import OpenRouterProvider
-    from src.archi.providers.local_provider import LocalProvider
+    from src.archi.providers.local_provider import LocalProvider, OllamaProvider, VLLMProvider
     from src.archi.providers.cern_litellm_provider import CERNLiteLLMProvider
-    
+
     register_provider(ProviderType.OPENAI, OpenAIProvider)
     register_provider(ProviderType.ANTHROPIC, AnthropicProvider)
     register_provider(ProviderType.GEMINI, GeminiProvider)
     register_provider(ProviderType.OPENROUTER, OpenRouterProvider)
     register_provider(ProviderType.LOCAL, LocalProvider)
+    register_provider(ProviderType.OLLAMA, OllamaProvider)
+    register_provider(ProviderType.VLLM, VLLMProvider)
     register_provider(ProviderType.CERN_LITELLM, CERNLiteLLMProvider)
 
 
@@ -146,7 +148,9 @@ def get_provider_by_name(name: str, **kwargs) -> BaseProvider:
     - "anthropic", "claude", "Anthropic"
     - "gemini", "google", "Gemini"
     - "openrouter", "OpenRouter"
-    - "local", "ollama", "Local"
+    - "local", "Local" (generic local server, single `local_mode`)
+    - "ollama", "Ollama" (pinned to Ollama mode; can run alongside "vllm")
+    - "vllm", "vLLM" (pinned to OpenAI-compatible mode; can run alongside "ollama")
     
     Args:
         name: The provider name
@@ -167,8 +171,8 @@ def get_provider_by_name(name: str, **kwargs) -> BaseProvider:
         "google": ProviderType.GEMINI,
         "openrouter": ProviderType.OPENROUTER,
         "local": ProviderType.LOCAL,
-        "ollama": ProviderType.LOCAL,
-        "vllm": ProviderType.LOCAL,
+        "ollama": ProviderType.OLLAMA,
+        "vllm": ProviderType.VLLM,
         "cern_litellm": ProviderType.CERN_LITELLM,
     }
     

--- a/src/archi/providers/base.py
+++ b/src/archi/providers/base.py
@@ -25,6 +25,8 @@ class ProviderType(str, Enum):
     GEMINI = "gemini"
     OPENROUTER = "openrouter"
     LOCAL = "local"
+    OLLAMA = "ollama"
+    VLLM = "vllm"
     CERN_LITELLM = "cern_litellm"
 
 
@@ -118,7 +120,7 @@ class BaseProvider(ABC):
     def is_configured(self) -> bool:
         """Check if the provider has necessary credentials configured."""
         # Local providers may not need an API key
-        if self.provider_type == ProviderType.LOCAL:
+        if self.provider_type in (ProviderType.LOCAL, ProviderType.OLLAMA, ProviderType.VLLM):
             return bool(self.config.base_url)
         return bool(self._api_key)
     

--- a/src/archi/providers/local_provider.py
+++ b/src/archi/providers/local_provider.py
@@ -18,19 +18,25 @@ logger = get_logger(__name__)
 class LocalProvider(BaseProvider):
     """
     Provider for local LLM servers (Ollama, vLLM, LM Studio, etc.)
-    
+
     Supports two modes:
     1. Ollama mode (default): Uses ChatOllama from langchain_ollama
     2. OpenAI-compatible mode: Uses ChatOpenAI for vLLM, LM Studio, etc.
-    
-    The mode is determined by the 'local_mode' setting in extra_kwargs.
+
+    The mode is determined by the 'local_mode' setting in extra_kwargs. Subclasses
+    (OllamaProvider, VLLMProvider) pin the mode/provider_type/default base URL so
+    that both flavors can be configured and used at the same time, under distinct
+    `providers.<name>` config blocks.
     """
-    
+
     provider_type = ProviderType.LOCAL
     display_name = "Local Server"
-    
+
     DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434"
     DEFAULT_OPENAI_COMPAT_BASE_URL = "http://localhost:8000/v1"
+
+    # Overridden by subclasses to pin a specific mode instead of defaulting to Ollama.
+    DEFAULT_LOCAL_MODE = "ollama"
 
     @staticmethod
     def _normalize_base_url(url: Optional[str]) -> Optional[str]:
@@ -40,37 +46,45 @@ class LocalProvider(BaseProvider):
         if url.startswith(("http://", "https://")):
             return url
         return f"http://{url}"
-    
+
+    def _default_base_url(self) -> str:
+        if self.DEFAULT_LOCAL_MODE == "openai_compat":
+            return self.DEFAULT_OPENAI_COMPAT_BASE_URL
+        return self.DEFAULT_OLLAMA_BASE_URL
+
     def __init__(self, config: Optional[ProviderConfig] = None):
         import os
-        
-        # Check for OLLAMA_HOST environment variable (supports Docker/Podman deployments)
-        # If set, prefer it over the config value so runners can override host/port
-        env_ollama_host = self._normalize_base_url(os.environ.get("OLLAMA_HOST"))
-        default_ollama_host = env_ollama_host or self.DEFAULT_OLLAMA_BASE_URL
+
+        default_host = self._default_base_url()
+        env_ollama_host = None
+        if self.DEFAULT_LOCAL_MODE == "ollama":
+            # Check for OLLAMA_HOST environment variable (supports Docker/Podman deployments)
+            # If set, prefer it over the config value so runners can override host/port
+            env_ollama_host = self._normalize_base_url(os.environ.get("OLLAMA_HOST"))
+            default_host = env_ollama_host or default_host
 
         if config is None:
             config = ProviderConfig(
-                provider_type=ProviderType.LOCAL,
-                base_url=default_ollama_host,
+                provider_type=self.provider_type,
+                base_url=default_host,
                 models=[],  # dynamic fetch
                 default_model="",  # set from first available model if present
-                # Default to Ollama mode
-                extra_kwargs={"local_mode": "ollama"},
+                extra_kwargs={"local_mode": self.DEFAULT_LOCAL_MODE},
             )
         else:
             # Let env override the config base_url when provided (useful in CI)
             if env_ollama_host:
                 config.base_url = env_ollama_host
             elif not config.base_url:
-                config.base_url = default_ollama_host
+                config.base_url = default_host
             config.base_url = self._normalize_base_url(config.base_url)
+            config.extra_kwargs.setdefault("local_mode", self.DEFAULT_LOCAL_MODE)
         super().__init__(config)
     
     @property
     def local_mode(self) -> str:
         """Get the local server mode (ollama or openai_compat)."""
-        return self.config.extra_kwargs.get("local_mode", "ollama")
+        return self.config.extra_kwargs.get("local_mode", self.DEFAULT_LOCAL_MODE)
     
     def get_chat_model(self, model_name: str, **kwargs) -> BaseChatModel:
         """Get a local chat model instance."""
@@ -234,3 +248,28 @@ class LocalProvider(BaseProvider):
         """
         models = self.list_models()
         return [m.id for m in models]
+
+
+class OllamaProvider(LocalProvider):
+    """
+    Provider pinned to Ollama mode, configured via its own `providers.ollama`
+    config block. Lets a service run Ollama and vLLM at the same time by giving
+    each its own ProviderType/config, instead of sharing the generic `local`
+    provider's single `local_mode` setting.
+    """
+
+    provider_type = ProviderType.OLLAMA
+    display_name = "Ollama"
+    DEFAULT_LOCAL_MODE = "ollama"
+
+
+class VLLMProvider(LocalProvider):
+    """
+    Provider pinned to OpenAI-compatible mode (vLLM, LM Studio, etc.), configured
+    via its own `providers.vllm` config block. See OllamaProvider for why this is
+    a separate provider type rather than another `local_mode` value.
+    """
+
+    provider_type = ProviderType.VLLM
+    display_name = "vLLM"
+    DEFAULT_LOCAL_MODE = "openai_compat"

--- a/src/interfaces/chat_app/app.py
+++ b/src/interfaces/chat_app/app.py
@@ -161,7 +161,8 @@ def _build_provider_config_from_payload(config_payload: Dict[str, Any], provider
 
     models = [ModelInfo(id=m, name=m, display_name=m) for m in cfg.get("models", [])]
     extra = {}
-    if provider_type == ProviderType.LOCAL and cfg.get("mode"):
+    local_types = (ProviderType.LOCAL, ProviderType.OLLAMA, ProviderType.VLLM)
+    if provider_type in local_types and cfg.get("mode"):
         extra["local_mode"] = cfg.get("mode")
 
     return ProviderConfig(
@@ -4498,8 +4499,8 @@ class FlaskAppWrapper(object):
             
             providers_status = []
             for provider_type in list_provider_types():
-                # Skip local provider - no API key needed
-                if provider_type == ProviderType.LOCAL:
+                # Skip local providers - no API key needed
+                if provider_type in (ProviderType.LOCAL, ProviderType.OLLAMA, ProviderType.VLLM):
                     continue
                     
                 ptype_str = provider_type.value


### PR DESCRIPTION
## Summary
- Adds `ProviderType.OLLAMA` and `ProviderType.VLLM` as distinct, independently registered provider types (via new `OllamaProvider`/`VLLMProvider` subclasses of `LocalProvider`), instead of both sharing the single `ProviderType.LOCAL` / `providers.local` config block and its one `local_mode` setting.
- This lets a single service (e.g. `chat_app`) configure `providers.ollama` and `providers.vllm` separately and reference models as `"ollama/<model>"` and `"vllm/<model>"` in the same `models` list, so both backends can be used concurrently.
- `providers.local` / `ProviderType.LOCAL` keep working exactly as before for existing single-mode configs — this is purely additive.
- Updated the two `_build_provider_config*` helpers (`base_react.py`, `chat_app/app.py`) and the BYOK provider-status endpoint to recognize the new types, and documented the new setup in `docs/docs/models_providers.md`.

## Test plan
- [x] `python3 -m py_compile` on all changed files
- [x] Manual verification (langchain deps stubbed, since they're not installed in this shell): confirmed `get_provider_by_name("ollama")` and `get_provider_by_name("vllm")` return distinct instances with correct default base URLs (`:11434` vs `:8000/v1`) and correct `local_mode`, and that `get_chat_model(...)` builds the right kwargs for each
- [ ] End-to-end run against real local Ollama + vLLM servers configured together in one `chat_app` service

🤖 Generated with [Claude Code](https://claude.com/claude-code)