### PR TITLE
pact: migrate the corpus to v5, bump the okg pin, correct the internal docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,40 @@ conflicts with this repo, these overrides win (they match
 - References to `okg-workspace`, `okg dogfood`, and okg-repo runbooks
   (`docs/runbooks/agent-*.md`) do not exist in this repo; the PACT graph
   projection here is the interim `archi-pact` ledger deployment.
+- **This repo's PACT corpus is v5; the managed section's verb list is
+  stale (2026-09-08).** All nine manifests under `pact/changes/` and
+  `pact/archive/` were migrated by okg's own `pact migrate`. The v5 CLI is
+  a separate entry point that ignores `pact/project.yaml` entirely and
+  takes the git toplevel as its root:
+
+  ```
+  /work/submit/lavezzo/okg-venv/bin/python -m pact.cli --root <repo> <verb>
+  ```
+
+  Its verbs are `new`, `view`, `evidence attach`, `check`, `approve`,
+  `digest`, `migrate`, `usage`. **`check` is the one gate** — it validates,
+  binds receipts, verifies approval and computes the tier in a single call,
+  replacing the separate gate/decide steps below. **`approve` records the
+  operator's approval as a `Pact-Approved` git commit trailer**, not as a
+  ledger row. `gate`, `decide`, `hooks`, `sync` and `migrate-version` are
+  suppressed in v5: where the managed section names them, prefer `check`.
+
+  Two consequences worth knowing before you trust a reading:
+  - The old `okg pact view` still parses a v5 manifest but reports
+    `normative_v4: true` on it. Treat that output as degraded, not as
+    authority.
+  - A v5 task has only `id`, `requirement` and `verification` — **there is
+    no per-task status field.** Completion is derived from receipts bound
+    to a commit, so migrated evidence carries as `evidence_unbound`
+    warnings until it is re-attached with `evidence attach`. That is why
+    `check` currently reports W2's five requirements as unproven; it is the
+    same conclusion v4's staleness guard had already reached, not new
+    breakage.
+
+  `pact/project.yaml` deliberately still declares `pact_version: 4` — okg
+  left theirs at 4 after migrating their own corpus, the v4 compatibility
+  reader still uses it, and v5 never reads it. Do not "fix" it.
+
 - **Alignment-page policy (standing):** `docs/okg-alignment.md` is the
   OKG-side program's (okg#1178) window into this repo. Any change that
   touches python/archi's okg imports, bumps the okg commit we test

--- a/docs/okg-alignment.md
+++ b/docs/okg-alignment.md
@@ -71,10 +71,21 @@ acknowledgement binds one Archi revision to one OKG schema digest, so a commit t
 either side stales it again — an open question on that comment asks whether it is
 meant to be re-issued per run.
 
-**Still on v4 PACT.** okg cut its corpus over to v5 (#1691, #1687, merged
-2026-09-07); `pact/project.yaml` here still declares `pact_version: 4`. v5 support
-exists only at `dev` — `src/pact/` and `okg/substrate/pact/v5_adapter.py` — so the
-migration was blocked until this pin bump and is now unblocked.
+**PACT corpus migrated to v5 (2026-09-08).** okg cut over on 2026-09-07 (#1691,
+#1687) and we followed the same day, using okg's own `pact migrate`: all nine
+manifests under `pact/changes/` and `pact/archive/` are now `pact_version: 5`, zero
+refused, zero destructive notes. Two things for anyone reading our ledger:
+
+- **Our evidence carries but does not bind.** `check` reports the migrated evidence
+  rows as `evidence_unbound` and W2's five requirements as unproven. v5 binds
+  receipts to a commit and ours predate that model. This is the same conclusion v4's
+  staleness guard had already reached after PR #617 touched `python/archi` — not new
+  breakage — but it does mean our ledger currently asserts less than its prose does,
+  and re-attaching receipts is outstanding work.
+- **`pact/project.yaml` stays at `pact_version: 4` deliberately**, matching okg's own
+  choice for theirs: the v4 compatibility reader consults it and the v5 CLI never
+  does. Note also that `okg pact view` still parses a v5 manifest but reports
+  `normative_v4: true` on it — degraded output, not authority.
 
 **Sprint 11 (okg#1698) is the Archi chain.** Its exit criteria are
 #1178 → #1179 → #1181 → #1180 → #1183 → #1184 → #1185, with #1185 run on a real

--- a/docs/okg-alignment.md
+++ b/docs/okg-alignment.md
@@ -20,9 +20,8 @@ reimplementation of OKG services.
 
 ## Current state (update this section when it changes)
 
-*Last updated 2026-09-08. Tested against okg `dev` @ `2d528e824`; live okg `dev` is
-`1475c87d5`, so **the pin is behind and the re-audit is pending** — see "Pin drift"
-below. Archi branch `archi_v3` with PRs #610–#631 merged and #632 open.*
+*Last updated 2026-09-08, tested against okg `dev` @ `1475c87d5`; archi branch
+`archi_v3` with PRs #610–#634 merged.*
 
 **The bundle now ships the assistant's system prompt (2026-09-08, PR #632).**
 `bundles/cern-team/skills/chat-system-prompt.md`, declared as
@@ -51,19 +50,31 @@ cannot be declared at all (`chat-instance up` injects two hardcoded variables,
 reports green on an instance that cannot answer. Third, the first admin account is
 not bootstrapped. Filed separately; recorded here so #1183's design has them.
 
-**Pin drift, and why it matters more than usual (2026-09-08).** We are pinned to
-`2d528e824`; `dev` is `1475c87d5`. The external-distribution conformance contract
-landed inside that gap — `conformance.py` did not exist at our pin and is 2,132 lines
-at `dev`, arriving in `46c42c7e0` via PR #1377 (merged 2026-08-28), with #1406
-following on 08-30. Two consequences: our installed okg cannot evaluate the
-conformance schema at all, and **our existing acknowledgement is stale**. Comment
-`5440260363` names branch `f4081329` and schema digest `sha256:301ec97f…`; the
-catalog digest at `dev` is now
-`sha256:db38e9bbbe571dbb9efec29192f786d851095ca412f5a5fda17d1af81f62e662`. Until it
-is re-issued, the real conformance arm returns
-`conformance_external_acknowledgement_pending`. The suite has **not** yet been re-run
-against `1475c87d5`; the ten guarded `okg.substrate.*` symbols below are therefore
-still asserted only at `2d528e824`.
+**Pin bumped 2d528e824 → 1475c87d5, drift closed (2026-09-08).** A 1153-commit
+fast-forward, and **the import surface survived it unchanged**: full archi suite
+**339 passed**, including `test_alignment_page.py`, which mechanically checks every
+one of the ten private `okg.substrate.*` symbols below still resolves. No source
+change was needed on our side.
+
+The external-distribution conformance contract landed inside that gap —
+`conformance.py` did not exist at the old pin and is 2,132 lines at `dev`, arriving
+in `46c42c7e0` via PR #1377 (merged 2026-08-28), with #1406 following on 08-30. That
+had made our acknowledgement stale twice over: comment `5440260363` named branch
+`f4081329` and schema digest `sha256:301ec97f…`, while the catalog digest is now
+`sha256:db38e9bbbe571dbb9efec29192f786d851095ca412f5a5fda17d1af81f62e662`. **Re-issued
+2026-09-08** at
+[#1185 comment `5591114065`](https://github.com/mitdbg/okg/issues/1185#issuecomment-5591114065),
+naming `dev` rather than a branch and vouching for `archi_v3` @ `0aec65f9`, so the
+real conformance arm no longer returns
+`conformance_external_acknowledgement_pending`. Note for whoever re-runs it: that
+acknowledgement binds one Archi revision to one OKG schema digest, so a commit to
+either side stales it again — an open question on that comment asks whether it is
+meant to be re-issued per run.
+
+**Still on v4 PACT.** okg cut its corpus over to v5 (#1691, #1687, merged
+2026-09-07); `pact/project.yaml` here still declares `pact_version: 4`. v5 support
+exists only at `dev` — `src/pact/` and `okg/substrate/pact/v5_adapter.py` — so the
+migration was blocked until this pin bump and is now unblocked.
 
 **Sprint 11 (okg#1698) is the Archi chain.** Its exit criteria are
 #1178 → #1179 → #1181 → #1180 → #1183 → #1184 → #1185, with #1185 run on a real

--- a/docs/outbound/DRAFT-okg-1181-enricher-scope.md
+++ b/docs/outbound/DRAFT-okg-1181-enricher-scope.md
@@ -1,0 +1,89 @@
+Answering the enricher question, with the surface list and migration notes you asked
+for. Short version: **ship connectors first**, with one condition.
+
+## The answer
+
+Scope #1181's first pass to connectors. Do not hold it for the enricher read surface.
+
+Our exposure is lopsided — roughly 25 connectors against 6 enrichers — so a
+connectors-only pass covers most of what we depend on. More importantly, the enricher
+problem is genuinely hard, and it currently sits in front of the rest of Sprint 11,
+including #1185, which is the work that proves the whole distribution functions. That
+is the wrong thing to block.
+
+**The condition: keep the existing enricher path working until its replacement
+exists.** Our five database-backed enrichers work today. If the boundary lint or the
+cleanup removes the live-connection path before there is something to move to, they
+break with nowhere to go. Deferring the design is fine; deferring the design while
+withdrawing the current mechanism is not.
+
+## Our numbers match yours
+
+Five of our six enrichers cannot be expressed without a live connection — the same
+ratio as your 34 of 38. Only the anonymizer stays out of the database.
+
+| Enricher | What it derives |
+|---|---|
+| `jira_affects` | links a JIRA issue to the software it affects |
+| `meeting_document_reference_rollup` | links a meeting to what its documents reference |
+| `chunk_reference_rollup` | rolls chunk-level references up to the parent document |
+| `alias` | resolves that two names denote the same thing |
+| `dqm_run_range` | attaches certifications to the runs they cover |
+| `anonymizer` | strips personal data — the only one needing no reads |
+
+## The read surface we would need
+
+In rough order of how hard they look to express:
+
+1. **Multi-hop traversal.** `meeting_document_reference_rollup` walks meeting →
+   `contains` → document → `contains` → chunk → `references` → target: three hops,
+   six joins, in one query. A one-node-at-a-time read API turns this into an N+1
+   walk over the whole meeting corpus.
+2. **Incremental change detection over the fact log.** Two of ours read
+   `okg.node_facts` / `okg.edge_facts` with `fact_id > <watermark>` — "what changed
+   since I last ran". This is not a graph read at all; it is a monotonic cursor over
+   the append-only log, and it is the capability most likely to be missing from any
+   node-and-edge-shaped API. Without it these become full rescans.
+3. **Aggregation over a traversal.** Three of ours `GROUP BY` across the join to roll
+   many child references into one parent edge, with counts.
+4. **Anti-join on existence.** `dqm_run_range` does
+   `LEFT JOIN okg.graph_edges existing … WHERE existing.edge_id IS NULL` — create this
+   edge only where one does not already exist. Expressible as a read-then-filter, but
+   only if the read is bulk.
+5. **Scan by subtype, returning attributes.** Not just ids: `alias` and
+   `dqm_run_range` both need `attrs`.
+6. **Range join.** `dqm_run_range` joins certifications to runs by run-number
+   interval, not by equality.
+7. **Edge existence by id set.** A bulk `edge_id = ANY(...)` membership check.
+
+**What we do not need, so you can leave it out of a first cut:** vector top-k. None
+of our enrichers use similarity search.
+
+**On the write side** we are simpler than the read side suggests: we emit derived
+edges through `insert_deterministic_edges` with `DerivedEdgeCandidate`, and write no
+node facts. If the first enricher pass covered reads plus deterministic derived
+edges, it would cover all six of ours.
+
+## Migration notes
+
+The names our enrichers import today, as the surface list you asked for:
+
+- `okg.substrate.enrichers.base` — `EnrichResult`, `IncrementalContext`
+- `okg.substrate.enrichers.derived_edges` — `DerivedEdgeCandidate`,
+  `insert_deterministic_edges`
+- `okg.substrate.alias.protocol` — `AliasMatch`
+- `okg.substrate.library.linkers.declarative` — `DeclarativeLinker`
+- `okg.substrate.library.linkers` — **`_chronos`**
+
+That last one is worth flagging: we depend on an underscore-prefixed name, private by
+Python convention, never mind by your boundary rules. It is the clearest example of
+why this SDK is worth doing, and if the connectors-only pass can absorb nothing else
+from this list, that one is the one to take.
+
+Two smaller points on your note. Your §2 is right that enrichers are handed a live
+connection inside a savepoint on the publish cycle's transaction, and that moving
+them out relocates derived edges relative to the source facts' generation boundary —
+that is a semantic change for us, not only a plumbing one, so we would want it called
+out explicitly rather than arriving as a side effect. And we agree with ordering the
+read surface *before* the enricher protocol; designing the protocol first would just
+encode whatever the reads happen to allow.

--- a/pact/archive/circleback-fixes/pact.yaml
+++ b/pact/archive/circleback-fixes/pact.yaml
@@ -1,112 +1,67 @@
-pact_version: 4
-target_pact_version: 4
-change:
-  id: circleback-fixes
-  title: 'Circle-back review fixes: scope-claim, anonymizer, and hygiene waves'
-  status: proposal
-  rationale: 'The deferred whole-package adversarial review (4 domain reviewers on
-    archi_v3@728739e6) confirmed 3 blockers / 15 majors, dominated by one class: connectors
-    claiming completed_scope after silently losing input, which under missing_from_completed_scope
-    means mass retraction of good records; plus PII leak paths in the anonymizer (the
-    v2 anonymize_data cutover gate). Fixes are deliberate deviations from the frozen
-    canonical okg-deployments/cms copies (~85% of findings are shared), recorded in
-    per-domain notes files in this change dir. Out of scope by design: enricher dedupe/retraction
-    lifecycle and SourceRun.record_set plumbing (substrate-side contracts, routed
-    to okg#1178).'
-  root_cause: Small nontrivial change whose intent, task, acceptance, and proof fit
-    the PACT fast path.
-  tier: 1
-  method_metadata:
-    pact_shape: fast_path
-    fast_path: Compact PACT for small nontrivial work. Upgrade when scope, risk, hierarchy,
-      formal proof, graph evidence, or review complexity increases.
-  affected_areas:
-  - python/archi/sources
-  - python/archi/tools
-  - python/archi/enrichment
-  - skills
-  affected_code: []
+pact_version: 5
+id: circleback-fixes
+title: 'Circle-back review fixes: scope-claim, anonymizer, and hygiene waves'
+tier: 1
+why: 'The deferred whole-package adversarial review (4 domain reviewers on archi_v3@728739e6)
+  confirmed 3 blockers / 15 majors, dominated by one class: connectors claiming completed_scope
+  after silently losing input, which under missing_from_completed_scope means mass retraction
+  of good records; plus PII leak paths in the anonymizer (the v2 anonymize_data cutover gate).
+  Fixes are deliberate deviations from the frozen canonical okg-deployments/cms copies (~85%
+  of findings are shared), recorded in per-domain notes files in this change dir. Out of scope
+  by design: enricher dedupe/retraction lifecycle and SourceRun.record_set plumbing (substrate-side
+  contracts, routed to okg#1178).
+
+
+  Small nontrivial change whose intent, task, acceptance, and proof fit the PACT fast path.'
+affected_code: []
 requirements:
 - id: req.circleback-fixes
-  title: 'Circle-back review fixes: scope-claim, anonymizer, and hygiene waves'
-  statement: Every confirmed blocker/major finding from the circle-back review is
-    either fixed with a regression test reproducing its failure scenario, or explicitly
-    routed upstream (okg#1178) with the reason recorded. No connector claims completed_scope
-    when any enumerated input failed, was truncated, or parsed to nothing from non-empty
-    input; no anonymizer leak case in the review corpus survives; the full v3 suite
-    passes with zero regressions; every behavioral deviation from canonical cms code
-    is recorded in notes-{catalogs,live,enrichment}.md in this change dir.
-  evidence_policy:
-    required:
-    - executed_test
-  scenarios:
-  - id: scn.circleback-fixes.fast-path
-    title: Fast-path work is verified
-    given:
-    - a small nontrivial change fits one requirement
-    when:
-    - the declared verification runs
-    then:
-    - the requirement has executed proof before completion
-    and: []
-  acceptance:
-  - id: acc.circleback-fixes
-    description: Full suite green including new regression tests for each fixed finding
-      (scope-claim class, anonymizer leak corpus, tools error contract); notes files
-      present for all three domains.
-    evidence:
-    - executed_test
+  statement: "Circle-back review fixes: scope-claim, anonymizer, and hygiene waves\n\nEvery\
+    \ confirmed blocker/major finding from the circle-back review is either fixed with a regression\
+    \ test reproducing its failure scenario, or explicitly routed upstream (okg#1178) with\
+    \ the reason recorded. No connector claims completed_scope when any enumerated input failed,\
+    \ was truncated, or parsed to nothing from non-empty input; no anonymizer leak case in\
+    \ the review corpus survives; the full v3 suite passes with zero regressions; every behavioral\
+    \ deviation from canonical cms code is recorded in notes-{catalogs,live,enrichment}.md\
+    \ in this change dir.\n\nAcceptance:\n- acc.circleback-fixes: Full suite green including\
+    \ new regression tests for each fixed finding (scope-claim class, anonymizer leak corpus,\
+    \ tools error contract); notes files present for all three domains. [evidence: executed_test]\n\
+    \nScenarios:\n- scn.circleback-fixes.fast-path Fast-path work is verified\n  Given a small\
+    \ nontrivial change fits one requirement\n  When the declared verification runs\n  Then\
+    \ the requirement has executed proof before completion"
 tasks:
 - id: task.circleback-fixes
-  title: 'Circle-back review fixes: scope-claim, anonymizer, and hygiene waves'
-  status: done
-  verification: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests -q
-    (full suite, zero failures; includes new regression tests per fixed finding)
-  requirements:
-  - req.circleback-fixes
-  evidence: []
-  environment: []
-dependencies: []
-test_plan:
-- id: test.req-circleback-fixes.full-suite
   requirement: req.circleback-fixes
-  test_id: python/tests
-  evidence:
-  - pytest
-formal: []
-waivers: []
+  verification: 'Circle-back review fixes: scope-claim, anonymizer, and hygiene waves
+
+
+    /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests -q (full suite, zero failures;
+    includes new regression tests per fixed finding)
+
+
+    Test plan:
+
+    - python/tests [evidence: pytest]'
 evidence:
-- id: ev.executed-test.req-circleback-fixes.20260824T141031575824Z
-  kind: executed_test
+- kind: executed_test
+  requirement: req.circleback-fixes
   status: pass
-  refs:
-  - req.circleback-fixes
-  artifact: python/tests
   command: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests -q
-  summary: Full suite 320 passed (254 baseline + 66 new regression tests across catalogs/live/enrichment/hygiene
+  at: '2026-08-24T14:10:31.575851+00:00'
+  note: Full suite 320 passed (254 baseline + 66 new regression tests across catalogs/live/enrichment/hygiene
     waves); junit report ingested.
-  data:
-    attached_at: '2026-08-24T14:10:31.575851+00:00'
-- id: ev.executed-test.acc-circleback-fixes.20260824T141033150775Z
-  kind: executed_test
+- kind: executed_test
+  requirement: req.circleback-fixes
   status: pass
-  refs:
-  - acc.circleback-fixes
-  artifact: python/tests
-  summary: 'Acceptance: suite green incl. leak-corpus, scope-claim, and tools-error
-    regression tests; notes files present for catalogs/live/enrichment/hygiene.'
-  data:
-    attached_at: '2026-08-24T14:10:33.150802+00:00'
-- id: ev.executed-test.req-circleback-fixes.20260824T143454559459Z
-  kind: executed_test
+  at: '2026-08-24T14:10:33.150802+00:00'
+  note: 'Acceptance: suite green incl. leak-corpus, scope-claim, and tools-error regression
+    tests; notes files present for catalogs/live/enrichment/hygiene.'
+- kind: executed_test
+  requirement: req.circleback-fixes
   status: pass
-  refs:
-  - req.circleback-fixes
-  artifact: python/tests
   command: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests -q
-  summary: 'Final suite after adversarial-review deltas: 326 passed (72 new regression
-    tests over the 254 baseline). Independent adversarial diff review: branch holds;
-    its one major escape (cmssw map-path zero-parse) and all prescriptions fixed or
-    documented.'
-  data:
-    attached_at: '2026-08-24T14:34:54.559492+00:00'
+  at: '2026-08-24T14:34:54.559492+00:00'
+  note: 'Final suite after adversarial-review deltas: 326 passed (72 new regression tests
+    over the 254 baseline). Independent adversarial diff review: branch holds; its one major
+    escape (cmssw map-path zero-parse) and all prescriptions fixed or documented.'
+decisions: []

--- a/pact/archive/w1-prove-the-seam/pact.yaml
+++ b/pact/archive/w1-prove-the-seam/pact.yaml
@@ -1,90 +1,52 @@
-pact_version: 4
-target_pact_version: 4
-change:
-  id: w1-prove-the-seam
-  title: 'W1: prove the pip-installed package seam'
-  status: verification
-  rationale: "ADR 0001 (W1) rests the whole v3 architecture on one unexercised mechanism:\
-    \ a pip-installed archi package serving sources and schemas to an out-of-tree\
-    \ OKG deployment. This change records the constructive proof, executed 2026-08-11\
-    \ on submit82 against okg dev@21c5b8c3e: an archi wheel (one source, one schema,\
-    \ zero dependencies) was registered in a scratch deployment via `module: archi.sources.cmssw`,\
-    \ fetched the public cms-bot releases.map, ingested, published a generation, and\
-    \ both MCP `search` and `query` returned the facts generation-pinned with provenance\
-    \ `source: archi.cmssw-releases`. `okg deployment lint` reported only info-level\
-    \ findings. Friction found is logged in FRICTION.md (6 items) and feeds ADR 0001\
-    \ \xA77 ask 5."
-  root_cause: The importlib-based source registry supports installed packages, but
-    no test or doc upstream exercises that path; Archi depends on it everywhere.
-  method_metadata:
-    pact_shape: fast_path
-    fast_path: Retroactive record of the W1 spike; live round-trip evidence is narrative
-      (FRICTION.md) until the decision ledger exists; the offline adapter contract
-      is covered by executed tests in spike/.
-  affected_areas:
-  - pact/changes/w1-prove-the-seam/spike
-  affected_code: []
+pact_version: 5
+id: w1-prove-the-seam
+title: 'W1: prove the pip-installed package seam'
+tier: 1
+why: 'ADR 0001 (W1) rests the whole v3 architecture on one unexercised mechanism: a pip-installed
+  archi package serving sources and schemas to an out-of-tree OKG deployment. This change
+  records the constructive proof, executed 2026-08-11 on submit82 against okg dev@21c5b8c3e:
+  an archi wheel (one source, one schema, zero dependencies) was registered in a scratch deployment
+  via `module: archi.sources.cmssw`, fetched the public cms-bot releases.map, ingested, published
+  a generation, and both MCP `search` and `query` returned the facts generation-pinned with
+  provenance `source: archi.cmssw-releases`. `okg deployment lint` reported only info-level
+  findings. Friction found is logged in FRICTION.md (6 items) and feeds ADR 0001 §7 ask 5.
+
+
+  The importlib-based source registry supports installed packages, but no test or doc upstream
+  exercises that path; Archi depends on it everywhere.'
+affected_code: []
 requirements:
 - id: req.w1-prove-the-seam
-  title: Wheel-served source round-trips through an OKG deployment
-  statement: A source adapter imported from an installed archi wheel (not a deployment
-    directory) must run under OKG's SourceRunner, publish into a generation, and be
-    readable over the MCP surface generation-pinned; its adapter contract (parse determinism,
-    NodeFact shape, content-hash probe declaration) must hold under offline test.
-  evidence_policy:
-    required:
-    - executed_test
-  scenarios:
-  - id: scn.w1-prove-the-seam.fast-path
-    title: Fast-path work is verified
-    given:
-    - the spike package in spike/ mirrors the wheel that ran live on 2026-08-11
-    when:
-    - the declared verification runs with an okg-bearing interpreter
-    then:
-    - the requirement has executed proof before completion
-    and: []
-  acceptance:
-  - id: acc.w1-prove-the-seam
-    description: 'spike/test_seam_source.py passes (4 tests: parse grouping/ordering,
-      limit semantics, NodeFact emission from cache, probe-kind declaration); the
-      live round trip is reproducible from FRICTION.md''s bring-up sequence.'
-    evidence:
-    - executed_test
+  statement: "Wheel-served source round-trips through an OKG deployment\n\nA source adapter\
+    \ imported from an installed archi wheel (not a deployment directory) must run under OKG's\
+    \ SourceRunner, publish into a generation, and be readable over the MCP surface generation-pinned;\
+    \ its adapter contract (parse determinism, NodeFact shape, content-hash probe declaration)\
+    \ must hold under offline test.\n\nAcceptance:\n- acc.w1-prove-the-seam: spike/test_seam_source.py\
+    \ passes (4 tests: parse grouping/ordering, limit semantics, NodeFact emission from cache,\
+    \ probe-kind declaration); the live round trip is reproducible from FRICTION.md's bring-up\
+    \ sequence. [evidence: executed_test]\n\nScenarios:\n- scn.w1-prove-the-seam.fast-path\
+    \ Fast-path work is verified\n  Given the spike package in spike/ mirrors the wheel that\
+    \ ran live on 2026-08-11\n  When the declared verification runs with an okg-bearing interpreter\n\
+    \  Then the requirement has executed proof before completion"
 tasks:
 - id: task.w1-prove-the-seam
-  title: Execute the seam proof and record friction
-  status: done
-  verification: pact/changes/w1-prove-the-seam/spike/test_seam_source.py
-  requirements:
-  - req.w1-prove-the-seam
-  evidence: []
-  environment:
-  - id: env.w1.okg-interpreter
-    kind: env_var
-    env: OKG_VENV_PYTHON
-    description: Path to an okg-bearing interpreter (e.g. /work/submit/lavezzo/okg-venv/bin/python).
-      okg is a host dependency, deliberately not an archi dependency.
-    required: false
-dependencies: []
-test_plan:
-- id: test.req-w1-prove-the-seam.spike-test-seam-source
   requirement: req.w1-prove-the-seam
-  test_id: pact/changes/w1-prove-the-seam/spike/test_seam_source.py
-  evidence:
-  - pytest
-formal: []
-waivers: []
+  verification: 'Execute the seam proof and record friction
+
+
+    pact/changes/w1-prove-the-seam/spike/test_seam_source.py
+
+
+    Test plan:
+
+    - pact/changes/w1-prove-the-seam/spike/test_seam_source.py [evidence: pytest]'
 evidence:
-- id: ev.pytest.req-w1-prove-the-seam.20260811T205000796912Z
-  kind: pytest
+- kind: executed_test
+  requirement: req.w1-prove-the-seam
   status: pass
-  refs:
-  - req.w1-prove-the-seam
-  artifact: pact/changes/w1-prove-the-seam/spike/test_seam_source.py
   command: /work/submit/lavezzo/okg-venv/bin/python -m pytest pact/changes/w1-prove-the-seam/spike/test_seam_source.py
     -q
-  summary: 4/4 adapter-contract tests pass (parse grouping/order, limit, NodeFact
-    emission, probe kind); live round trip recorded in FRICTION.md
-  data:
-    attached_at: '2026-08-11T20:50:00.796963+00:00'
+  at: '2026-08-11T20:50:00.796963+00:00'
+  note: 4/4 adapter-contract tests pass (parse grouping/order, limit, NodeFact emission, probe
+    kind); live round trip recorded in FRICTION.md
+decisions: []

--- a/pact/archive/w6-cern-team-bundle/pact.yaml
+++ b/pact/archive/w6-cern-team-bundle/pact.yaml
@@ -1,78 +1,48 @@
-pact_version: 4
-target_pact_version: 4
-change:
-  id: w6-cern-team-bundle
-  title: 'W6: cern-team bundle + install demo'
-  status: proposal
-  rationale: 'ADR 0001 W6 / okg#1185: the cern-team bundle turns a blank OKG install
-    into a working HEP instance. Demo executed 2026-08-21 on submit82: okg install
-    --profile cern-team on a fresh DB, lint zero blocker/warning, four connectors
-    ingest OK (live cmssw fetch), a generation published with cross-connector reference
-    edges, idempotent re-run. Runbook docs/cern-team-demo.md; results + friction log
-    in w2-consolidate-hep-sources/cern-team-demo-evidence.md.'
-  root_cause: Small nontrivial change whose intent, task, acceptance, and proof fit
-    the PACT fast path.
-  tier: 1
-  method_metadata:
-    pact_shape: fast_path
-    fast_path: Compact PACT for small nontrivial work. Upgrade when scope, risk, hierarchy,
-      formal proof, graph evidence, or review complexity increases.
-  affected_areas: []
-  affected_code: []
+pact_version: 5
+id: w6-cern-team-bundle
+title: 'W6: cern-team bundle + install demo'
+tier: 1
+why: 'ADR 0001 W6 / okg#1185: the cern-team bundle turns a blank OKG install into a working
+  HEP instance. Demo executed 2026-08-21 on submit82: okg install --profile cern-team on a
+  fresh DB, lint zero blocker/warning, four connectors ingest OK (live cmssw fetch), a generation
+  published with cross-connector reference edges, idempotent re-run. Runbook docs/cern-team-demo.md;
+  results + friction log in w2-consolidate-hep-sources/cern-team-demo-evidence.md.
+
+
+  Small nontrivial change whose intent, task, acceptance, and proof fit the PACT fast path.'
+affected_code: []
 requirements:
 - id: req.w6-cern-team-bundle
-  title: 'W6: cern-team bundle + install demo'
-  statement: okg install --profile cern-team (external OKG_PROFILES_DIR) plus the
-    two documented manual steps must produce a lint-clean instance whose connectors
-    ingest and publish a readable generation; the bundle files must keep the strict-admission
-    shape, resolvable playbook symlinks, and no operator paths or credential values.
-  evidence_policy:
-    required:
-    - executed_test
-  scenarios:
-  - id: scn.w6-cern-team-bundle.fast-path
-    title: Fast-path work is verified
-    given:
-    - a small nontrivial change fits one requirement
-    when:
-    - the declared verification runs
-    then:
-    - the requirement has executed proof before completion
-    and: []
-  acceptance:
-  - id: acc.w6-cern-team-bundle
-    description: python/tests/test_bundle_cern_team.py passes (4 structural guards);
-      the live run is reproducible from docs/cern-team-demo.md.
-    evidence:
-    - executed_test
+  statement: "W6: cern-team bundle + install demo\n\nokg install --profile cern-team (external\
+    \ OKG_PROFILES_DIR) plus the two documented manual steps must produce a lint-clean instance\
+    \ whose connectors ingest and publish a readable generation; the bundle files must keep\
+    \ the strict-admission shape, resolvable playbook symlinks, and no operator paths or credential\
+    \ values.\n\nAcceptance:\n- acc.w6-cern-team-bundle: python/tests/test_bundle_cern_team.py\
+    \ passes (4 structural guards); the live run is reproducible from docs/cern-team-demo.md.\
+    \ [evidence: executed_test]\n\nScenarios:\n- scn.w6-cern-team-bundle.fast-path Fast-path\
+    \ work is verified\n  Given a small nontrivial change fits one requirement\n  When the\
+    \ declared verification runs\n  Then the requirement has executed proof before completion"
 tasks:
 - id: task.w6-cern-team-bundle
-  title: 'W6: cern-team bundle + install demo'
-  status: done
-  verification: python/tests/test_bundle_cern_team.py
-  requirements:
-  - req.w6-cern-team-bundle
-  evidence: []
-  environment: []
-dependencies: []
-test_plan:
-- id: test.req-w6-cern-team-bundle.tests-todo-test-w6-cern-team-bundle-py-test-w6-cern-team-bundle
   requirement: req.w6-cern-team-bundle
-  test_id: python/tests/test_bundle_cern_team.py
-  evidence:
-  - pytest
-formal: []
-waivers: []
+  verification: 'W6: cern-team bundle + install demo
+
+
+    python/tests/test_bundle_cern_team.py
+
+
+    Test plan:
+
+    - python/tests/test_bundle_cern_team.py [evidence: pytest]'
 evidence:
-- id: ev.pytest.req-w6-cern-team-bundle.20260821T160621143261Z
-  kind: pytest
+- kind: executed_test
+  requirement: req.w6-cern-team-bundle
   status: pass
-  refs:
-  - req.w6-cern-team-bundle
-  artifact: python/tests/test_bundle_cern_team.py
   command: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests/test_bundle_cern_team.py
     -q
-  summary: '4/4 bundle guards; live demo: lint clean, 4 connectors OK, gen 20260821T155948...
+  artifact: python/tests/test_bundle_cern_team.py
+  sha256: f3515d5aec7d8600fd5eaec289ea42b349ecea6a6928c0605ae1d7378f411a31
+  at: '2026-08-21T16:06:21.143296+00:00'
+  note: '4/4 bundle guards; live demo: lint clean, 4 connectors OK, gen 20260821T155948...
     published, cross-connector edges, idempotent (docs/cern-team-demo.md)'
-  data:
-    attached_at: '2026-08-21T16:06:21.143296+00:00'
+decisions: []

--- a/pact/archive/w7-compops-instance/pact.yaml
+++ b/pact/archive/w7-compops-instance/pact.yaml
@@ -1,98 +1,60 @@
-pact_version: 4
-target_pact_version: 4
-change:
-  id: w7-compops-instance
-  title: 'W7: cms-compops v3 instance + parity gate'
-  status: proposal
-  rationale: 'ADR 0001 W7, model corrected 2026-08-21: gitlab.cern.ch/archi/cms-compops
-    (branch archi_v3) is THE comp-ops instance repo; it gains a v3 instance definition
-    built on the archi distribution, replacing its v2 A2rchi configs at cutover. okg-deployments/cms
-    is the frozen prototype/parity reference and retires at parity. Local half: author
-    + fixture-validate the instance from submit82. Credentialed half (live bring-up
-    + strict parity vs the v2 corpus) runs on a CERN host per docs/bring-up.md and
-    is the W7 exit gate.'
-  root_cause: Small nontrivial change whose intent, task, acceptance, and proof fit
-    the PACT fast path.
-  tier: 1
-  method_metadata:
-    pact_shape: fast_path
-    fast_path: Compact PACT for small nontrivial work. Upgrade when scope, risk, hierarchy,
-      formal proof, graph evidence, or review complexity increases.
-  affected_areas: []
-  affected_code: []
+pact_version: 5
+id: w7-compops-instance
+title: 'W7: cms-compops v3 instance + parity gate'
+tier: 1
+why: 'ADR 0001 W7, model corrected 2026-08-21: gitlab.cern.ch/archi/cms-compops (branch archi_v3)
+  is THE comp-ops instance repo; it gains a v3 instance definition built on the archi distribution,
+  replacing its v2 A2rchi configs at cutover. okg-deployments/cms is the frozen prototype/parity
+  reference and retires at parity. Local half: author + fixture-validate the instance from
+  submit82. Credentialed half (live bring-up + strict parity vs the v2 corpus) runs on a CERN
+  host per docs/bring-up.md and is the W7 exit gate.
+
+
+  Small nontrivial change whose intent, task, acceptance, and proof fit the PACT fast path.'
+affected_code: []
 requirements:
 - id: req.w7-compops-instance
-  title: 'W7: cms-compops v3 instance + parity gate'
-  statement: cms-compops@archi_v3 carries the full v3 instance definition (versions
-    pins, deployment.yaml, complete connector registry mirroring the canonical selection,
-    materialized schemas/playbooks, relocated parity harness, credentialed runbook);
-    it lints with zero blocker/warning, fixture-backed connectors ingest and publish
-    locally, and credentialed connectors fail clean (no crash, no false complete scope).
-  evidence_policy:
-    required:
-    - graph_report
-  scenarios:
-  - id: scn.w7-compops-instance.fast-path
-    title: Fast-path work is verified
-    given:
-    - a small nontrivial change fits one requirement
-    when:
-    - the declared verification runs
-    then:
-    - the requirement has executed proof before completion
-    and: []
-  acceptance:
-  - id: acc.w7-compops-instance
-    description: okg deployment lint cms-compops zero blocker/warning + local validation
-      table (per-connector ingest status, generation id) recorded as evidence; live
-      parity audit deferred to the credentialed half, tracked in this change until
-      run.
-    evidence:
-    - graph_report
+  statement: "W7: cms-compops v3 instance + parity gate\n\ncms-compops@archi_v3 carries the\
+    \ full v3 instance definition (versions pins, deployment.yaml, complete connector registry\
+    \ mirroring the canonical selection, materialized schemas/playbooks, relocated parity\
+    \ harness, credentialed runbook); it lints with zero blocker/warning, fixture-backed connectors\
+    \ ingest and publish locally, and credentialed connectors fail clean (no crash, no false\
+    \ complete scope).\n\nAcceptance:\n- acc.w7-compops-instance: okg deployment lint cms-compops\
+    \ zero blocker/warning + local validation table (per-connector ingest status, generation\
+    \ id) recorded as evidence; live parity audit deferred to the credentialed half, tracked\
+    \ in this change until run. [evidence: graph_report]\n\nScenarios:\n- scn.w7-compops-instance.fast-path\
+    \ Fast-path work is verified\n  Given a small nontrivial change fits one requirement\n\
+    \  When the declared verification runs\n  Then the requirement has executed proof before\
+    \ completion"
 tasks:
 - id: task.w7-compops-instance
-  title: 'W7: cms-compops v3 instance + parity gate'
-  status: done
-  verification: okg deployment lint cms-compops --json (zero blocker/warning) + docs/w7-local-validation.md
-    in cms-compops@archi_v3
-  requirements:
-  - req.w7-compops-instance
-  evidence: []
-  environment: []
-dependencies: []
-test_plan:
-- id: test.req-w7-compops-instance.tests-todo-test-w7-compops-instance-py-test-w7-compops-instance
   requirement: req.w7-compops-instance
-  test_id: cms-compops@archi_v3:docs/w7-local-validation.md
-  evidence:
-  - graph_report
-formal: []
-waivers: []
+  verification: 'W7: cms-compops v3 instance + parity gate
+
+
+    okg deployment lint cms-compops --json (zero blocker/warning) + docs/w7-local-validation.md
+    in cms-compops@archi_v3
+
+
+    Test plan:
+
+    - cms-compops@archi_v3:docs/w7-local-validation.md [evidence: graph_report]'
 evidence:
-- id: ev.graph-report.req-w7-compops-instance.20260821T183415802592Z
-  kind: graph_report
+- kind: published_generation
+  requirement: req.w7-compops-instance
   status: pass
-  refs:
-  - req.w7-compops-instance
-  artifact: okg:cms-compops:branch:default:gen:20260821T182629928816Z:099cd854669c
-  command: OKG_DEPLOYMENTS_DIR=cms-compops/okg okg deployment lint cms-compops --json;
-    full cycle in docs/w7-local-validation.md (cms-compops@archi_v3)
-  summary: 'cms-compops v3 instance: lint ok zero blocker/warning (independently re-run);
-    13 connectors ingest OK, 8 credential-gated fail clean (completed_scope=false,
-    0 facts); generation published, idempotent re-run 0 retractions; read-back verified
-    via okg search.'
-  data:
-    attached_at: '2026-08-21T18:34:15.802628+00:00'
-- id: ev.graph-report.acc-w7-compops-instance.20260821T183418114254Z
-  kind: graph_report
+  command: OKG_DEPLOYMENTS_DIR=cms-compops/okg okg deployment lint cms-compops --json; full
+    cycle in docs/w7-local-validation.md (cms-compops@archi_v3)
+  at: '2026-08-21T18:34:15.802628+00:00'
+  note: 'cms-compops v3 instance: lint ok zero blocker/warning (independently re-run); 13
+    connectors ingest OK, 8 credential-gated fail clean (completed_scope=false, 0 facts);
+    generation published, idempotent re-run 0 retractions; read-back verified via okg search.'
+- kind: published_generation
+  requirement: req.w7-compops-instance
   status: pass
-  refs:
-  - acc.w7-compops-instance
-  artifact: cms-compops@archi_v3:docs/w7-local-validation.md
-  summary: 'Acceptance: full instance definition authored (deployment.yaml, 21-connector
-    registry, schemas incl. pruned operations bridge, 20 playbooks, invariants, relocated
-    parity harness, bring-up runbook, versions.lock pinning okg f5ec3b58d + archi
-    728739e6); local validation green; credentialed half documented for CERN host
-    in docs/bring-up.md.'
-  data:
-    attached_at: '2026-08-21T18:34:18.114284+00:00'
+  at: '2026-08-21T18:34:18.114284+00:00'
+  note: 'Acceptance: full instance definition authored (deployment.yaml, 21-connector registry,
+    schemas incl. pruned operations bridge, 20 playbooks, invariants, relocated parity harness,
+    bring-up runbook, versions.lock pinning okg f5ec3b58d + archi 728739e6); local validation
+    green; credentialed half documented for CERN host in docs/bring-up.md.'
+decisions: []

--- a/pact/changes/w0-ratify-and-pin/pact.yaml
+++ b/pact/changes/w0-ratify-and-pin/pact.yaml
@@ -1,81 +1,49 @@
-pact_version: 4
-target_pact_version: 4
-change:
-  id: w0-ratify-and-pin
-  title: 'W0: ratify the ADR, adopt PACT, file the asks, pin the repos'
-  status: proposal
-  rationale: 'Invariant 1 says one PACT change per work package; W0 shipped without
-    one, so the wave that adopted PACT is itself unrecorded in the ledger. This backfills
-    it. Recorded retroactively and honestly: three of the ADR''s four done-clauses
-    now hold, and the fourth is not ours to close. OPEN CLAUSE: R1-R3 owners and dates
-    are unassigned (maintainer''s).'
-  root_cause: Small nontrivial change whose intent, task, acceptance, and proof fit
-    the PACT fast path.
-  tier: 1
-  method_metadata:
-    pact_shape: fast_path
-    fast_path: Compact PACT for small nontrivial work. Upgrade when scope, risk, hierarchy,
-      formal proof, graph evidence, or review complexity increases.
-  affected_areas: []
-  affected_code: []
+pact_version: 5
+id: w0-ratify-and-pin
+title: 'W0: ratify the ADR, adopt PACT, file the asks, pin the repos'
+tier: 1
+why: 'Invariant 1 says one PACT change per work package; W0 shipped without one, so the wave
+  that adopted PACT is itself unrecorded in the ledger. This backfills it. Recorded retroactively
+  and honestly: three of the ADR''s four done-clauses now hold, and the fourth is not ours
+  to close. OPEN CLAUSE: R1-R3 owners and dates are unassigned (maintainer''s).
+
+
+  Small nontrivial change whose intent, task, acceptance, and proof fit the PACT fast path.'
+affected_code: []
 requirements:
 - id: req.w0-ratify-and-pin
-  title: 'W0: ratify the ADR, adopt PACT, file the asks, pin the repos'
-  statement: 'The ADR is merged and is the program''s reference; PACT is adopted (pact/project.yaml,
-    the interim archi-pact ledger, openspec archived); the five asks have upstream
-    issue links (okg#1179-#1185, plus #1282/#1283/#1284 for porting frictions); and
-    the suite runs in CI on archi_v3. The remaining ADR clause, owners and dates for
-    R1-R3, is a maintainer assignment and is recorded here as open rather than silently
-    dropped.'
-  evidence_policy:
-    required:
-    - executed_test
-  scenarios:
-  - id: scn.w0-ratify-and-pin.fast-path
-    title: Fast-path work is verified
-    given:
-    - a small nontrivial change fits one requirement
-    when:
-    - the declared verification runs
-    then:
-    - the requirement has executed proof before completion
-    and: []
-  acceptance:
-  - id: acc.w0-ratify-and-pin
-    description: docs/adr/0001-archi-v3-program-spec.md present on archi_v3; pact/project.yaml
-      present with the archi-pact projection; the asks resolvable as okg#1179-#1185;
-      a green CI run on archi_v3 covering the full suite.
-    evidence:
-    - executed_test
+  statement: "W0: ratify the ADR, adopt PACT, file the asks, pin the repos\n\nThe ADR is merged\
+    \ and is the program's reference; PACT is adopted (pact/project.yaml, the interim archi-pact\
+    \ ledger, openspec archived); the five asks have upstream issue links (okg#1179-#1185,\
+    \ plus #1282/#1283/#1284 for porting frictions); and the suite runs in CI on archi_v3.\
+    \ The remaining ADR clause, owners and dates for R1-R3, is a maintainer assignment and\
+    \ is recorded here as open rather than silently dropped.\n\nAcceptance:\n- acc.w0-ratify-and-pin:\
+    \ docs/adr/0001-archi-v3-program-spec.md present on archi_v3; pact/project.yaml present\
+    \ with the archi-pact projection; the asks resolvable as okg#1179-#1185; a green CI run\
+    \ on archi_v3 covering the full suite. [evidence: executed_test]\n\nScenarios:\n- scn.w0-ratify-and-pin.fast-path\
+    \ Fast-path work is verified\n  Given a small nontrivial change fits one requirement\n\
+    \  When the declared verification runs\n  Then the requirement has executed proof before\
+    \ completion"
 tasks:
 - id: task.w0-ratify-and-pin
-  title: 'W0: ratify the ADR, adopt PACT, file the asks, pin the repos'
-  status: todo
-  verification: gh run view (CI green on archi_v3) + docs/adr/0001-archi-v3-program-spec.md
-    and pact/project.yaml on trunk
-  requirements:
-  - req.w0-ratify-and-pin
-  evidence: []
-  environment: []
-dependencies: []
-test_plan:
-- id: test.req-w0-ratify-and-pin.backfill
   requirement: req.w0-ratify-and-pin
-  test_id: python/tests
-  evidence:
-  - pytest
-formal: []
-waivers: []
+  verification: 'W0: ratify the ADR, adopt PACT, file the asks, pin the repos
+
+
+    gh run view (CI green on archi_v3) + docs/adr/0001-archi-v3-program-spec.md and pact/project.yaml
+    on trunk
+
+
+    Test plan:
+
+    - python/tests [evidence: pytest]'
 evidence:
-- id: ev.executed-test.req-w0-ratify-and-pin.20260825T015917752351Z
-  kind: executed_test
+- kind: executed_test
+  requirement: req.w0-ratify-and-pin
   status: pass
-  refs:
-  - req.w0-ratify-and-pin
-  artifact: python/tests
   command: gh run view 32799269515
-  summary: "CI on archi_v3 is green (run 32799269515: tests (python 3.12) 326 passed,\
-    \ substrate-free checks 3 passed) \u2014 this was W0's last unmet mechanical clause.\
-    \ ADR merged on archi_v3; pact/project.yaml present; asks resolve to okg#1179-#1185."
-  data:
-    attached_at: '2026-08-25T01:59:17.752378+00:00'
+  at: '2026-08-25T01:59:17.752378+00:00'
+  note: 'CI on archi_v3 is green (run 32799269515: tests (python 3.12) 326 passed, substrate-free
+    checks 3 passed) — this was W0''s last unmet mechanical clause. ADR merged on archi_v3;
+    pact/project.yaml present; asks resolve to okg#1179-#1185.'
+decisions: []

--- a/pact/changes/w10-v2-teardown/pact.yaml
+++ b/pact/changes/w10-v2-teardown/pact.yaml
@@ -1,83 +1,54 @@
-pact_version: 4
-target_pact_version: 4
-change:
-  id: w10-v2-teardown
-  title: 'W10: delete the v2 application from the v3 line'
-  status: proposal
-  rationale: 'Backfills the unrecorded W10 wave. The deletions executed as PR #611
-    without a PACT change and without the LOC delta the ADR and section 10 both require;
-    that number is recorded here. The wave stays open because its done-clause is the
-    section 14 cutover, which does not hold. OPEN BY DESIGN: deletions done; cutover
-    conditions unmet (W7 parity delegated, W9 unstarted).'
-  root_cause: Small nontrivial change whose intent, task, acceptance, and proof fit
-    the PACT fast path.
-  tier: 1
-  method_metadata:
-    pact_shape: fast_path
-    fast_path: Compact PACT for small nontrivial work. Upgrade when scope, risk, hierarchy,
-      formal proof, graph evidence, or review complexity increases.
-  affected_areas: []
-  affected_code: []
+pact_version: 5
+id: w10-v2-teardown
+title: 'W10: delete the v2 application from the v3 line'
+tier: 1
+why: 'Backfills the unrecorded W10 wave. The deletions executed as PR #611 without a PACT
+  change and without the LOC delta the ADR and section 10 both require; that number is recorded
+  here. The wave stays open because its done-clause is the section 14 cutover, which does
+  not hold. OPEN BY DESIGN: deletions done; cutover conditions unmet (W7 parity delegated,
+  W9 unstarted).
+
+
+  Small nontrivial change whose intent, task, acceptance, and proof fit the PACT fast path.'
+affected_code: []
 requirements:
 - id: req.w10-v2-teardown
-  title: 'W10: delete the v2 application from the v3 line'
-  statement: 'The superseded v2 application is removed from the archi_v3 line: src/
-    (including data_manager), configs/, tests/, examples/, scripts/, requirements/,
-    the root build files, the v2 CI workflows and the accidentally-committed profiles/w1-scratch.
-    LOC DELTA (the ADR asks for it per PR and #611 did not report it): 433 files changed,
-    39 insertions, 106,475 deletions. v2 continues to serve live deployments from
-    main until cutover. The wave is NOT done: section 14''s cutover conditions require
-    W7 parity - which the maintainer has handed to the comp-ops team - and the W9
-    chat migration, which has not started.'
-  evidence_policy:
-    required:
-    - executed_test
-  scenarios:
-  - id: scn.w10-v2-teardown.fast-path
-    title: Fast-path work is verified
-    given:
-    - a small nontrivial change fits one requirement
-    when:
-    - the declared verification runs
-    then:
-    - the requirement has executed proof before completion
-    and: []
-  acceptance:
-  - id: acc.w10-v2-teardown
-    description: The v3 branch line contains no v2 application code (guarded by python/tests/test_packaging.py::test_v2_tree_removed)
-      AND the section 14 cutover conditions hold.
-    evidence:
-    - executed_test
+  statement: "W10: delete the v2 application from the v3 line\n\nThe superseded v2 application\
+    \ is removed from the archi_v3 line: src/ (including data_manager), configs/, tests/,\
+    \ examples/, scripts/, requirements/, the root build files, the v2 CI workflows and the\
+    \ accidentally-committed profiles/w1-scratch. LOC DELTA (the ADR asks for it per PR and\
+    \ #611 did not report it): 433 files changed, 39 insertions, 106,475 deletions. v2 continues\
+    \ to serve live deployments from main until cutover. The wave is NOT done: section 14's\
+    \ cutover conditions require W7 parity - which the maintainer has handed to the comp-ops\
+    \ team - and the W9 chat migration, which has not started.\n\nAcceptance:\n- acc.w10-v2-teardown:\
+    \ The v3 branch line contains no v2 application code (guarded by python/tests/test_packaging.py::test_v2_tree_removed)\
+    \ AND the section 14 cutover conditions hold. [evidence: executed_test]\n\nScenarios:\n\
+    - scn.w10-v2-teardown.fast-path Fast-path work is verified\n  Given a small nontrivial\
+    \ change fits one requirement\n  When the declared verification runs\n  Then the requirement\
+    \ has executed proof before completion"
 tasks:
 - id: task.w10-v2-teardown
-  title: 'W10: delete the v2 application from the v3 line'
-  status: todo
-  verification: pytest python/tests/test_packaging.py -q (v2 tree absent) + section
-    14 cutover conditions (W7 parity, W9 chat) - currently unmet
-  requirements:
-  - req.w10-v2-teardown
-  evidence: []
-  environment: []
-dependencies: []
-test_plan:
-- id: test.req-w10-v2-teardown.backfill
   requirement: req.w10-v2-teardown
-  test_id: python/tests
-  evidence:
-  - pytest
-formal: []
-waivers: []
+  verification: 'W10: delete the v2 application from the v3 line
+
+
+    pytest python/tests/test_packaging.py -q (v2 tree absent) + section 14 cutover conditions
+    (W7 parity, W9 chat) - currently unmet
+
+
+    Test plan:
+
+    - python/tests [evidence: pytest]'
 evidence:
-- id: ev.executed-test.req-w10-v2-teardown.20260825T015920482878Z
-  kind: executed_test
+- kind: executed_test
+  requirement: req.w10-v2-teardown
   status: pass
-  refs:
-  - req.w10-v2-teardown
-  artifact: python/tests/test_packaging.py
   command: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests/test_packaging.py
     -q
-  summary: 'test_v2_tree_removed asserts src/, setup.py and configs/ are absent from
-    the v3 line. LOC delta of the teardown (PR #611): 433 files, +39 / -106475. Cutover
-    conditions (section 14) remain unmet by design.'
-  data:
-    attached_at: '2026-08-25T01:59:20.482904+00:00'
+  artifact: python/tests/test_packaging.py
+  sha256: c43d0d986e0c0dcd4ab63eda1862e8f8f900a31d5271b2933c02feb4c7970d76
+  at: '2026-08-25T01:59:20.482904+00:00'
+  note: 'test_v2_tree_removed asserts src/, setup.py and configs/ are absent from the v3 line.
+    LOC delta of the teardown (PR #611): 433 files, +39 / -106475. Cutover conditions (section
+    14) remain unmet by design.'
+decisions: []

--- a/pact/changes/w2-consolidate-hep-sources/pact.yaml
+++ b/pact/changes/w2-consolidate-hep-sources/pact.yaml
@@ -1,505 +1,326 @@
-pact_version: 4
-target_pact_version: 4
-change:
-  id: w2-consolidate-hep-sources
-  title: 'W2: consolidate HEP sources into the archi package'
-  status: proposal
-  rationale: "ADR 0001 W2: the domain layer is consolidation, not construction. The\
-    \ HEP source code exists in three places \u2014 okg-deployments/cms/cms_sources/\
-    \ (22 adapter classes, 9,328 LOC), archi origin/dev's Scrapy layer (the current\
-    \ scraper design), and cooper (deferred) \u2014 and TWiki parsing alone exists\
-    \ three times. This change consolidates it into the pip-installable archi package\
-    \ proven by w1-prove-the-seam, per the porting matrix (porting-matrix.md in this\
-    \ change)."
-  root_cause: v2 scattered HEP ingestion across archi's collectors, agent tools, and
-    the CMS OKG deployment's local package; nothing is shareable across instances
-    without copy-paste (the wisdqm _cache.py and TWiki-parser forks are the live evidence).
-  tier: 2
-  affected_areas:
-  - python/
-  - pact/changes/w2-consolidate-hep-sources
-  affected_code:
-  - python/archi/**
+pact_version: 5
+id: w2-consolidate-hep-sources
+title: 'W2: consolidate HEP sources into the archi package'
+tier: 2
+why: 'ADR 0001 W2: the domain layer is consolidation, not construction. The HEP source code
+  exists in three places — okg-deployments/cms/cms_sources/ (22 adapter classes, 9,328 LOC),
+  archi origin/dev''s Scrapy layer (the current scraper design), and cooper (deferred) — and
+  TWiki parsing alone exists three times. This change consolidates it into the pip-installable
+  archi package proven by w1-prove-the-seam, per the porting matrix (porting-matrix.md in
+  this change).
+
+
+  v2 scattered HEP ingestion across archi''s collectors, agent tools, and the CMS OKG deployment''s
+  local package; nothing is shareable across instances without copy-paste (the wisdqm _cache.py
+  and TWiki-parser forks are the live evidence).'
+affected_code:
+- python/archi/**
 requirements:
 - id: req.w2.packaging
-  title: v3 package builds without touching the v2 build
-  statement: The archi v3 distribution builds as a wheel from python/ (its own pyproject)
-    while the v2 root build (setup.py/pyproject.toml, src/) remains untouched and
-    v2 unit tests keep passing on archi_v3.
-  evidence_policy:
-    required:
-    - executed_test
-  scenarios:
-  - id: scn.w2.packaging.coexist
-    title: Both builds coexist on one branch
-    given:
-    - the archi_v3 branch with python/ added
-    when:
-    - the v3 wheel is built and the v2 unit suite runs
-    then:
-    - both succeed with no file overlap between the two builds
-    and: []
-  acceptance:
-  - id: acc.w2.packaging
-    description: python/tests/test_packaging.py passes (wheel builds from python/,
-      v3 never imports v2, schema data ships in the wheel, no operator paths, root
-      build files untouched). CI wiring is deferred by maintainer decision (2026-08-11,
-      "let's not worry about those actions for now") and returns with the OKG_REPO_TOKEN
-      secret.
-    evidence:
-    - executed_test
+  statement: "v3 package builds without touching the v2 build\n\nThe archi v3 distribution\
+    \ builds as a wheel from python/ (its own pyproject) while the v2 root build (setup.py/pyproject.toml,\
+    \ src/) remains untouched and v2 unit tests keep passing on archi_v3.\n\nAcceptance:\n\
+    - acc.w2.packaging: python/tests/test_packaging.py passes (wheel builds from python/,\
+    \ v3 never imports v2, schema data ships in the wheel, no operator paths, root build files\
+    \ untouched). CI wiring is deferred by maintainer decision (2026-08-11, \"let's not worry\
+    \ about those actions for now\") and returns with the OKG_REPO_TOKEN secret. [evidence:\
+    \ executed_test]\n\nScenarios:\n- scn.w2.packaging.coexist Both builds coexist on one\
+    \ branch\n  Given the archi_v3 branch with python/ added\n  When the v3 wheel is built\
+    \ and the v2 unit suite runs\n  Then both succeed with no file overlap between the two\
+    \ builds"
 - id: req.w2.auth
-  title: CERN auth plumbing is package code, credentials are instance data
-  statement: archi/auth/ consolidates the preflight probes, CERN SSO flows, and the
-    cache utility; no module contains a hardcoded operator path (/Users/, /root/,
-    /home/ literals) or a credential value; credentials arrive only by environment/credential_refs
-    indirection.
-  evidence_policy:
-    required:
-    - executed_test
-  scenarios:
-  - id: scn.w2.auth.no-paths
-    title: No operator paths or secrets in package code
-    given:
-    - archi/auth and archi/sources fully ported
-    when:
-    - the path/secret lint test runs over python/archi
-    then:
-    - zero findings
-    and: []
-  acceptance:
-  - id: acc.w2.auth
-    description: A lint test asserts no hardcoded operator paths or credential literals
-      in python/archi.
-    evidence:
-    - executed_test
+  statement: "CERN auth plumbing is package code, credentials are instance data\n\narchi/auth/\
+    \ consolidates the preflight probes, CERN SSO flows, and the cache utility; no module\
+    \ contains a hardcoded operator path (/Users/, /root/, /home/ literals) or a credential\
+    \ value; credentials arrive only by environment/credential_refs indirection.\n\nAcceptance:\n\
+    - acc.w2.auth: A lint test asserts no hardcoded operator paths or credential literals\
+    \ in python/archi. [evidence: executed_test]\n\nScenarios:\n- scn.w2.auth.no-paths No\
+    \ operator paths or secrets in package code\n  Given archi/auth and archi/sources fully\
+    \ ported\n  When the path/secret lint test runs over python/archi\n  Then zero findings"
 - id: req.w2.sources
-  title: The source families port against the current adapter contract
-  statement: Every source in the porting matrix lands rewritten against the current
-    SourceAdapter + registry contract (sound change probe, producer authority, admission
-    mode), with offline unit tests, a documented registry-entry template, and okg
-    deployment lint green on a scratch registry entry. The parity families (jira,
-    docsite, gitlab_docs) come first; the TWiki three-way merge produces exactly one
-    parser.
-  evidence_policy:
-    required:
-    - executed_test
-  scenarios:
-  - id: scn.w2.sources.lint
-    title: Each ported source lints and ingests on scratch
-    given:
-    - a ported source registered in the w1-style scratch deployment
-    when:
-    - okg deployment lint and okg ingest run
-    then:
-    - lint has no blocker/warning findings for the source and the run is OK
-    and: []
-  acceptance:
-  - id: acc.w2.sources
-    description: Per-source fixture-driven unit tests pass offline; at least the parity
-      families demonstrate a scratch-instance ingest cycle; provenance (source repo
-      + ref + what changed) is recorded per port.
-    evidence:
-    - executed_test
+  statement: "The source families port against the current adapter contract\n\nEvery source\
+    \ in the porting matrix lands rewritten against the current SourceAdapter + registry contract\
+    \ (sound change probe, producer authority, admission mode), with offline unit tests, a\
+    \ documented registry-entry template, and okg deployment lint green on a scratch registry\
+    \ entry. The parity families (jira, docsite, gitlab_docs) come first; the TWiki three-way\
+    \ merge produces exactly one parser.\n\nAcceptance:\n- acc.w2.sources: Per-source fixture-driven\
+    \ unit tests pass offline; at least the parity families demonstrate a scratch-instance\
+    \ ingest cycle; provenance (source repo + ref + what changed) is recorded per port. [evidence:\
+    \ executed_test]\n\nScenarios:\n- scn.w2.sources.lint Each ported source lints and ingests\
+    \ on scratch\n  Given a ported source registered in the w1-style scratch deployment\n\
+    \  When okg deployment lint and okg ingest run\n  Then lint has no blocker/warning findings\
+    \ for the source and the run is OK"
 - id: req.w2.enrichment
-  title: Enrichers and identifier/link defaults are importable package data
-  statement: "The five CMS enrichers, the alias backend, and the extractor/linker/\
-    \ identifier-pattern defaults move into archi/enrichment/, consumable by an instance's\
-    \ config as selectable defaults (wisdqm's DQM patterns included \u2014 the second\
-    \ call site exists)."
-  evidence_policy:
-    required:
-    - executed_test
-  scenarios:
-  - id: scn.w2.enrichment.defaults
-    title: An instance selects packaged defaults
-    given:
-    - archi/enrichment/defaults shipped in the wheel
-    when:
-    - a scratch deployment config references them
-    then:
-    - catalog load composes them without copying files into the deployment
-    and: []
-  acceptance:
-  - id: acc.w2.enrichment
-    description: Unit tests load the defaults from the installed wheel and validate
-      their shape.
-    evidence:
-    - executed_test
+  statement: "Enrichers and identifier/link defaults are importable package data\n\nThe five\
+    \ CMS enrichers, the alias backend, and the extractor/linker/ identifier-pattern defaults\
+    \ move into archi/enrichment/, consumable by an instance's config as selectable defaults\
+    \ (wisdqm's DQM patterns included — the second call site exists).\n\nAcceptance:\n- acc.w2.enrichment:\
+    \ Unit tests load the defaults from the installed wheel and validate their shape. [evidence:\
+    \ executed_test]\n\nScenarios:\n- scn.w2.enrichment.defaults An instance selects packaged\
+    \ defaults\n  Given archi/enrichment/defaults shipped in the wheel\n  When a scratch deployment\
+    \ config references them\n  Then catalog load composes them without copying files into\
+    \ the deployment"
 - id: req.w2.compops-unbroken
-  title: The comp-ops instance stays green throughout
-  statement: "W2 does not switch okg-deployments/cms to the package (that is W7);\
-    \ its lint and checks must pass unchanged at every W2 merge (ADR 0001 D10 \u2014\
-    \ breaking comp-ops is a blocking regression)."
-  evidence_policy:
-    required:
-    - executed_test
-  scenarios:
-  - id: scn.w2.compops.green
-    title: comp-ops lint unchanged
-    given:
-    - any W2 merge to archi_v3
-    when:
-    - okg deployment lint runs on okg-deployments/cms
-    then:
-    - findings are identical to the pre-W2 baseline
-    and: []
-  acceptance:
-  - id: acc.w2.compops
-    description: The comp-ops lint baseline is recorded before W2 starts and re-checked
-      per merge.
-    evidence:
-    - executed_test
+  statement: "The comp-ops instance stays green throughout\n\nW2 does not switch okg-deployments/cms\
+    \ to the package (that is W7); its lint and checks must pass unchanged at every W2 merge\
+    \ (ADR 0001 D10 — breaking comp-ops is a blocking regression).\n\nAcceptance:\n- acc.w2.compops:\
+    \ The comp-ops lint baseline is recorded before W2 starts and re-checked per merge. [evidence:\
+    \ executed_test]\n\nScenarios:\n- scn.w2.compops.green comp-ops lint unchanged\n  Given\
+    \ any W2 merge to archi_v3\n  When okg deployment lint runs on okg-deployments/cms\n \
+    \ Then findings are identical to the pre-W2 baseline"
 tasks:
 - id: task.w2.packaging
-  title: python/ package skeleton + CI wheel lane
-  status: done
-  verification: python/tests/test_packaging.py
-  requirements:
-  - req.w2.packaging
-  evidence: []
-  environment:
-  - id: env.w2.okg-repo-token
-    kind: env_var
-    env: OKG_REPO_TOKEN
-    description: CI secret for okg-dependent test lanes (Luca to add to the repo).
-    required: false
-- id: task.w2.auth
-  title: "archi/auth \u2014 preflight, SSO, cache util"
-  status: done
-  verification: python/tests/auth/
-  requirements:
-  - req.w2.auth
-  evidence: []
-  environment: []
-- id: task.w2.sources-parity
-  title: 'Parity families: jira, docs (docsite + gitlab_docs + cmsweb)'
-  status: done
-  verification: python/tests/sources/test_jira.py and python/tests/sources/test_docs.py
-  requirements:
-  - req.w2.sources
-  evidence: []
-  environment: []
-- id: task.w2.sources-twiki
-  title: TWiki three-way merge (cms twiki_eos + cern-twiki + wisdqm parsers)
-  status: done
-  verification: python/tests/sources/test_twiki.py
-  requirements:
-  - req.w2.sources
-  evidence: []
-  environment: []
-- id: task.w2.sources-monit
-  title: MONIT sources + archi/tools/monit.py live tools
-  status: done
-  verification: python/tests/sources/test_monit.py and python/tests/tools/test_monit_live.py
-  requirements:
-  - req.w2.sources
-  evidence: []
-  environment: []
-- id: task.w2.sources-catalogs
-  title: 'Catalogs: cric, cmssw (merge W1 spike), dbs, conddb, dqm, gocdb, siteconf,
-    wmstats, github_repos, hypernews, indico'
-  status: done
-  verification: python/tests/sources/
-  requirements:
-  - req.w2.sources
-  evidence: []
-  environment: []
-- id: task.w2.enrichment
-  title: "archi/enrichment \u2014 enrichers, alias backend, defaults"
-  status: done
-  verification: python/tests/enrichment/
-  requirements:
-  - req.w2.enrichment
-  evidence: []
-  environment: []
-- id: task.w2.compops-baseline
-  title: Record comp-ops lint baseline and re-check per merge
-  status: done
-  verification: okg deployment lint on okg-deployments/cms compared to recorded baseline
-  requirements:
-  - req.w2.compops-unbroken
-  evidence: []
-  environment: []
-dependencies: []
-test_plan:
-- id: test.req-w2-packaging.python-tests-test-packaging
   requirement: req.w2.packaging
-  test_id: python/tests/test_packaging.py
-  evidence:
-  - pytest
-- id: test.req-w2-auth.python-tests-auth
+  verification: 'python/ package skeleton + CI wheel lane
+
+
+    python/tests/test_packaging.py
+
+
+    Test plan:
+
+    - python/tests/test_packaging.py [evidence: pytest]'
+- id: task.w2.auth
   requirement: req.w2.auth
-  test_id: python/tests/auth/
-  evidence:
-  - pytest
-- id: test.req-w2-sources.python-tests-sources
+  verification: 'archi/auth — preflight, SSO, cache util
+
+
+    python/tests/auth/
+
+
+    Test plan:
+
+    - python/tests/auth/ [evidence: pytest]'
+- id: task.w2.sources-parity
   requirement: req.w2.sources
-  test_id: python/tests/sources/
-  evidence:
-  - pytest
-- id: test.req-w2-enrichment.python-tests-enrichment
+  verification: 'Parity families: jira, docs (docsite + gitlab_docs + cmsweb)
+
+
+    python/tests/sources/test_jira.py and python/tests/sources/test_docs.py
+
+
+    Test plan:
+
+    - python/tests/sources/ [evidence: pytest]'
+- id: task.w2.sources-twiki
+  requirement: req.w2.sources
+  verification: 'TWiki three-way merge (cms twiki_eos + cern-twiki + wisdqm parsers)
+
+
+    python/tests/sources/test_twiki.py'
+- id: task.w2.sources-monit
+  requirement: req.w2.sources
+  verification: 'MONIT sources + archi/tools/monit.py live tools
+
+
+    python/tests/sources/test_monit.py and python/tests/tools/test_monit_live.py'
+- id: task.w2.sources-catalogs
+  requirement: req.w2.sources
+  verification: 'Catalogs: cric, cmssw (merge W1 spike), dbs, conddb, dqm, gocdb, siteconf,
+    wmstats, github_repos, hypernews, indico
+
+
+    python/tests/sources/'
+- id: task.w2.enrichment
   requirement: req.w2.enrichment
-  test_id: python/tests/enrichment/
-  evidence:
-  - pytest
-- id: test.req-w2-compops-unbroken.compops-lint-baseline
+  verification: 'archi/enrichment — enrichers, alias backend, defaults
+
+
+    python/tests/enrichment/
+
+
+    Test plan:
+
+    - python/tests/enrichment/ [evidence: pytest]'
+- id: task.w2.compops-baseline
   requirement: req.w2.compops-unbroken
-  test_id: pact/changes/w2-consolidate-hep-sources/compops-lint-baseline.json
-  evidence:
-  - graph_report
-formal: []
-waivers: []
+  verification: 'Record comp-ops lint baseline and re-check per merge
+
+
+    okg deployment lint on okg-deployments/cms compared to recorded baseline
+
+
+    Test plan:
+
+    - pact/changes/w2-consolidate-hep-sources/compops-lint-baseline.json [evidence: graph_report]'
 evidence:
-- id: ev.pytest.req-w2-packaging.20260811T210431898899Z
-  kind: pytest
+- kind: executed_test
+  requirement: req.w2.packaging
   status: pass
-  refs:
-  - req.w2.packaging
-  artifact: python/tests/test_packaging.py
   command: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests/test_packaging.py
     -q
-  summary: '7/7: wheel builds from python/ (hatchling), v3 never imports v2, schema
-    ships in wheel, no operator paths, root build untouched'
-  data:
-    attached_at: '2026-08-11T21:04:31.898947+00:00'
-- id: ev.pytest.req-w2-packaging.20260811T210527248898Z
-  kind: pytest
-  status: pass
-  refs:
-  - req.w2.packaging
   artifact: python/tests/test_packaging.py
+  sha256: c43d0d986e0c0dcd4ab63eda1862e8f8f900a31d5271b2933c02feb4c7970d76
+  at: '2026-08-11T21:04:31.898947+00:00'
+  note: '7/7: wheel builds from python/ (hatchling), v3 never imports v2, schema ships in
+    wheel, no operator paths, root build untouched'
+- kind: executed_test
+  requirement: req.w2.packaging
+  status: pass
   command: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests/test_packaging.py
     -q
-  summary: '7/7: wheel builds from python/ (hatchling), v3 never imports v2, schema
-    ships in wheel, no operator paths, root build untouched'
-  data:
-    attached_at: '2026-08-11T21:05:27.249012+00:00'
-- id: ev.pytest.req-w2-auth.20260812T003827308891Z
-  kind: pytest
+  artifact: python/tests/test_packaging.py
+  sha256: c43d0d986e0c0dcd4ab63eda1862e8f8f900a31d5271b2933c02feb4c7970d76
+  at: '2026-08-11T21:05:27.249012+00:00'
+  note: '7/7: wheel builds from python/ (hatchling), v3 never imports v2, schema ships in
+    wheel, no operator paths, root build untouched'
+- kind: executed_test
+  requirement: req.w2.auth
   status: pass
-  refs:
-  - req.w2.auth
-  artifact: python/tests/auth/
   command: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests/auth/ -q
-  summary: 46/46 auth tests incl. review-fix regressions; no-operator-paths lint green
-    in packaging suite
-  data:
-    attached_at: '2026-08-12T00:38:27.308914+00:00'
-- id: ev.pytest.req-w2-auth.20260812T003850633918Z
-  kind: pytest
+  at: '2026-08-12T00:38:27.308914+00:00'
+  note: 46/46 auth tests incl. review-fix regressions; no-operator-paths lint green in packaging
+    suite
+- kind: executed_test
+  requirement: req.w2.auth
   status: pass
-  refs:
-  - req.w2.auth
-  artifact: python/tests/auth/
   command: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests/auth/ -q
-  summary: 45/45 auth tests incl. two review-fix regressions (corrects prior entry's
-    46/46 typo); no-operator-paths lint green in packaging suite
-  data:
-    attached_at: '2026-08-12T00:38:50.633941+00:00'
-- id: ev.pytest.req-w2-sources.20260812T124326967398Z
-  kind: pytest
+  at: '2026-08-12T00:38:50.633941+00:00'
+  note: 45/45 auth tests incl. two review-fix regressions (corrects prior entry's 46/46 typo);
+    no-operator-paths lint green in packaging suite
+- kind: executed_test
+  requirement: req.w2.sources
   status: pass
-  refs:
-  - req.w2.sources
-  artifact: python/tests/sources/
-  command: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests/sources/
-    -q
-  summary: '57 source tests pass (jira 30, docs 27) incl. 10 review-fix regressions;
-    scratch-instance ingest cycle proven (see parity-ingest-demonstration.md): lint
-    zero findings, publish gen 20260812T005035..., cross-source references edge, idempotent
-    re-run'
-  data:
-    attached_at: '2026-08-12T12:43:26.967431+00:00'
-- id: ev.pytest.req-w2-sources.20260812T182728402302Z
-  kind: pytest
+  command: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests/sources/ -q
+  at: '2026-08-12T12:43:26.967431+00:00'
+  note: '57 source tests pass (jira 30, docs 27) incl. 10 review-fix regressions; scratch-instance
+    ingest cycle proven (see parity-ingest-demonstration.md): lint zero findings, publish
+    gen 20260812T005035..., cross-source references edge, idempotent re-run'
+- kind: executed_test
+  requirement: req.w2.sources
   status: pass
-  refs:
-  - req.w2.sources
-  artifact: python/tests/sources/test_twiki.py
   command: pytest python/tests/sources/test_twiki.py -q
-  summary: '47 twiki tests: parser core fidelity flags w/ cms byte-parity fixture,
-    EOS+crawl sources, completeness/dead-link/truncation discipline (10 review fixes)'
-  data:
-    attached_at: '2026-08-12T18:27:28.402333+00:00'
-- id: ev.pytest.req-w2-sources.20260812T182731280363Z
-  kind: pytest
+  artifact: python/tests/sources/test_twiki.py
+  sha256: 41d2fd7a5b6f950b33632b3f14b44e1a454c3234b76feaf051f9e735d370c1bf
+  at: '2026-08-12T18:27:28.402333+00:00'
+  note: '47 twiki tests: parser core fidelity flags w/ cms byte-parity fixture, EOS+crawl
+    sources, completeness/dead-link/truncation discipline (10 review fixes)'
+- kind: executed_test
+  requirement: req.w2.sources
   status: pass
-  refs:
-  - req.w2.sources
-  artifact: python/tests/sources/test_monit.py
   command: pytest python/tests/sources/test_monit.py python/tests/tools/test_monit_live.py
     -q
-  summary: '36 MONIT tests: four sources faithful to cms (query bodies/retry/emission),
-    four live tools with wiring contract'
-  data:
-    attached_at: '2026-08-12T18:27:31.280388+00:00'
-- id: ev.graph-report.req-w2-compops-unbroken.20260821T152841269273Z
-  kind: graph_report
+  artifact: python/tests/sources/test_monit.py
+  sha256: 50d8ac7fd5bd02ea77406210b667ae3f4fc218f92efbf60cb5142cd71c51e193
+  at: '2026-08-12T18:27:31.280388+00:00'
+  note: '36 MONIT tests: four sources faithful to cms (query bodies/retry/emission), four
+    live tools with wiring contract'
+- kind: published_generation
+  requirement: req.w2.compops-unbroken
   status: pass
-  refs:
-  - req.w2.compops-unbroken
-  artifact: pact/changes/w2-consolidate-hep-sources/compops-lint-recheck-20260821.json
   command: okg deployment lint cms --json (okg dev@f5ec3b58d) diffed vs compops-lint-baseline.json
-  summary: '30 vs 29 baseline findings; sole delta is a version-introduced ''skipped:
-    reference_routes_not_applicable'' notice; zero new errors/warnings, zero regressions;
-    cms deployment untouched by W2'
-  data:
-    attached_at: '2026-08-21T15:28:41.269330+00:00'
-- id: ev.pytest.req-w2-compops-unbroken.20260821T152918062692Z
-  kind: pytest
+  artifact: pact/changes/w2-consolidate-hep-sources/compops-lint-recheck-20260821.json
+  sha256: f108c05e59e9608a1fc87d3f20a3d66ddc64ea64265700185ebef1ede29b5c8d
+  at: '2026-08-21T15:28:41.269330+00:00'
+  note: '30 vs 29 baseline findings; sole delta is a version-introduced ''skipped: reference_routes_not_applicable''
+    notice; zero new errors/warnings, zero regressions; cms deployment untouched by W2'
+- kind: executed_test
+  requirement: req.w2.compops-unbroken
   status: pass
-  refs:
-  - req.w2.compops-unbroken
-  artifact: python/tests/test_compops_lint_recheck.py
   command: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests/test_compops_lint_recheck.py
     -q
-  summary: 'Deterministic diff of committed baseline vs 2026-08-21 recheck: zero regressions;
+  artifact: python/tests/test_compops_lint_recheck.py
+  sha256: fc7fafa0a8a8133e3cbdc95de5dbe4d4624756ff85a83dd24c11d9b56d63440b
+  at: '2026-08-21T15:29:18.062721+00:00'
+  note: 'Deterministic diff of committed baseline vs 2026-08-21 recheck: zero regressions;
     sole delta is a version-introduced skipped notice'
-  data:
-    attached_at: '2026-08-21T15:29:18.062721+00:00'
-- id: ev.pytest.req-w2-sources.20260821T153146371518Z
-  kind: pytest
+- kind: executed_test
+  requirement: req.w2.sources
   status: pass
-  refs:
-  - req.w2.sources
-  artifact: python/tests/sources/
   command: pytest python/tests/sources/ -q
-  summary: 'All 12 connector families ported and fixture-tested (catalogs batch adds
-    25 tests: cric, cmssw, dbs, conddb, dqm, gocdb, siteconf, wmstats, github_repos,
-    hypernews, indico); strict-shape registry templates throughout; schema dedupe
-    complete (each class/narrowing in exactly one file)'
-  data:
-    attached_at: '2026-08-21T15:31:46.371609+00:00'
-- id: ev.pytest.req-w2-enrichment.20260821T153153454622Z
-  kind: pytest
+  at: '2026-08-21T15:31:46.371609+00:00'
+  note: 'All 12 connector families ported and fixture-tested (catalogs batch adds 25 tests:
+    cric, cmssw, dbs, conddb, dqm, gocdb, siteconf, wmstats, github_repos, hypernews, indico);
+    strict-shape registry templates throughout; schema dedupe complete (each class/narrowing
+    in exactly one file)'
+- kind: executed_test
+  requirement: req.w2.enrichment
   status: pass
-  refs:
-  - req.w2.enrichment
-  artifact: python/tests/enrichment/
   command: pytest python/tests/enrichment/ -q
-  summary: Five enrichers (verbatim lifts), packaged defaults loader (incl. wisdqm
-    DQM patterns), alias backend, dev-branch anonymizer (closes anonymize_data gate);
-    25 tests; defaults ship in wheel
-  data:
-    attached_at: '2026-08-21T15:31:53.454661+00:00'
-- id: ev.executed-test.acc-w2-packaging.20260824T214155736759Z
-  kind: executed_test
+  at: '2026-08-21T15:31:53.454661+00:00'
+  note: Five enrichers (verbatim lifts), packaged defaults loader (incl. wisdqm DQM patterns),
+    alias backend, dev-branch anonymizer (closes anonymize_data gate); 25 tests; defaults
+    ship in wheel
+- kind: executed_test
+  requirement: req.w2.packaging
   status: pass
-  refs:
-  - acc.w2.packaging
-  artifact: python/tests/test_packaging.py
   command: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests/test_packaging.py
     -q
-  summary: '7 passed (2026-08-24 re-run on archi_v3): wheel builds from python/, v3
-    never imports the v2 tree, schema data ships in the wheel, no operator paths,
-    and the v2 build files are gone per the W10 teardown.'
-  data:
-    attached_at: '2026-08-24T21:41:55.736787+00:00'
-- id: ev.executed-test.acc-w2-auth.20260824T214157398786Z
-  kind: executed_test
+  artifact: python/tests/test_packaging.py
+  sha256: c43d0d986e0c0dcd4ab63eda1862e8f8f900a31d5271b2933c02feb4c7970d76
+  at: '2026-08-24T21:41:55.736787+00:00'
+  note: '7 passed (2026-08-24 re-run on archi_v3): wheel builds from python/, v3 never imports
+    the v2 tree, schema data ships in the wheel, no operator paths, and the v2 build files
+    are gone per the W10 teardown.'
+- kind: executed_test
+  requirement: req.w2.packaging
   status: pass
-  refs:
-  - acc.w2.auth
-  artifact: python/tests/auth
   command: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests/auth -q
-  summary: '46 passed (2026-08-24 re-run): archi.auth preflight/cache/cookies, including
-    the lint assertion that no hardcoded operator paths or credential literals exist
-    in python/archi.'
-  data:
-    attached_at: '2026-08-24T21:41:57.398833+00:00'
-- id: ev.executed-test.acc-w2-sources.20260824T214158765991Z
-  kind: executed_test
+  at: '2026-08-24T21:41:57.398833+00:00'
+  note: '46 passed (2026-08-24 re-run): archi.auth preflight/cache/cookies, including the
+    lint assertion that no hardcoded operator paths or credential literals exist in python/archi.'
+- kind: executed_test
+  requirement: req.w2.packaging
   status: pass
-  refs:
-  - acc.w2.sources
-  artifact: python/tests/sources
-  command: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests/sources
-    -q
-  summary: '202 passed (2026-08-24 re-run): per-connector fixture-driven unit tests
-    for all 12 families offline, including the circle-back scope-claim regressions.'
-  data:
-    attached_at: '2026-08-24T21:41:58.766018+00:00'
-- id: ev.executed-test.acc-w2-enrichment.20260824T214200011306Z
-  kind: executed_test
+  command: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests/sources -q
+  at: '2026-08-24T21:41:58.766018+00:00'
+  note: '202 passed (2026-08-24 re-run): per-connector fixture-driven unit tests for all 12
+    families offline, including the circle-back scope-claim regressions.'
+- kind: executed_test
+  requirement: req.w2.packaging
   status: pass
-  refs:
-  - acc.w2.enrichment
-  artifact: python/tests/enrichment
-  command: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests/enrichment
-    -q
-  summary: '36 passed (2026-08-24 re-run): enrichers plus packaged defaults loaded
-    from the installed wheel and shape-validated, including the anonymizer leak corpus.'
-  data:
-    attached_at: '2026-08-24T21:42:00.011344+00:00'
-- id: ev.executed-test.acc-w2-compops.20260824T214201208887Z
-  kind: executed_test
+  command: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests/enrichment -q
+  at: '2026-08-24T21:42:00.011344+00:00'
+  note: '36 passed (2026-08-24 re-run): enrichers plus packaged defaults loaded from the installed
+    wheel and shape-validated, including the anonymizer leak corpus.'
+- kind: executed_test
+  requirement: req.w2.packaging
   status: pass
-  refs:
-  - acc.w2.compops
-  artifact: python/tests/test_compops_lint_recheck.py
   command: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests/test_compops_lint_recheck.py
     -q
-  summary: '1 passed (2026-08-24 re-run): comp-ops lint re-check against the recorded
-    pre-W2 baseline, zero regressions.'
-  data:
-    attached_at: '2026-08-24T21:42:01.208914+00:00'
-- id: ev.executed-test.req-w2-packaging.20260824T214442853986Z
-  kind: executed_test
+  artifact: python/tests/test_compops_lint_recheck.py
+  sha256: fc7fafa0a8a8133e3cbdc95de5dbe4d4624756ff85a83dd24c11d9b56d63440b
+  at: '2026-08-24T21:42:01.208914+00:00'
+  note: '1 passed (2026-08-24 re-run): comp-ops lint re-check against the recorded pre-W2
+    baseline, zero regressions.'
+- kind: executed_test
+  requirement: req.w2.packaging
   status: pass
-  refs:
-  - req.w2.packaging
-  artifact: python/tests/test_packaging.py
   command: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests/test_packaging.py
     -q
-  summary: '7 passed, re-run 2026-08-24 AFTER the circle-back fixes (PR #617) changed
-    python/archi; supersedes the 2026-08-11 evidence the scope-drift guard revoked.'
-  data:
-    attached_at: '2026-08-24T21:44:42.854023+00:00'
-- id: ev.executed-test.req-w2-auth.20260824T214444343077Z
-  kind: executed_test
+  artifact: python/tests/test_packaging.py
+  sha256: c43d0d986e0c0dcd4ab63eda1862e8f8f900a31d5271b2933c02feb4c7970d76
+  at: '2026-08-24T21:44:42.854023+00:00'
+  note: '7 passed, re-run 2026-08-24 AFTER the circle-back fixes (PR #617) changed python/archi;
+    supersedes the 2026-08-11 evidence the scope-drift guard revoked.'
+- kind: executed_test
+  requirement: req.w2.auth
   status: pass
-  refs:
-  - req.w2.auth
-  artifact: python/tests/auth
   command: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests/auth -q
-  summary: '46 passed, re-run 2026-08-24 after PR #617; supersedes the revoked 2026-08-12
-    entries.'
-  data:
-    attached_at: '2026-08-24T21:44:44.343107+00:00'
-- id: ev.executed-test.req-w2-sources.20260824T214446194882Z
-  kind: executed_test
+  at: '2026-08-24T21:44:44.343107+00:00'
+  note: '46 passed, re-run 2026-08-24 after PR #617; supersedes the revoked 2026-08-12 entries.'
+- kind: executed_test
+  requirement: req.w2.sources
   status: pass
-  refs:
-  - req.w2.sources
-  artifact: python/tests/sources
-  command: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests/sources
-    -q
-  summary: '202 passed, re-run 2026-08-24 after PR #617 (includes the new scope-claim
-    regressions); supersedes the revoked 2026-08-12 evidence.'
-  data:
-    attached_at: '2026-08-24T21:44:46.194911+00:00'
-- id: ev.executed-test.req-w2-enrichment.20260824T214448103511Z
-  kind: executed_test
+  command: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests/sources -q
+  at: '2026-08-24T21:44:46.194911+00:00'
+  note: '202 passed, re-run 2026-08-24 after PR #617 (includes the new scope-claim regressions);
+    supersedes the revoked 2026-08-12 evidence.'
+- kind: executed_test
+  requirement: req.w2.enrichment
   status: pass
-  refs:
-  - req.w2.enrichment
-  artifact: python/tests/enrichment
-  command: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests/enrichment
-    -q
-  summary: '36 passed, re-run 2026-08-24 after PR #617 (includes the anonymizer leak
-    corpus); supersedes the revoked 2026-08-21 entry.'
-  data:
-    attached_at: '2026-08-24T21:44:48.103541+00:00'
-- id: ev.executed-test.req-w2-compops-unbroken.20260824T214450106945Z
-  kind: executed_test
+  command: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests/enrichment -q
+  at: '2026-08-24T21:44:48.103541+00:00'
+  note: '36 passed, re-run 2026-08-24 after PR #617 (includes the anonymizer leak corpus);
+    supersedes the revoked 2026-08-21 entry.'
+- kind: executed_test
+  requirement: req.w2.compops-unbroken
   status: pass
-  refs:
-  - req.w2.compops-unbroken
-  artifact: python/tests/test_compops_lint_recheck.py
   command: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests/test_compops_lint_recheck.py
     -q
-  summary: '1 passed, re-run 2026-08-24 after PR #617: comp-ops lint re-check vs the
-    recorded baseline, zero regressions; supersedes the revoked 2026-08-21 graph report.'
-  data:
-    attached_at: '2026-08-24T21:44:50.106978+00:00'
+  artifact: python/tests/test_compops_lint_recheck.py
+  sha256: fc7fafa0a8a8133e3cbdc95de5dbe4d4624756ff85a83dd24c11d9b56d63440b
+  at: '2026-08-24T21:44:50.106978+00:00'
+  note: '1 passed, re-run 2026-08-24 after PR #617: comp-ops lint re-check vs the recorded
+    baseline, zero regressions; supersedes the revoked 2026-08-21 graph report.'
+decisions: []

--- a/pact/changes/w3-hep-schemas/pact.yaml
+++ b/pact/changes/w3-hep-schemas/pact.yaml
@@ -1,79 +1,46 @@
-pact_version: 4
-target_pact_version: 4
-change:
-  id: w3-hep-schemas
-  title: 'W3: HEP schema slices and deployment bridges'
-  status: proposal
-  rationale: >-
-    Backfills the unrecorded W3 wave, and records that its ADR
-    done-clause is FALSE AS WRITTEN rather than quietly re-scoping it. The
-    clause reads: 'the cern-team bundle and the comp-ops instance compose the
-    same files without divergence.' They do not, and cannot today.
-    OPEN BY DESIGN: the ADR done-clause is false as written; see docs/okg-alignment.md.
-  root_cause: Small nontrivial change whose intent, task, acceptance, and proof fit
-    the PACT fast path.
-  tier: 1
-  method_metadata:
-    pact_shape: fast_path
-    fast_path: Compact PACT for small nontrivial work. Upgrade when scope, risk, hierarchy,
-      formal proof, graph evidence, or review complexity increases.
-  affected_areas: []
-  affected_code: []
+pact_version: 5
+id: w3-hep-schemas
+title: 'W3: HEP schema slices and deployment bridges'
+tier: 1
+why: 'Backfills the unrecorded W3 wave, and records that its ADR done-clause is FALSE AS WRITTEN
+  rather than quietly re-scoping it. The clause reads: ''the cern-team bundle and the comp-ops
+  instance compose the same files without divergence.'' They do not, and cannot today. OPEN
+  BY DESIGN: the ADR done-clause is false as written; see docs/okg-alignment.md.
+
+
+  Small nontrivial change whose intent, task, acceptance, and proof fit the PACT fast path.'
+affected_code: []
 requirements:
 - id: req.w3-hep-schemas
-  title: 'W3: HEP schema slices and deployment bridges'
-  statement: >-
-    The schema slices shipped: archi/schemas/operations.yaml and
-    sources.yaml plus schemas/bridges/, deployment-scoped, every class and
-    narrowing single-defined, shipping inside the wheel. The composition
-    clause does NOT hold: the wheel's bridges/operations.yaml cannot be copied
-    verbatim into any instance, because its narrowings lack
-    optional_when_subtypes_missing and catalog load then fails with
-    bridge_subtype_unknown (first failure: documentation_page_references_dataset,
-    child subtype dataset). Both consumers therefore hand-prune, and prune
-    DIFFERENTLY - the cern-team demo keeps only cmssw_release_supersedes_release,
-    while cms-compops prunes the five narrowings owned by the ticket/service/code
-    modules. That is divergence twice over. The fix has precedent in our own
-    tree (bridges/sources.yaml already flags the MONIT narrowings) and is filed
-    upstream as part of okg#1179; this change stays OPEN until a packaged bridge
-    composes without hand-editing.
-  evidence_policy:
-    required:
-    - executed_test
-  scenarios:
-  - id: scn.w3-hep-schemas.fast-path
-    title: Fast-path work is verified
-    given:
-    - a small nontrivial change fits one requirement
-    when:
-    - the declared verification runs
-    then:
-    - the requirement has executed proof before completion
-    and: []
-  acceptance:
-  - id: acc.w3-hep-schemas
-    description: >-
-      A packaged bridge composes on both the cern-team bundle and the
-      cms-compops instance with no hand-pruning, and okg catalog load is green
-      on both from the wheel's files as shipped.
-    evidence:
-    - executed_test
+  statement: "W3: HEP schema slices and deployment bridges\n\nThe schema slices shipped: archi/schemas/operations.yaml\
+    \ and sources.yaml plus schemas/bridges/, deployment-scoped, every class and narrowing\
+    \ single-defined, shipping inside the wheel. The composition clause does NOT hold: the\
+    \ wheel's bridges/operations.yaml cannot be copied verbatim into any instance, because\
+    \ its narrowings lack optional_when_subtypes_missing and catalog load then fails with\
+    \ bridge_subtype_unknown (first failure: documentation_page_references_dataset, child\
+    \ subtype dataset). Both consumers therefore hand-prune, and prune DIFFERENTLY - the cern-team\
+    \ demo keeps only cmssw_release_supersedes_release, while cms-compops prunes the five\
+    \ narrowings owned by the ticket/service/code modules. That is divergence twice over.\
+    \ The fix has precedent in our own tree (bridges/sources.yaml already flags the MONIT\
+    \ narrowings) and is filed upstream as part of okg#1179; this change stays OPEN until\
+    \ a packaged bridge composes without hand-editing.\n\nAcceptance:\n- acc.w3-hep-schemas:\
+    \ A packaged bridge composes on both the cern-team bundle and the cms-compops instance\
+    \ with no hand-pruning, and okg catalog load is green on both from the wheel's files as\
+    \ shipped. [evidence: executed_test]\n\nScenarios:\n- scn.w3-hep-schemas.fast-path Fast-path\
+    \ work is verified\n  Given a small nontrivial change fits one requirement\n  When the\
+    \ declared verification runs\n  Then the requirement has executed proof before completion"
 tasks:
 - id: task.w3-hep-schemas
-  title: 'W3: HEP schema slices and deployment bridges'
-  status: todo
-  verification: "okg catalog load --apply on both consumers using the wheel's bridges/operations.yaml unmodified (currently fails with bridge_subtype_unknown)"
-  requirements:
-  - req.w3-hep-schemas
-  evidence: []
-  environment: []
-dependencies: []
-test_plan:
-- id: test.req-w3-hep-schemas.backfill
   requirement: req.w3-hep-schemas
-  test_id: python/tests
-  evidence:
-  - pytest
-formal: []
-waivers: []
+  verification: 'W3: HEP schema slices and deployment bridges
+
+
+    okg catalog load --apply on both consumers using the wheel''s bridges/operations.yaml
+    unmodified (currently fails with bridge_subtype_unknown)
+
+
+    Test plan:
+
+    - python/tests [evidence: pytest]'
 evidence: []
+decisions: []

--- a/pact/changes/w4-playbooks/pact.yaml
+++ b/pact/changes/w4-playbooks/pact.yaml
@@ -1,89 +1,61 @@
-pact_version: 4
-target_pact_version: 4
-change:
-  id: w4-playbooks
-  title: 'W4: port and de-site-ify the CMS playbooks'
-  status: proposal
-  rationale: 'Backfills the unrecorded W4 wave. The playbooks shipped and one of the ADR''s
-    three done-clauses is evidenced; the other two were never implemented or never run, and
-    are recorded here as open rather than assumed. OPEN CLAUSES: skill_bundle_hash pinning
-    unimplemented; doctor check never run.'
-  root_cause: Small nontrivial change whose intent, task, acceptance, and proof fit the PACT
-    fast path.
-  tier: 1
-  method_metadata:
-    pact_shape: fast_path
-    fast_path: Compact PACT for small nontrivial work. Upgrade when scope, risk, hierarchy,
-      formal proof, graph evidence, or review complexity increases.
-  affected_areas: []
-  affected_code: []
+pact_version: 5
+id: w4-playbooks
+title: 'W4: port and de-site-ify the CMS playbooks'
+tier: 1
+why: 'Backfills the unrecorded W4 wave. The playbooks shipped and one of the ADR''s three
+  done-clauses is evidenced; the other two were never implemented or never run, and are recorded
+  here as open rather than assumed. OPEN CLAUSES: skill_bundle_hash pinning unimplemented;
+  doctor check never run.
+
+
+  Small nontrivial change whose intent, task, acceptance, and proof fit the PACT fast path.'
+affected_code: []
 requirements:
 - id: req.w4-playbooks
-  title: 'W4: port and de-site-ify the CMS playbooks'
-  statement: 'The CMS playbooks are ported and de-site-ified (21 in skills/, symlinked into
-    bundles/cern-team/skills/ and materialised into the wheel), skill_triggers is wired per
-    bundle, and no playbook carries site markers, hostnames or secrets - that clause is test-enforced
-    and green. The other two ADR clauses are MIS-SPECIFIED rather than merely unmet, established
-    by running them. (1) ''bundle install materializes playbooks with skill_bundle_hash pinned'':
-    the hash is computed by okg from the instance''s skills_dir during `okg deployment release`
-    (deployment_release.py:308), which further requires a release.channel the instance does
-    not declare. It is an instance release-lifecycle step, never a distribution or bundle-install
-    one, so no work in this repo can satisfy the clause as worded; skills/README.md claimed
-    otherwise and has been corrected. (2) ''okg doctor --check agent-skills green'': the check
-    RUNS green against the comp-ops instance, but it inspects the okg checkout''s own agent
-    tooling skills (root = the okg repo, 18 skills, targets claude-code and codex), not a
-    deployment''s playbooks - green and irrelevant. This change stays OPEN until the wave
-    definition is re-specified against mechanisms that actually measure playbooks.'
-  evidence_policy:
-    required:
-    - executed_test
-  scenarios:
-  - id: scn.w4-playbooks.fast-path
-    title: Fast-path work is verified
-    given:
-    - a small nontrivial change fits one requirement
-    when:
-    - the declared verification runs
-    then:
-    - the requirement has executed proof before completion
-    and: []
-  acceptance:
-  - id: acc.w4-playbooks
-    description: python/tests/test_skills.py green (playbook set, trigger references, no site
-      markers) AND a bundle install that pins skill_bundle_hash AND okg doctor --check agent-skills
-      green on an instance.
-    evidence:
-    - executed_test
+  statement: "W4: port and de-site-ify the CMS playbooks\n\nThe CMS playbooks are ported and\
+    \ de-site-ified (21 in skills/, symlinked into bundles/cern-team/skills/ and materialised\
+    \ into the wheel), skill_triggers is wired per bundle, and no playbook carries site markers,\
+    \ hostnames or secrets - that clause is test-enforced and green. The other two ADR clauses\
+    \ are MIS-SPECIFIED rather than merely unmet, established by running them. (1) 'bundle\
+    \ install materializes playbooks with skill_bundle_hash pinned': the hash is computed\
+    \ by okg from the instance's skills_dir during `okg deployment release` (deployment_release.py:308),\
+    \ which further requires a release.channel the instance does not declare. It is an instance\
+    \ release-lifecycle step, never a distribution or bundle-install one, so no work in this\
+    \ repo can satisfy the clause as worded; skills/README.md claimed otherwise and has been\
+    \ corrected. (2) 'okg doctor --check agent-skills green': the check RUNS green against\
+    \ the comp-ops instance, but it inspects the okg checkout's own agent tooling skills (root\
+    \ = the okg repo, 18 skills, targets claude-code and codex), not a deployment's playbooks\
+    \ - green and irrelevant. This change stays OPEN until the wave definition is re-specified\
+    \ against mechanisms that actually measure playbooks.\n\nAcceptance:\n- acc.w4-playbooks:\
+    \ python/tests/test_skills.py green (playbook set, trigger references, no site markers)\
+    \ AND a bundle install that pins skill_bundle_hash AND okg doctor --check agent-skills\
+    \ green on an instance. [evidence: executed_test]\n\nScenarios:\n- scn.w4-playbooks.fast-path\
+    \ Fast-path work is verified\n  Given a small nontrivial change fits one requirement\n\
+    \  When the declared verification runs\n  Then the requirement has executed proof before\
+    \ completion"
 tasks:
 - id: task.w4-playbooks
-  title: 'W4: port and de-site-ify the CMS playbooks'
-  status: todo
-  verification: pytest python/tests/test_skills.py -q (passing) + okg doctor --check agent-skills
-    on a live instance (never run)
-  requirements:
-  - req.w4-playbooks
-  evidence: []
-  environment: []
-dependencies: []
-test_plan:
-- id: test.req-w4-playbooks.backfill
   requirement: req.w4-playbooks
-  test_id: python/tests
-  evidence:
-  - pytest
-formal: []
-waivers: []
+  verification: 'W4: port and de-site-ify the CMS playbooks
+
+
+    pytest python/tests/test_skills.py -q (passing) + okg doctor --check agent-skills on a
+    live instance (never run)
+
+
+    Test plan:
+
+    - python/tests [evidence: pytest]'
 evidence:
-- id: ev.executed-test.req-w4-playbooks.20260825T015919131561Z
-  kind: executed_test
+- kind: executed_test
+  requirement: req.w4-playbooks
   status: pass
-  refs:
-  - req.w4-playbooks
-  artifact: python/tests/test_skills.py
   command: /work/submit/lavezzo/okg-venv/bin/python -m pytest python/tests/test_skills.py
     -q
-  summary: Playbook set, trigger references and the no-site-markers/hostnames/secrets clause
+  artifact: python/tests/test_skills.py
+  sha256: 502df07b19f64c8e0d72db07d3939c1711c770ae5a1237249dfba022c88125fa
+  at: '2026-08-25T01:59:19.131587+00:00'
+  note: Playbook set, trigger references and the no-site-markers/hostnames/secrets clause
     are test-enforced and green. The skill_bundle_hash and doctor clauses remain unmet and
     are stated in the requirement.
-  data:
-    attached_at: '2026-08-25T01:59:19.131587+00:00'
+decisions: []

--- a/pact/project.yaml
+++ b/pact/project.yaml
@@ -1,3 +1,19 @@
+# The CORPUS is v5 as of 2026-09-08: every manifest under pact/changes/ and
+# pact/archive/ carries `pact_version: 5`, migrated by okg's own `pact migrate`.
+#
+# This file stays at 4 on purpose, and okg made the same choice for their own
+# project.yaml after migrating their corpus. Two reasons: the v4 compatibility
+# reader behind `okg pact ...` still consults it, and the v5 CLI never reads it
+# at all — v5 is git-native and takes the git toplevel as its root. Bumping the
+# number here would change nothing for v5 and degrade the v4 reader.
+#
+# Author NEW changes with the v5 CLI, not `okg pact new`, or you will get a v4
+# manifest in a v5 corpus:
+#   /work/submit/lavezzo/okg-venv/bin/python -m pact.cli --root <repo> new <id>
+#
+# The `review_policy` and `decide/merge gate` wording below describes the v4
+# lifecycle. v5 replaces that whole flow with one `check` gate plus a
+# `Pact-Approved` git commit trailer. See CLAUDE.md's overrides section.
 pact_version: 4
 project: archi
 default_change_status: proposal


### PR DESCRIPTION
## What this changes

Our PACT ledger is now v5, matching okg, and CLAUDE.md no longer tells agents to use verbs that v5 removed. Also carries the okg pin bump and our filed reply on enricher scope.

## Behavior before → after

**Before.** Authoring and gating followed a six-verb v4 flow — `gate`, `decide`, `evidence`, `hooks`, `view`, `migrate-version` — against a decision ledger, and we were the last thing still on v4 after okg cut over on 2026-09-07.

**After.** v5 is git-native: one `check` gate that validates, binds receipts, verifies approval and computes tier, plus `approve` writing a `Pact-Approved` commit trailer. All nine manifests migrated, zero refused.

## Findings, worst first

1. **`pact/changes/w2-consolidate-hep-sources/pact.yaml` — migrating does not carry our proof forward as proof.** `check` reports 21 evidence rows as `evidence_unbound` and all five W2 requirements as unproven. The rows survive with `pass` intact, but v5 binds receipts to a commit and ours predate that model. **This is not new damage** — v4's staleness guard had already revoked those same five requirements after PR #617 touched `python/archi`. Same conclusion, new vocabulary. Re-attaching receipts is outstanding and deliberately not attempted here.
2. **A v5 task has no status field.** Twelve task statuses reading `done` were dropped, eight of them W2's. Checked against okg's own migrated manifests: a v5 task carries only `id`, `requirement`, `verification`. Completion is derived from receipts, not stored — so the drop is the format working as designed.
3. **`pact/project.yaml:1` stays at `pact_version: 4` deliberately.** okg made the same choice for their own file after migrating their corpus: the v4 compatibility reader consults it, and the v5 CLI never reads it — it is git-native and roots at the git toplevel. Bumping it changes nothing for v5 and degrades the v4 reader. Commented in place so nobody "fixes" it.
4. **`okg pact view` lies quietly on a v5 manifest**, reporting `normative_v4: true`. Recorded in CLAUDE.md as degraded output rather than authority.
5. **`CLAUDE.md:15` — the v5 guidance went in the overrides section, not the managed block.** Lines 23–137 are okg-generated boilerplate their installer rewrites, so an edit there would be silently reverted. The overrides section already declares it wins on conflict.
6. **`docs/okg-alignment.md` — the okg pin moved `2d528e824` → `1475c87d5`**, a 1153-commit fast-forward, and the import surface survived it unchanged: all ten guarded `okg.substrate.*` symbols still resolve, no source change needed. We now test against the same revision okg's Sprint 11 design notes were verified against.

## How I verified

- Dry run first, with a report, before writing anything: zero destructive notes — no `evidence_dropped`, no `artifact_outside_repo`, no `waived_becomes_fail`, no `formal_carried:*:fail`.
- `migrate --check --include-archive` now reports all 9 manifests v5.
- Suite **339 passed**, at the new okg pin.
- `check` run against the migrated W2 to see what the new gate actually says, rather than assuming the migration was lossless.

## Not addressed here

- Re-attaching evidence receipts so v5 considers our requirements proven.
- Pinning the okg revision in `docs/cern-team-quickstart.md` — deferred; the document is not being shared with collaborators yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Dhd8kXJLfAJjDDZHXaXds
