### PR TITLE
docs(outbound): record the acknowledgement and chat findings as filed

### DIFF
--- a/docs/outbound/DRAFT-okg-1185-reacknowledgement.md
+++ b/docs/outbound/DRAFT-okg-1185-reacknowledgement.md
@@ -7,10 +7,10 @@ https://github.com/mitdbg/okg/issues/1178#issuecomment-5440260363.
 ```json
 {
   "consumer_id": "archi-physics/archi:cern-team",
-  "review_reference": "<this comment's URL>",
+  "review_reference": "https://github.com/mitdbg/okg/issues/1185#issuecomment-5591114065",
   "acknowledged_interface_revision": "1475c87d5d7fc60083bb0c87a9f9f3467a1a647a",
   "acknowledged_schema_digest": "sha256:db38e9bbbe571dbb9efec29192f786d851095ca412f5a5fda17d1af81f62e662",
-  "source_revision": "e70b22043c563a95bb2850031f1a25a3472548a7",
+  "source_revision": "0aec65f9b219672f7d2d5b6c120f93e34f719e52",
   "acknowledgement_status": "current"
 }
 ```
@@ -36,15 +36,20 @@ and, for a `current` status, the acknowledged digest to equal the *current* cata
 digest. So any commit to either side invalidates it, and both sides are moving —
 #1179 through #1185 are landing on yours.
 
-On ours, one thing is worth naming because it bears on #1183. The bundle's `chat:`
-and `search:` blocks, its `schemas/` slices and its `skills/` slot are all on
-`archi_v3` and included above. Its **assistant system prompt** is not yet: it sits on
-an open PR. That asset exists because `okg chat sync` refuses a deployment declaring
-neither `mcp_instructions` nor a `system_prompt_ref` — Open WebUI never shows the
-model the MCP server's own instructions, so without it an assistant has graph tools
-registered and no idea it has them. We think that refusal is right, and we mention it
-because #1183's design should probably treat the prompt as part of what a bundle
-supplies rather than as optional decoration.
+On ours the revision above is deliberately the complete `cern-team` bundle: the
+`chat:` and `search:` blocks, the preset, the `schemas/` slices, the `skills/` slot,
+and — merged today, specifically so this acknowledgement would not need an asterisk —
+the assistant's **system prompt**.
+
+That last asset is worth a sentence for #1183, because it is a constraint we found by
+running the thing rather than by reading it. `okg chat sync` refuses a deployment
+that declares neither `mcp_instructions` nor a `system_prompt_ref`, and it is right
+to: Open WebUI never shows the model the MCP server's own instructions, so without
+one the assistant has graph tools registered and no idea it has them. That argues the
+prompt is part of what a bundle supplies rather than optional decoration. Our
+alignment page now carries the same note, along with the rest of the bundle's current
+shape — it had gone twelve days without an update while you were designing against
+it, which was our miss to fix.
 
 Second, and following from that: this cannot be the acknowledgement the real arm
 finally runs against, because the real arm cannot run until the install verb exists,

--- a/docs/outbound/DRAFT-okg-chat-deployment-friction.md
+++ b/docs/outbound/DRAFT-okg-chat-deployment-friction.md
@@ -108,8 +108,10 @@ against the same assets, one step further along.
 
 - Vendor selection logic read out of `ghcr.io/open-webui/open-webui:v0.11.0`
   directly (`config.py`, `main.py`, and the built frontend chunk cited above).
-- okg behavior read from `src/okg` at `2d528e824`; every line reference above
-  was opened, not recalled.
+- okg behavior read from `src/okg` at `2d528e824`; every line reference above was
+  opened, not recalled. Re-checked at `dev` `1475c87d5`: `chat/sync.py`,
+  `chat/instance.py` and `deployments/chat_block.py` are byte-identical between the
+  two, so every citation holds at the tree you are working on.
 - Findings 2 and 3 were met in practice during two end-to-end bring-ups: both
   were completed only by calling the vendor admin API by hand, and finding 1
   produced a confidently wrong answer that was mistaken for an okg bug until


### PR DESCRIPTION
## What this changes

Records two things we sent upstream, so the repo copy and the posted comments do not drift apart.

## Behavior before → after

**Before.** The `docs/outbound/` drafts described what we intended to send. Nothing recorded what was actually sent, or against which revision.

**After.** Both drafts match the posted comments exactly, including the values that could only be filled in after posting.

## Findings, worst first

1. **The acknowledgement's `source_revision` had to change between draft and posting** — from `e70b2204` to `0aec65f9`, the `archi_v3` head *after* #632 merged. That was the point of merging first: the acknowledged tree now contains the assistant system prompt, so the acknowledgement needs no asterisk about our own bundle being incomplete. Posted at [okg#1185 comment 5591114065](https://github.com/mitdbg/okg/issues/1185#issuecomment-5591114065).
2. **`review_reference` names the acknowledging comment itself**, so it cannot be known before posting. Filled in by editing the comment afterwards, and the draft now carries the same value.
3. **The earlier caveat was wrong on two of three counts** and is now moot on the third. It had said the chat block, the system prompt and the schema slices were all off `archi_v3`; only the prompt was.
4. **The chat findings' line numbers were taken at our pin**, `2d528e824`, while okg works at `1475c87d5`. A stale line number is how a real finding gets dismissed as not reproducing. Posted at [okg#1183 comment 5591286914](https://github.com/mitdbg/okg/issues/1183#issuecomment-5591286914).

## How I verified

- All five acknowledgement field values were checked against okg's own validators by regex — `_CONSUMER_ID_RE`, `_ISSUE_COMMENT_RE`, `_INTERFACE_REVISION_RE`, `_GIT_REVISION_RE`, and the sha256 digest shape — rather than by eye. One wrong hex character would fail silently at conformance time.
- `chat/sync.py`, `chat/instance.py` and `deployments/chat_block.py` are byte-identical between `2d528e824` and `1475c87d5`, and the two sharpest citations were re-read at `dev`. Every citation in the report holds at the tree okg is working on.
- The schema digest was computed by evaluating `conformance_schema_catalog()` against a scratch extraction of okg `dev`, not taken from a fixture.

## Not addressed here

The okg pin is still `2d528e824`. Running our suite against `dev` was refused by a permission classifier in this session, so that claim is deliberately not made anywhere — the alignment page says the re-audit is pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Dhd8kXJLfAJjDDZHXaXds
