### PR TITLE
pact: declare the tier v5 computes, so the gate stops refusing four changes

### DIFF
--- a/pact/changes/w0-ratify-and-pin/pact.yaml
+++ b/pact/changes/w0-ratify-and-pin/pact.yaml
@@ -1,7 +1,7 @@
 pact_version: 5
 id: w0-ratify-and-pin
 title: 'W0: ratify the ADR, adopt PACT, file the asks, pin the repos'
-tier: 1
+tier: 2
 why: 'Invariant 1 says one PACT change per work package; W0 shipped without one, so the wave
   that adopted PACT is itself unrecorded in the ledger. This backfills it. Recorded retroactively
   and honestly: three of the ADR''s four done-clauses now hold, and the fourth is not ours

--- a/pact/changes/w10-v2-teardown/pact.yaml
+++ b/pact/changes/w10-v2-teardown/pact.yaml
@@ -1,7 +1,7 @@
 pact_version: 5
 id: w10-v2-teardown
 title: 'W10: delete the v2 application from the v3 line'
-tier: 1
+tier: 2
 why: 'Backfills the unrecorded W10 wave. The deletions executed as PR #611 without a PACT
   change and without the LOC delta the ADR and section 10 both require; that number is recorded
   here. The wave stays open because its done-clause is the section 14 cutover, which does

--- a/pact/changes/w3-hep-schemas/pact.yaml
+++ b/pact/changes/w3-hep-schemas/pact.yaml
@@ -1,7 +1,7 @@
 pact_version: 5
 id: w3-hep-schemas
 title: 'W3: HEP schema slices and deployment bridges'
-tier: 1
+tier: 2
 why: 'Backfills the unrecorded W3 wave, and records that its ADR done-clause is FALSE AS WRITTEN
   rather than quietly re-scoping it. The clause reads: ''the cern-team bundle and the comp-ops
   instance compose the same files without divergence.'' They do not, and cannot today. OPEN

--- a/pact/changes/w4-playbooks/pact.yaml
+++ b/pact/changes/w4-playbooks/pact.yaml
@@ -1,7 +1,7 @@
 pact_version: 5
 id: w4-playbooks
 title: 'W4: port and de-site-ify the CMS playbooks'
-tier: 1
+tier: 2
 why: 'Backfills the unrecorded W4 wave. The playbooks shipped and one of the ADR''s three
   done-clauses is evidenced; the other two were never implemented or never run, and are recorded
   here as open rather than assumed. OPEN CLAUSES: skill_bundle_hash pinning unimplemented;


### PR DESCRIPTION
## What this changes

Four of our five open PACT changes were being **refused** outright by the v5 gate, not merely reported as incomplete. They now pass it.

## Behavior before → after

**Before.** `pact check` returned `refused (tier_below_computed:2); state=open` for `w0-ratify-and-pin`, `w3-hep-schemas`, `w4-playbooks` and `w10-v2-teardown`.

**After.** All five return `recorded; state=open`.

## Findings

1. **This was a migration artifact, not a judgement call.** All four declared `tier: 1`. v4 had no computed tier to disagree with, so that sat unchallenged for months; the migration carried it forward verbatim, and defaulted one manifest's tier outright (`tier_defaulted_to_1`). v5 computes the tier from the diff and refuses anything *declared* below it — so the entire open ledger was refused the moment we migrated. Raising the declaration to 2 states what the tool already computes; it reclassifies nothing.
2. **`pact/changes/w2-consolidate-hep-sources/pact.yaml` needed no change.** It already declared `tier: 2`, which is exactly why it alone came back `recorded` rather than refused — a useful control on the diagnosis.

## How I verified

Ran `pact check` against all five before and after. The four refusals cleared; no warning count moved in either direction, which is what a correct fix looks like here — the declaration changed, nothing about the changes themselves did. Suite **339 passed**.

## Not addressed here

- **Every change reports `approval_missing`.** In v5 approval is the operator's `Pact-Approved` git commit trailer, so it is Luca's to give and not something I can or should synthesize.
- **Evidence remains unbound** — 21 rows on W2, one each on w0, w4 and w10. Whether to re-prove W2 or retire it as historical is an open decision, tracked separately. W2 is the widest-scoped change in the programme, so under any version model it keeps being invalidated by unrelated merges to `python/archi`; that is the argument for retiring rather than re-proving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Dhd8kXJLfAJjDDZHXaXds
