### PR TITLE
feat(sdk): move the connector surface onto the public okg.deployment SDK (except SourceRun)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,14 +55,25 @@ jobs:
           # The pin is the commit archi is tested against; see
           # docs/okg-alignment.md, which states the drift from okg dev.
           #
-          # Install from mitdbg/okg, NOT a fork. This used to point at
-          # lucalavezzo/okg@f5ec3b58d, and the fork's dev silently stopped
-          # tracking upstream on 2026-08-25 — so from then until 2026-09-10 CI
-          # was re-checking a three-week-old okg while the alignment page
-          # claimed we tested against current dev. A fork adds a manual sync
-          # step whose only observable effect is that kind of quiet rot.
+          # THE FORK IS LOAD-BEARING, and the pin must be kept fresh by hand.
+          # OKG_REPO_TOKEN is scoped to this account's own repositories: pointing
+          # this at mitdbg/okg directly returns 403 (measured, run 34494575759),
+          # so the fork is the only copy CI can read.
+          #
+          # That makes the fork a standing hazard rather than a convenience. Its
+          # `dev` silently stopped tracking upstream on 2026-08-25, and from then
+          # until 2026-09-10 CI re-checked a three-week-old okg while
+          # docs/okg-alignment.md claimed we tested against current dev. Nothing
+          # failed, which is exactly why nobody noticed.
+          #
+          # So: before bumping this pin, sync the fork, or the new commit will not
+          # be fetchable —
+          #   gh repo sync lucalavezzo/okg --source mitdbg/okg --branch dev
+          # (needs `gh auth refresh -s workflow`). Keep this pin equal to the
+          # commit named in docs/okg-alignment.md; if they differ, the page is
+          # describing a build that never ran.
           python -m pip install --upgrade pip
-          pip install "okg @ git+https://x-access-token:${OKG_REPO_TOKEN}@github.com/mitdbg/okg@34efbad1b5768fd3ca635992173694a9cc91ebd2"
+          pip install "okg @ git+https://x-access-token:${OKG_REPO_TOKEN}@github.com/lucalavezzo/okg@34efbad1b5768fd3ca635992173694a9cc91ebd2"
 
       - name: Install archi with dev extras
         run: pip install -e "./python[dev]"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,15 @@ jobs:
           fi
           # The pin is the commit archi is tested against; see
           # docs/okg-alignment.md, which states the drift from okg dev.
+          #
+          # Install from mitdbg/okg, NOT a fork. This used to point at
+          # lucalavezzo/okg@f5ec3b58d, and the fork's dev silently stopped
+          # tracking upstream on 2026-08-25 — so from then until 2026-09-10 CI
+          # was re-checking a three-week-old okg while the alignment page
+          # claimed we tested against current dev. A fork adds a manual sync
+          # step whose only observable effect is that kind of quiet rot.
           python -m pip install --upgrade pip
-          pip install "okg @ git+https://x-access-token:${OKG_REPO_TOKEN}@github.com/lucalavezzo/okg@f5ec3b58d"
+          pip install "okg @ git+https://x-access-token:${OKG_REPO_TOKEN}@github.com/mitdbg/okg@34efbad1b5768fd3ca635992173694a9cc91ebd2"
 
       - name: Install archi with dev extras
         run: pip install -e "./python[dev]"

--- a/docs/okg-alignment.md
+++ b/docs/okg-alignment.md
@@ -253,20 +253,21 @@ dereference (your "materialized payload" wording already covers this).
 
 ## The exact substrate surface Archi consumes today
 
-This is the de-facto interface #1181 (public connector/enricher SDK) will replace.
-If you change any of these on `dev`, Archi breaks; when the SDK lands, Archi
-migrates to it in one sweep (imports are centralized).
+**The connector half is done (2026-09-10).** Everything Archi's connectors need now
+comes from the public `okg.deployment` SDK, so #1181's boundary lint has nothing left
+to find on that side. What remains below is enricher-only, and is blocked on #1181
+slice 5 — the enricher read surface, deferred at
+[our own recommendation](https://github.com/mitdbg/okg/issues/1181#issuecomment-5591973861).
 
-**Python imports (all of them):**
+**Python imports (all of them).** The first entry is the public SDK; everything
+below it is still private substrate, and all of it is enricher-side.
+
 ```
-okg.substrate.library.sources.base:
-    NodeFact, EdgeFact, SourceRun, SourceHealth, SourcePreflightResult,
-    ProgressMarker
-okg.substrate.library.sources.content_hash_probe: ContentHashProbe
-okg.substrate.library.sources.mutable_api_probe:  MutableApiProbe
-okg.substrate.sources.preflight:
-    file_ref_preflight, credential_env_preflight, http_probe_result
-okg.substrate.sources.redaction:  redact_text
+okg.deployment:
+    NodeFact, EdgeFact, ProgressMarker,
+    ConnectorRun, ConnectorHealth, PreflightResult,
+    ContentHashProbe, MutableApiProbe,
+    file_preflight, credential_preflight, http_preflight, redact
 okg.substrate.enrichers.base:     EnrichResult, IncrementalContext
 okg.substrate.enrichers.derived_edges:
     DerivedEdgeCandidate, insert_deterministic_edges, mint_edge_id
@@ -274,6 +275,18 @@ okg.substrate.library.linkers:    _chronos
 okg.substrate.library.linkers.declarative: DeclarativeLinker
 okg.substrate.alias.protocol:     AliasMatch
 ```
+
+Every SDK name above was verified to be the *same object* as the substrate name it
+replaced, except `ConnectorRun`, which is a genuinely narrower type: it drops
+`next_cursor`, `effective_scope_complete`, `bootstrap_identity` and three
+`applied_token_*` fields — none of which Archi ever referenced — and retains
+`record_authority_stream`, `record_set` and `record_set_replacement_keys`, the
+fields #1181's design note warned would cost incremental sources their changed-slice
+retractions.
+
+If you change any of the remaining `okg.substrate.*` entries on `dev`, Archi breaks.
+`_chronos` is underscore-private by Python convention and remains the single item
+most worth absorbing into the SDK.
 
 **Contracts consumed as data/CLI (not imports):** the source-registry entry schema
 (`source_class`, `record_identity_*`, `change_probe_kind` soundness, admission

--- a/docs/okg-alignment.md
+++ b/docs/okg-alignment.md
@@ -20,8 +20,43 @@ reimplementation of OKG services.
 
 ## Current state (update this section when it changes)
 
-*Last updated 2026-09-08, tested against okg `dev` @ `1475c87d5`; archi branch
-`archi_v3` with PRs #610–#634 merged.*
+*Last updated 2026-09-10, tested against okg `dev` @ `34efbad1b`; archi branch
+`archi_v3` with PRs #610–#639 merged.*
+
+**Pin bumped `1475c87d5` → `34efbad1b` (2026-09-10), Sprint 11's 45 merges.** Full
+archi suite **339 passed**, `test_alignment_page.py` included, so all ten guarded
+`okg.substrate.*` symbols still resolve across 663 commits. No source change needed.
+
+**Our migration debt, now measured rather than estimated.** 43 imports of
+`okg.substrate.*` across ten private modules:
+
+| Side | Sites | Status |
+|---|---|---|
+| Connector — `library.sources.base` (17), `sources.preflight` (4), `content_hash_probe` (3), `mutable_api_probe` (3), `sources.redaction` (1) | **28** | **Migratable now.** `okg.deployment` exports 82 names; 17 of the 20 we need are present. `SourceRun` → `ConnectorRun` and `SourceHealth` → `ConnectorHealth` are renames touching ~133 references. We do not use `content_hash_items`. |
+| Enricher — `enrichers.base` (4), `enrichers.derived_edges` (4), `library.linkers` (5), `linkers.declarative` (1), `alias.protocol` (1) | **15** | **Blocked** on #1181 slice 5, the enricher read surface, deferred at our own recommendation. |
+
+One of the fifteen is `okg.substrate.library.linkers._chronos` — underscore-private by
+Python convention, and the single item we flagged upstream as most worth absorbing.
+
+**Sprint 11 closed 2026-09-10 with our three reports absorbed.** Its
+[closing summary](https://github.com/mitdbg/okg/issues/1698#issuecomment-5616923942)
+retains the **connectors-first** example and records the enricher read surface as
+**deferred** — both our recommendation on
+[#1181](https://github.com/mitdbg/okg/issues/1181#issuecomment-5591973861). Sprint 14
+**#1792 owns provider/admin bootstrap** (our
+[#1183 findings](https://github.com/mitdbg/okg/issues/1183#issuecomment-5591286914) 2
+and 3) and **#1795 owns operator acceptance** including install and chat (our
+[#1179 ask](https://github.com/mitdbg/okg/issues/1179#issuecomment-5594656468)).
+**#1185 did not pass** and moved to Sprint 14 (#1789); our wheel remains its required
+real arm.
+
+**Owed by us, per that summary:** trusted admission policy, a real legacy inventory,
+and **acknowledgement of the current v2 contract — the v1 one is now insufficient**.
+The v1 digest we acknowledged (`sha256:db38e9bb…`) is still valid for v1; v2 is
+`sha256:5cba96ce160313402809651027e0d0c708610542a485c8ac0a88a578b2c69f6a`. Held
+deliberately until the real arm can run, since #1185 still lacks the consumer
+environment, sealed packages and lifecycle receipts that would make an
+acknowledgement outlive the day it is issued.
 
 **The bundle now ships the assistant's system prompt (2026-09-08, PR #632).**
 `bundles/cern-team/skills/chat-system-prompt.md`, declared as

--- a/docs/okg-alignment.md
+++ b/docs/okg-alignment.md
@@ -27,15 +27,21 @@ reimplementation of OKG services.
 archi suite **339 passed**, `test_alignment_page.py` included, so all ten guarded
 `okg.substrate.*` symbols still resolve across 663 commits. No source change needed.
 
-**CI was testing a different okg than this page claimed, and now is not.** Until
-2026-09-10 the workflow installed `lucalavezzo/okg@f5ec3b58d` — a *fork*, whose `dev`
-silently stopped tracking upstream on 2026-08-25. So while this page recorded two pin
-bumps and a passing suite, CI was re-checking a three-week-old okg; every "passed
-against `dev`" claim here was true of local runs only. Found because the connector
-SDK migration failed CI on `ImportError: cannot import name 'EdgeFact'` — the SDK did
-not exist in the pinned commit. The workflow now installs from **`mitdbg/okg`
-directly**, pinned to the same commit this page names, so the two cannot drift apart
-again without the pin visibly changing.
+**CI was testing a different okg than this page claimed.** Until 2026-09-10 the
+workflow installed `lucalavezzo/okg@f5ec3b58d` — a *fork*, whose `dev` silently
+stopped tracking upstream on 2026-08-25. So while this page recorded two pin bumps
+and a passing suite, CI re-checked a three-week-old okg; every "passed against `dev`"
+claim here was true of local runs only. Nothing failed, which is why nobody noticed.
+Found only because the connector SDK migration failed CI on `ImportError: cannot
+import name 'EdgeFact'` — the SDK did not exist in the pinned commit.
+
+**The fork cannot be removed**, which is the uncomfortable part. `OKG_REPO_TOKEN` is
+scoped to that account's own repositories, so pointing CI at `mitdbg/okg` returns 403
+(measured, run `34494575759`). CI can only read the fork, and the fork only tracks
+upstream when someone syncs it by hand. The pin is now `34efbad1b`, matching this
+page, and the workflow carries the sync command plus the rule that the two must stay
+equal — but the structural fix is a token that can read `mitdbg/okg` directly, which
+needs a classic PAT rather than the current fine-grained one.
 
 **Our migration debt, now measured rather than estimated.** 43 imports of
 `okg.substrate.*` across ten private modules:

--- a/docs/okg-alignment.md
+++ b/docs/okg-alignment.md
@@ -27,6 +27,16 @@ reimplementation of OKG services.
 archi suite **339 passed**, `test_alignment_page.py` included, so all ten guarded
 `okg.substrate.*` symbols still resolve across 663 commits. No source change needed.
 
+**CI was testing a different okg than this page claimed, and now is not.** Until
+2026-09-10 the workflow installed `lucalavezzo/okg@f5ec3b58d` — a *fork*, whose `dev`
+silently stopped tracking upstream on 2026-08-25. So while this page recorded two pin
+bumps and a passing suite, CI was re-checking a three-week-old okg; every "passed
+against `dev`" claim here was true of local runs only. Found because the connector
+SDK migration failed CI on `ImportError: cannot import name 'EdgeFact'` — the SDK did
+not exist in the pinned commit. The workflow now installs from **`mitdbg/okg`
+directly**, pinned to the same commit this page names, so the two cannot drift apart
+again without the pin visibly changing.
+
 **Our migration debt, now measured rather than estimated.** 43 imports of
 `okg.substrate.*` across ten private modules:
 

--- a/python/archi/auth/cache.py
+++ b/python/archi/auth/cache.py
@@ -26,8 +26,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
 
-from okg.substrate.library.sources.content_hash_probe import ContentHashProbe
-from okg.substrate.library.sources.mutable_api_probe import MutableApiProbe
+from okg.deployment import ContentHashProbe
+from okg.deployment import MutableApiProbe
 
 DATA_ROOT_ENV = "ARCHI_DATA_ROOT"
 

--- a/python/archi/auth/preflight.py
+++ b/python/archi/auth/preflight.py
@@ -17,7 +17,7 @@ Rewritten from okg-deployments ``cms/cms_sources/preflight.py``
   tagged it ``cache``).
 
 Probes emit no NodeFact/EdgeFact; a run returns an empty fact stream
-with a SourceHealth summarizing the probe outcome. The failure
+with a ConnectorHealth summarizing the probe outcome. The failure
 vocabulary is unchanged: ``ok`` / ``missing_credential`` /
 ``auth_failed`` / ``tls_failed`` / ``endpoint_failed`` /
 ``cache_missing``. Credentials arrive as env-var references and file
@@ -35,16 +35,16 @@ from typing import Any, Iterable, Mapping, Optional
 
 import requests
 
-from okg.substrate.library.sources.base import (
-    SourcePreflightResult,
-    SourceRun,
+from okg.deployment import (
+    PreflightResult,
+    ConnectorRun,
 )
-from okg.substrate.sources.preflight import (
-    credential_env_preflight,
-    file_ref_preflight,
-    http_probe_result,
+from okg.deployment import (
+    credential_preflight,
+    file_preflight,
+    http_preflight,
 )
-from okg.substrate.sources.redaction import redact_text
+from okg.deployment import redact
 
 from archi.auth.cache import resolve_repo_path
 from archi.auth.cookies import (
@@ -99,15 +99,15 @@ def _load_cookie_file(session: requests.Session, path: Path) -> None:
 
 
 def _with_credential_context(
-    result: SourcePreflightResult,
+    result: PreflightResult,
     *,
     credential_ref: str,
     alias_refs: Mapping[str, tuple[str, ...]],
-) -> SourcePreflightResult:
+) -> PreflightResult:
     data = result.as_dict()
     data["credential_refs"] = (credential_ref,)
     data["alias_refs"] = dict(alias_refs)
-    return SourcePreflightResult(**data)
+    return PreflightResult(**data)
 
 
 def _login_page_detected(url: str, text: str) -> bool:
@@ -153,11 +153,11 @@ class CERNPreflightSource:
         )
         self.base = base
 
-    def preflight(self, mode: str = "live") -> SourcePreflightResult:
+    def preflight(self, mode: str = "live") -> PreflightResult:
         if self.kind == "cache":
             return self._cache_preflight(mode=mode)
         if self.kind == "token":
-            return credential_env_preflight(
+            return credential_preflight(
                 self.name,
                 self._credential_ref(),
                 aliases=self.aliases,
@@ -165,7 +165,7 @@ class CERNPreflightSource:
                 mode=mode,
             )
         if self.kind == "file":
-            return file_ref_preflight(
+            return file_preflight(
                 self.name,
                 self._credential_ref(),
                 aliases=self.aliases,
@@ -190,7 +190,7 @@ class CERNPreflightSource:
             return self._any_file_preflight(mode=mode)
         if self.kind == "all_env":
             return self._all_env_preflight(mode=mode)
-        return SourcePreflightResult(
+        return PreflightResult(
             source_name=self.name,
             status="endpoint_failed",
             mode=mode,
@@ -205,8 +205,8 @@ class CERNPreflightSource:
         *,
         mode: str = "cursor",
         sync_scope: Optional[Mapping[str, Any]] = None,
-    ) -> SourceRun:
-        return SourceRun(facts=[], health=self.preflight())
+    ) -> ConnectorRun:
+        return ConnectorRun(facts=[], health=self.preflight())
 
     def _credential_ref(self) -> str:
         if not self.credential_ref:
@@ -222,13 +222,13 @@ class CERNPreflightSource:
             )
         return self.endpoint
 
-    def _cache_preflight(self, *, mode: str) -> SourcePreflightResult:
+    def _cache_preflight(self, *, mode: str) -> PreflightResult:
         paths = [
             resolve_repo_path(p, base=self.base) for p in self.cache_paths
         ]
         missing = [p for p in paths if not p.exists()]
         if missing:
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="cache_missing",
                 mode="cache",
@@ -242,7 +242,7 @@ class CERNPreflightSource:
             try:
                 count += _json_record_count(path)
             except Exception as exc:  # noqa: BLE001
-                return SourcePreflightResult(
+                return PreflightResult(
                     source_name=self.name,
                     status="cache_missing",
                     mode="cache",
@@ -253,7 +253,7 @@ class CERNPreflightSource:
                     ),
                     checked_at=_checked_at(),
                 )
-        return SourcePreflightResult(
+        return PreflightResult(
             source_name=self.name,
             status="ok",
             mode="cache",
@@ -263,8 +263,8 @@ class CERNPreflightSource:
             checked_at=_checked_at(),
         )
 
-    def _ca_bundle_preflight(self, *, mode: str) -> SourcePreflightResult:
-        result = file_ref_preflight(
+    def _ca_bundle_preflight(self, *, mode: str) -> PreflightResult:
+        result = file_preflight(
             self.name,
             self._credential_ref(),
             aliases=self.aliases,
@@ -275,8 +275,8 @@ class CERNPreflightSource:
             data = result.as_dict()
             data["status"] = "tls_failed"
             data["reason"] = "CERN CA bundle is missing; refusing TLS bypass"
-            return SourcePreflightResult(**data)
-        return SourcePreflightResult(
+            return PreflightResult(**data)
+        return PreflightResult(
             source_name=self.name,
             status="ok",
             mode=mode,
@@ -287,8 +287,8 @@ class CERNPreflightSource:
             checked_at=_checked_at(),
         )
 
-    def _sso_cookie_preflight(self, *, mode: str) -> SourcePreflightResult:
-        result = file_ref_preflight(
+    def _sso_cookie_preflight(self, *, mode: str) -> PreflightResult:
+        result = file_preflight(
             self.name,
             self._credential_ref(),
             aliases=self.aliases,
@@ -305,7 +305,7 @@ class CERNPreflightSource:
             if self.max_age_hours is not None else None
         )
         status = check_cookie_file(cookie_path, max_age=max_age)
-        return SourcePreflightResult(
+        return PreflightResult(
             source_name=self.name,
             status="ok" if status.fresh else "auth_failed",
             mode=mode,
@@ -316,8 +316,8 @@ class CERNPreflightSource:
             checked_at=_checked_at(),
         )
 
-    def _x509_proxy_preflight(self, *, mode: str) -> SourcePreflightResult:
-        result = file_ref_preflight(
+    def _x509_proxy_preflight(self, *, mode: str) -> PreflightResult:
+        result = file_preflight(
             self.name,
             self._credential_ref(),
             aliases=self.aliases,
@@ -331,7 +331,7 @@ class CERNPreflightSource:
         )
         expiry = _x509_not_after(proxy_path)
         if expiry is not None and expiry <= datetime.now(timezone.utc):
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="auth_failed",
                 mode=mode,
@@ -344,7 +344,7 @@ class CERNPreflightSource:
                 checked_at=_checked_at(),
             )
         if expiry is None:
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="auth_failed",
                 mode=mode,
@@ -359,7 +359,7 @@ class CERNPreflightSource:
                 ),
                 checked_at=_checked_at(),
             )
-        return SourcePreflightResult(
+        return PreflightResult(
             source_name=self.name,
             status="ok",
             mode=mode,
@@ -370,9 +370,9 @@ class CERNPreflightSource:
             checked_at=_checked_at(),
         )
 
-    def _cern_sso_http_preflight(self, *, mode: str) -> SourcePreflightResult:
+    def _cern_sso_http_preflight(self, *, mode: str) -> PreflightResult:
         endpoint = self._endpoint()
-        file_result = file_ref_preflight(
+        file_result = file_preflight(
             self.name,
             self._credential_ref(),
             aliases=self.aliases,
@@ -389,7 +389,7 @@ class CERNPreflightSource:
             try:
                 _load_cookie_file(session, cookie_path)
             except Exception as exc:  # noqa: BLE001
-                return SourcePreflightResult(
+                return PreflightResult(
                     source_name=self.name,
                     status="auth_failed",
                     mode=mode,
@@ -397,7 +397,7 @@ class CERNPreflightSource:
                     credential_refs=(self._credential_ref(),),
                     alias_refs=file_result.alias_refs,
                     endpoint=endpoint,
-                    reason=redact_text(
+                    reason=redact(
                         f"SSO cookie file could not be parsed — re-acquire "
                         f"it (no request was sent): "
                         f"{type(exc).__name__}: {exc}"
@@ -411,7 +411,7 @@ class CERNPreflightSource:
                 allow_redirects=True,
             )
         except requests.exceptions.SSLError as exc:
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="tls_failed",
                 mode=mode,
@@ -419,14 +419,14 @@ class CERNPreflightSource:
                 credential_refs=(self._credential_ref(),),
                 alias_refs=file_result.alias_refs,
                 endpoint=endpoint,
-                reason=redact_text(
+                reason=redact(
                     f"CERN SSO HTTP probe failed TLS: "
                     f"{type(exc).__name__}: {exc}"
                 ),
                 checked_at=_checked_at(),
             )
         except Exception as exc:  # noqa: BLE001
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="endpoint_failed",
                 mode=mode,
@@ -434,7 +434,7 @@ class CERNPreflightSource:
                 credential_refs=(self._credential_ref(),),
                 alias_refs=file_result.alias_refs,
                 endpoint=endpoint,
-                reason=redact_text(
+                reason=redact(
                     f"CERN SSO HTTP probe failed: "
                     f"{type(exc).__name__}: {exc}"
                 ),
@@ -451,7 +451,7 @@ class CERNPreflightSource:
         else:
             reason = f"CERN SSO HTTP probe returned HTTP {status_code}"
         return _with_credential_context(
-            http_probe_result(
+            http_preflight(
                 self.name,
                 ok=status_code == 200,
                 endpoint=endpoint,
@@ -464,7 +464,7 @@ class CERNPreflightSource:
             alias_refs=file_result.alias_refs,
         )
 
-    def _cern_tls_preflight(self, *, mode: str) -> SourcePreflightResult:
+    def _cern_tls_preflight(self, *, mode: str) -> PreflightResult:
         endpoint = self._endpoint()
         ca_result = self._ca_bundle_preflight(mode=mode)
         if ca_result.status != "ok":
@@ -478,7 +478,7 @@ class CERNPreflightSource:
                 verify=str(ca_path),
             )
         except requests.exceptions.SSLError as exc:
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="tls_failed",
                 mode=mode,
@@ -486,13 +486,13 @@ class CERNPreflightSource:
                 credential_refs=(self._credential_ref(),),
                 alias_refs=ca_result.alias_refs,
                 endpoint=endpoint,
-                reason=redact_text(
+                reason=redact(
                     f"CERN TLS probe failed: {type(exc).__name__}: {exc}"
                 ),
                 checked_at=_checked_at(),
             )
         except Exception as exc:  # noqa: BLE001
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="endpoint_failed",
                 mode=mode,
@@ -500,7 +500,7 @@ class CERNPreflightSource:
                 credential_refs=(self._credential_ref(),),
                 alias_refs=ca_result.alias_refs,
                 endpoint=endpoint,
-                reason=redact_text(
+                reason=redact(
                     f"CERN TLS probe failed: {type(exc).__name__}: {exc}"
                 ),
                 checked_at=_checked_at(),
@@ -516,7 +516,7 @@ class CERNPreflightSource:
         else:
             reason = f"CERN TLS probe returned HTTP {status_code}"
         return _with_credential_context(
-            http_probe_result(
+            http_preflight(
                 self.name,
                 ok=status_code == 200,
                 endpoint=endpoint,
@@ -529,12 +529,12 @@ class CERNPreflightSource:
             alias_refs=ca_result.alias_refs,
         )
 
-    def _x509_http_preflight(self, *, mode: str) -> SourcePreflightResult:
+    def _x509_http_preflight(self, *, mode: str) -> PreflightResult:
         endpoint = self._endpoint()
         refs = self.credential_refs or (self._credential_ref(),)
         proxy_ref = refs[0]
         ca_ref = refs[1] if len(refs) > 1 else None
-        proxy_result = file_ref_preflight(
+        proxy_result = file_preflight(
             self.name,
             proxy_ref,
             required=self.required,
@@ -544,7 +544,7 @@ class CERNPreflightSource:
             return proxy_result
         proxy_path = _credential_file_path(proxy_ref, ())
         if proxy_path is None:
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="missing_credential",
                 mode=mode,
@@ -555,7 +555,7 @@ class CERNPreflightSource:
             )
         expiry = _x509_not_after(proxy_path)
         if expiry is not None and expiry <= datetime.now(timezone.utc):
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="auth_failed",
                 mode=mode,
@@ -567,7 +567,7 @@ class CERNPreflightSource:
             )
         ca_path: Path | None = None
         if ca_ref:
-            ca_result = file_ref_preflight(
+            ca_result = file_preflight(
                 self.name,
                 ca_ref,
                 required=self.required,
@@ -577,7 +577,7 @@ class CERNPreflightSource:
                 data = ca_result.as_dict()
                 data["credential_refs"] = tuple(refs)
                 data["status"] = "tls_failed"
-                return SourcePreflightResult(**data)
+                return PreflightResult(**data)
             ca_path = _credential_file_path(ca_ref, ())
         try:
             response = requests.Session().get(
@@ -589,7 +589,7 @@ class CERNPreflightSource:
             )
         except requests.exceptions.SSLError as exc:
             text = str(exc)
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status=(
                     "auth_failed"
@@ -599,21 +599,21 @@ class CERNPreflightSource:
                 required=self.required,
                 credential_refs=tuple(refs),
                 endpoint=endpoint,
-                reason=redact_text(
+                reason=redact(
                     f"X.509 HTTPS probe failed TLS: "
                     f"{type(exc).__name__}: {exc}"
                 ),
                 checked_at=_checked_at(),
             )
         except Exception as exc:  # noqa: BLE001
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="endpoint_failed",
                 mode=mode,
                 required=self.required,
                 credential_refs=tuple(refs),
                 endpoint=endpoint,
-                reason=redact_text(
+                reason=redact(
                     f"X.509 HTTPS probe failed: "
                     f"{type(exc).__name__}: {exc}"
                 ),
@@ -621,7 +621,7 @@ class CERNPreflightSource:
             )
         status_code = int(getattr(response, "status_code", 0) or 0)
         return _with_credential_context(
-            http_probe_result(
+            http_preflight(
                 self.name,
                 ok=status_code == 200,
                 endpoint=endpoint,
@@ -634,7 +634,7 @@ class CERNPreflightSource:
             alias_refs={},
         )
 
-    def _https_preflight(self, *, mode: str) -> SourcePreflightResult:
+    def _https_preflight(self, *, mode: str) -> PreflightResult:
         endpoint = self._endpoint()
         try:
             response = requests.Session().get(
@@ -643,25 +643,25 @@ class CERNPreflightSource:
                 allow_redirects=True,
             )
         except requests.exceptions.SSLError as exc:
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="tls_failed",
                 mode=mode,
                 required=self.required,
                 endpoint=endpoint,
-                reason=redact_text(
+                reason=redact(
                     f"HTTPS probe failed TLS: {type(exc).__name__}: {exc}"
                 ),
                 checked_at=_checked_at(),
             )
         except Exception as exc:  # noqa: BLE001
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="endpoint_failed",
                 mode=mode,
                 required=self.required,
                 endpoint=endpoint,
-                reason=redact_text(
+                reason=redact(
                     f"HTTPS probe failed: {type(exc).__name__}: {exc}"
                 ),
                 checked_at=_checked_at(),
@@ -670,7 +670,7 @@ class CERNPreflightSource:
         text = getattr(response, "text", "") or ""
         url = getattr(response, "url", endpoint) or endpoint
         login_page = _login_page_detected(url, text)
-        return http_probe_result(
+        return http_preflight(
             self.name,
             ok=status_code == 200,
             endpoint=endpoint,
@@ -680,13 +680,13 @@ class CERNPreflightSource:
             login_page_detected=login_page or status_code in {401, 403},
         )
 
-    def _any_file_preflight(self, *, mode: str) -> SourcePreflightResult:
+    def _any_file_preflight(self, *, mode: str) -> PreflightResult:
         refs = self.credential_refs or (self._credential_ref(),)
         env = _env()
         for ref in refs:
             value = env.get(ref)
             if value and Path(value).expanduser().is_file():
-                return SourcePreflightResult(
+                return PreflightResult(
                     source_name=self.name,
                     status="ok",
                     mode=mode,
@@ -695,7 +695,7 @@ class CERNPreflightSource:
                     reason=f"{ref} file exists",
                     checked_at=_checked_at(),
                 )
-        return SourcePreflightResult(
+        return PreflightResult(
             source_name=self.name,
             status="missing_credential",
             mode=mode,
@@ -705,12 +705,12 @@ class CERNPreflightSource:
             checked_at=_checked_at(),
         )
 
-    def _all_env_preflight(self, *, mode: str) -> SourcePreflightResult:
+    def _all_env_preflight(self, *, mode: str) -> PreflightResult:
         refs = self.credential_refs or (self._credential_ref(),)
         env = _env()
         missing = [ref for ref in refs if not env.get(ref)]
         if missing:
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="missing_credential",
                 mode=mode,
@@ -719,7 +719,7 @@ class CERNPreflightSource:
                 reason="missing env refs: " + ", ".join(missing),
                 checked_at=_checked_at(),
             )
-        return SourcePreflightResult(
+        return PreflightResult(
             source_name=self.name,
             status="ok",
             mode=mode,

--- a/python/archi/sources/_cache_report.py
+++ b/python/archi/sources/_cache_report.py
@@ -25,9 +25,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
 
-from okg.substrate.library.sources.base import (
-    SourceHealth,
-    SourcePreflightResult,
+from okg.deployment import (
+    ConnectorHealth,
+    PreflightResult,
 )
 
 from archi.auth.cache import content_hash, resolve_repo_path
@@ -42,12 +42,12 @@ def cache_preflight_result(
     required: bool = False,
     mode: str = "cache",
     base: str | None = None,
-) -> SourcePreflightResult:
+) -> PreflightResult:
     paths = tuple(cache_paths)
     resolved_paths = tuple(resolve_repo_path(p, base=base) for p in paths)
     missing = [p for p in resolved_paths if not p.is_file()]
     if missing:
-        return SourcePreflightResult(
+        return PreflightResult(
             source_name=source_name,
             status="cache_missing",
             mode=mode,
@@ -57,7 +57,7 @@ def cache_preflight_result(
             checked_at=_checked_at(),
         )
     count = len(tuple(records or ()))
-    return SourcePreflightResult(
+    return PreflightResult(
         source_name=source_name,
         status=_cache_status(count),
         mode=mode,
@@ -76,14 +76,14 @@ def cache_source_health(
     record_count: int,
     skipped_count: int = 0,
     base: str | None = None,
-) -> SourceHealth:
+) -> ConnectorHealth:
     status, reason = skipped_items_status(
         status=_cache_status(record_count),
         reason=_cache_reason(description, record_count, observed=False),
         record_count=record_count,
         skipped_count=skipped_count,
     )
-    return SourceHealth(
+    return ConnectorHealth(
         status=status,
         mode="cache",
         record_count=record_count,

--- a/python/archi/sources/cmssw.py
+++ b/python/archi/sources/cmssw.py
@@ -75,12 +75,12 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Iterator
 
-from okg.substrate.library.sources.base import (
+from okg.deployment import (
     EdgeFact,
     NodeFact,
-    SourceHealth,
-    SourcePreflightResult,
-    SourceRun,
+    ConnectorHealth,
+    PreflightResult,
+    ConnectorRun,
 )
 
 from archi.auth.cache import (
@@ -169,12 +169,12 @@ class CMSSWReleaseSource:
             return (self.map_cache_path,)
         return (self.records_path,)
 
-    def preflight(self, mode: str = "live") -> SourcePreflightResult:
+    def preflight(self, mode: str = "live") -> PreflightResult:
         path = resolve_repo_path(self.cache_paths[0], base=self.base)
         if not path.is_file() and not (
             self.map_cache_path is not None and self.fetch
         ):
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="cache_missing",
                 mode="cache",
@@ -184,7 +184,7 @@ class CMSSWReleaseSource:
                 checked_at=_checked_at(),
             )
         if not path.is_file():
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="ok",
                 mode="live",
@@ -194,7 +194,7 @@ class CMSSWReleaseSource:
                 checked_at=_checked_at(),
             )
         records = self._records()
-        return SourcePreflightResult(
+        return PreflightResult(
             source_name=self.name,
             status="ok",
             mode="cache",
@@ -205,7 +205,7 @@ class CMSSWReleaseSource:
             checked_at=_checked_at(),
         )
 
-    def run(self, run_id: str, *, mode: str = "cursor") -> SourceRun:
+    def run(self, run_id: str, *, mode: str = "cursor") -> ConnectorRun:
         records, skipped, truncated = self._records_with_details()
         revision = {
             "run_id": run_id,
@@ -239,7 +239,7 @@ class CMSSWReleaseSource:
                 f"; limit={self.limit} truncated the release list; "
                 "no complete scope claimed"
             )
-        return SourceRun(
+        return ConnectorRun(
             facts=_facts(),
             completed_scope=(
                 mode in {"scope_complete", "reconcile"}
@@ -247,7 +247,7 @@ class CMSSWReleaseSource:
                 and not truncated
             ),
             run_mode=mode,
-            health=SourceHealth(
+            health=ConnectorHealth(
                 status=status,
                 mode="cache",
                 record_count=len(records),

--- a/python/archi/sources/conddb.py
+++ b/python/archi/sources/conddb.py
@@ -63,11 +63,11 @@ import re
 from dataclasses import dataclass
 from typing import Any, Iterator
 
-from okg.substrate.library.sources.base import (
+from okg.deployment import (
     EdgeFact,
     NodeFact,
-    SourcePreflightResult,
-    SourceRun,
+    PreflightResult,
+    ConnectorRun,
 )
 
 from archi.auth.cache import (
@@ -138,7 +138,7 @@ class CondDBGlobalTagSource:
     def cache_paths(self) -> tuple[str, ...]:
         return (self.records_path,)
 
-    def preflight(self, mode: str = "live") -> SourcePreflightResult:
+    def preflight(self, mode: str = "live") -> PreflightResult:
         try:
             records = self._records()
         except FileNotFoundError:
@@ -152,7 +152,7 @@ class CondDBGlobalTagSource:
             base=self.base,
         )
 
-    def run(self, run_id: str, *, mode: str = "cursor") -> SourceRun:
+    def run(self, run_id: str, *, mode: str = "cursor") -> ConnectorRun:
         records, skipped = self._records_with_skips()
         revision = {
             "run_id": run_id,
@@ -180,7 +180,7 @@ class CondDBGlobalTagSource:
                 cmssw_targets | conddb_only_release_targets,
             )
 
-        return SourceRun(
+        return ConnectorRun(
             facts=_facts(),
             completed_scope=(
                 mode in {"scope_complete", "reconcile"} and not skipped

--- a/python/archi/sources/cric.py
+++ b/python/archi/sources/cric.py
@@ -120,12 +120,12 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Iterable, Iterator, Literal
 
-from okg.substrate.library.sources.base import (
+from okg.deployment import (
     EdgeFact,
     NodeFact,
-    SourceHealth,
-    SourcePreflightResult,
-    SourceRun,
+    ConnectorHealth,
+    PreflightResult,
+    ConnectorRun,
 )
 
 from archi.auth.cache import (
@@ -204,14 +204,14 @@ class CRICSource:
             self.responsibilities_path,
         )
 
-    def preflight(self, mode: str = "live") -> SourcePreflightResult:
+    def preflight(self, mode: str = "live") -> PreflightResult:
         missing = [
             str(resolve_repo_path(p, base=self.base))
             for p in self.cache_paths
             if not resolve_repo_path(p, base=self.base).is_file()
         ]
         if missing:
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="cache_missing",
                 mode="cache",
@@ -223,7 +223,7 @@ class CRICSource:
         try:
             records = self._records()
         except ValueError as exc:
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="endpoint_failed",
                 mode="cache",
@@ -231,7 +231,7 @@ class CRICSource:
                 reason=str(exc),
                 checked_at=_checked_at(),
             )
-        return SourcePreflightResult(
+        return PreflightResult(
             source_name=self.name,
             status="ok",
             mode="cache",
@@ -242,7 +242,7 @@ class CRICSource:
             checked_at=_checked_at(),
         )
 
-    def run(self, run_id: str, *, mode: str = "cursor") -> SourceRun:
+    def run(self, run_id: str, *, mode: str = "cursor") -> ConnectorRun:
         records = self._records()
         revision = {
             "run_id": run_id,
@@ -256,11 +256,11 @@ class CRICSource:
             for record in records:
                 yield from _edge_facts(record, revision)
 
-        return SourceRun(
+        return ConnectorRun(
             facts=_facts(),
             completed_scope=(mode in {"scope_complete", "reconcile"}),
             run_mode=mode,
-            health=SourceHealth(
+            health=ConnectorHealth(
                 status="ok",
                 mode="cache",
                 record_count=len(records),
@@ -554,14 +554,14 @@ class CRICCoreSource:
             self.federations_path,
         )
 
-    def preflight(self, mode: str = "live") -> SourcePreflightResult:
+    def preflight(self, mode: str = "live") -> PreflightResult:
         missing = [
             str(resolve_repo_path(p, base=self.base))
             for p in self.cache_paths
             if not resolve_repo_path(p, base=self.base).is_file()
         ]
         if missing:
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="cache_missing",
                 mode="cache",
@@ -571,7 +571,7 @@ class CRICCoreSource:
                 checked_at=_checked_at(),
             )
         records = self._records()
-        return SourcePreflightResult(
+        return PreflightResult(
             source_name=self.name,
             status="ok",
             mode="cache",
@@ -582,7 +582,7 @@ class CRICCoreSource:
             checked_at=_checked_at(),
         )
 
-    def run(self, run_id: str, *, mode: str = "cursor") -> SourceRun:
+    def run(self, run_id: str, *, mode: str = "cursor") -> ConnectorRun:
         records = self._records()
         revision = {
             "run_id": run_id,
@@ -596,11 +596,11 @@ class CRICCoreSource:
             for record in records:
                 yield from _core_edge_facts(record, revision)
 
-        return SourceRun(
+        return ConnectorRun(
             facts=_facts(),
             completed_scope=(mode in {"scope_complete", "reconcile"}),
             run_mode=mode,
-            health=SourceHealth(
+            health=ConnectorHealth(
                 status="ok",
                 mode="cache",
                 record_count=len(records),

--- a/python/archi/sources/dbs.py
+++ b/python/archi/sources/dbs.py
@@ -59,11 +59,11 @@ import re
 from dataclasses import dataclass
 from typing import Any, Iterator
 
-from okg.substrate.library.sources.base import (
+from okg.deployment import (
     EdgeFact,
     NodeFact,
-    SourcePreflightResult,
-    SourceRun,
+    PreflightResult,
+    ConnectorRun,
 )
 
 from archi.auth.cache import (
@@ -125,7 +125,7 @@ class DBSDatasetSource:
     def cache_paths(self) -> tuple[str, ...]:
         return (self.records_path,)
 
-    def preflight(self, mode: str = "live") -> SourcePreflightResult:
+    def preflight(self, mode: str = "live") -> PreflightResult:
         try:
             records = self._records()
         except FileNotFoundError:
@@ -139,7 +139,7 @@ class DBSDatasetSource:
             base=self.base,
         )
 
-    def run(self, run_id: str, *, mode: str = "cursor") -> SourceRun:
+    def run(self, run_id: str, *, mode: str = "cursor") -> ConnectorRun:
         records, skipped = self._records_with_skips()
         revision = {
             "run_id": run_id,
@@ -152,7 +152,7 @@ class DBSDatasetSource:
                 yield _node_fact(record, revision)
             yield from _edge_facts(records, revision)
 
-        return SourceRun(
+        return ConnectorRun(
             facts=_facts(),
             completed_scope=(
                 mode in {"scope_complete", "reconcile"} and not skipped

--- a/python/archi/sources/docs.py
+++ b/python/archi/sources/docs.py
@@ -265,12 +265,12 @@ from xml.etree import ElementTree
 
 import requests
 
-from okg.substrate.library.sources.base import (
+from okg.deployment import (
     EdgeFact,
     NodeFact,
-    SourceHealth,
-    SourcePreflightResult,
-    SourceRun,
+    ConnectorHealth,
+    PreflightResult,
+    ConnectorRun,
 )
 
 from archi.auth.cache import (
@@ -368,10 +368,10 @@ class DocumentationSource:
     def cache_paths(self) -> tuple[str, ...]:
         return (self.records_path,)
 
-    def preflight(self, mode: str = "live") -> SourcePreflightResult:
+    def preflight(self, mode: str = "live") -> PreflightResult:
         path = resolve_repo_path(self.records_path, base=self.base)
         if not path.is_file():
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="cache_missing",
                 mode="cache",
@@ -381,7 +381,7 @@ class DocumentationSource:
                 checked_at=_checked_at(),
             )
         records = self._records()
-        return SourcePreflightResult(
+        return PreflightResult(
             source_name=self.name,
             status="ok",
             mode="cache",
@@ -392,14 +392,14 @@ class DocumentationSource:
             checked_at=_checked_at(),
         )
 
-    def run(self, run_id: str, *, mode: str = "cursor") -> SourceRun:
+    def run(self, run_id: str, *, mode: str = "cursor") -> ConnectorRun:
         path = resolve_repo_path(self.records_path, base=self.base)
         if not path.is_file():
-            return SourceRun(
+            return ConnectorRun(
                 facts=(),
                 completed_scope=False,
                 run_mode=mode,
-                health=SourceHealth(
+                health=ConnectorHealth(
                     status="cache_missing",
                     mode="cache",
                     cache_path=str(path),
@@ -427,11 +427,11 @@ class DocumentationSource:
                 chunker_name=self.chunker_name,
             )
 
-        return SourceRun(
+        return ConnectorRun(
             facts=_facts(),
             completed_scope=(mode in {"scope_complete", "reconcile"}),
             run_mode=mode,
-            health=SourceHealth(
+            health=ConnectorHealth(
                 status="ok",
                 mode="cache",
                 record_count=len(records),
@@ -528,10 +528,10 @@ class SSOCookieDocsSource(DocumentationSource):
     def cache_paths(self) -> tuple[str, ...]:
         return ()
 
-    def preflight(self, mode: str = "live") -> SourcePreflightResult:
+    def preflight(self, mode: str = "live") -> PreflightResult:
         cookie_file = os.environ.get(self.cookie_file_env, "")
         if not cookie_file or not Path(cookie_file).is_file():
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="missing_credential",
                 mode="live",
@@ -549,7 +549,7 @@ class SSOCookieDocsSource(DocumentationSource):
             else None
         )
         status = check_cookie_file(cookie_file, max_age=max_age)
-        return SourcePreflightResult(
+        return PreflightResult(
             source_name=self.name,
             status="ok" if status.fresh else "auth_failed",
             mode="live",
@@ -560,18 +560,18 @@ class SSOCookieDocsSource(DocumentationSource):
             checked_at=_checked_at(),
         )
 
-    def run(self, run_id: str, *, mode: str = "cursor") -> SourceRun:
+    def run(self, run_id: str, *, mode: str = "cursor") -> ConnectorRun:
         session = self._cookie_session()
         if session is None:
             # A missing/unreadable cookie is an auth failure, not an
             # empty-but-complete crawl: with completed_scope=True the
             # registry's missing_from_completed_scope semantics would
             # retract every previously ingested page.
-            return SourceRun(
+            return ConnectorRun(
                 facts=(),
                 completed_scope=False,
                 run_mode=mode,
-                health=SourceHealth(
+                health=ConnectorHealth(
                     status="auth_failed",
                     mode="live",
                     credential_refs=(self.cookie_file_env,),
@@ -623,11 +623,11 @@ class SSOCookieDocsSource(DocumentationSource):
             # (missing_from_completed_scope would retract the failed
             # pages' records); emit what succeeded and report the rest.
             samples = ", ".join(crawl.failed_urls[:3])
-            return SourceRun(
+            return ConnectorRun(
                 facts=_facts(),
                 completed_scope=False,
                 run_mode=mode,
-                health=SourceHealth(
+                health=ConnectorHealth(
                     status="endpoint_failed",
                     mode="live",
                     credential_refs=(self.cookie_file_env,),
@@ -647,11 +647,11 @@ class SSOCookieDocsSource(DocumentationSource):
             # un-crawled pages would be retracted under
             # missing_from_completed_scope if this run claimed a
             # complete scope. Emit what was crawled and claim nothing.
-            return SourceRun(
+            return ConnectorRun(
                 facts=_facts(),
                 completed_scope=False,
                 run_mode=mode,
-                health=SourceHealth(
+                health=ConnectorHealth(
                     status="ok",
                     mode="live",
                     credential_refs=(self.cookie_file_env,),
@@ -664,11 +664,11 @@ class SSOCookieDocsSource(DocumentationSource):
                     ),
                 ),
             )
-        return SourceRun(
+        return ConnectorRun(
             facts=_facts(),
             completed_scope=(mode in {"scope_complete", "reconcile"}),
             run_mode=mode,
-            health=SourceHealth(
+            health=ConnectorHealth(
                 status="ok",
                 mode="live",
                 credential_refs=(self.cookie_file_env,),

--- a/python/archi/sources/dqm.py
+++ b/python/archi/sources/dqm.py
@@ -60,12 +60,12 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Iterator
 
-from okg.substrate.library.sources.base import (
+from okg.deployment import (
     EdgeFact,
     NodeFact,
-    SourceHealth,
-    SourcePreflightResult,
-    SourceRun,
+    ConnectorHealth,
+    PreflightResult,
+    ConnectorRun,
 )
 
 from archi.auth.cache import (
@@ -126,10 +126,10 @@ class DQMSource:
     def cache_paths(self) -> tuple[str, ...]:
         return (self.records_path,)
 
-    def preflight(self, mode: str = "live") -> SourcePreflightResult:
+    def preflight(self, mode: str = "live") -> PreflightResult:
         path = resolve_repo_path(self.records_path, base=self.base)
         if not path.is_file():
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="cache_missing",
                 mode="cache",
@@ -139,7 +139,7 @@ class DQMSource:
                 checked_at=_checked_at(),
             )
         records = self._records()
-        return SourcePreflightResult(
+        return PreflightResult(
             source_name=self.name,
             status="ok",
             mode="cache",
@@ -150,7 +150,7 @@ class DQMSource:
             checked_at=_checked_at(),
         )
 
-    def run(self, run_id: str, *, mode: str = "cursor") -> SourceRun:
+    def run(self, run_id: str, *, mode: str = "cursor") -> ConnectorRun:
         records, skipped = self._records_with_skips()
         revision = {
             "run_id": run_id,
@@ -167,13 +167,13 @@ class DQMSource:
             record_count=len(records),
             skipped_count=skipped,
         )
-        return SourceRun(
+        return ConnectorRun(
             facts=_facts(),
             completed_scope=(
                 mode in {"scope_complete", "reconcile"} and not skipped
             ),
             run_mode=mode,
-            health=SourceHealth(
+            health=ConnectorHealth(
                 status=status,
                 mode="cache",
                 record_count=len(records),

--- a/python/archi/sources/github_repos.py
+++ b/python/archi/sources/github_repos.py
@@ -59,14 +59,14 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Iterator
 
-from okg.substrate.library.sources.base import (
+from okg.deployment import (
     EdgeFact,
     NodeFact,
-    SourceHealth,
-    SourcePreflightResult,
-    SourceRun,
+    ConnectorHealth,
+    PreflightResult,
+    ConnectorRun,
 )
-from okg.substrate.library.sources.content_hash_probe import ContentHashProbe
+from okg.deployment import ContentHashProbe
 
 DEFAULT_REPOS = (
     "dmwm/WMCore",
@@ -130,9 +130,9 @@ class GitHubRepoSource:
             emit_targets=GitHubRepoSource,
         )
 
-    def preflight(self, mode: str = "live") -> SourcePreflightResult:
+    def preflight(self, mode: str = "live") -> PreflightResult:
         records = self._records()
-        return SourcePreflightResult(
+        return PreflightResult(
             source_name=self.name,
             status="ok",
             mode="registry_seed",
@@ -146,7 +146,7 @@ class GitHubRepoSource:
             checked_at=_checked_at(),
         )
 
-    def run(self, run_id: str, *, mode: str = "cursor") -> SourceRun:
+    def run(self, run_id: str, *, mode: str = "cursor") -> ConnectorRun:
         records = self._records()
         revision = {
             "run_id": run_id,
@@ -166,11 +166,11 @@ class GitHubRepoSource:
                     source_revision=revision,
                 )
 
-        return SourceRun(
+        return ConnectorRun(
             facts=_facts(),
             completed_scope=(mode in {"scope_complete", "reconcile"}),
             run_mode=mode,
-            health=SourceHealth(
+            health=ConnectorHealth(
                 status="ok",
                 mode="registry_seed",
                 record_count=len(records),

--- a/python/archi/sources/gocdb.py
+++ b/python/archi/sources/gocdb.py
@@ -66,12 +66,12 @@ from datetime import datetime, timezone
 from typing import Any, Iterator
 from urllib.parse import urlparse
 
-from okg.substrate.library.sources.base import (
+from okg.deployment import (
     EdgeFact,
     NodeFact,
-    SourceHealth,
-    SourcePreflightResult,
-    SourceRun,
+    ConnectorHealth,
+    PreflightResult,
+    ConnectorRun,
 )
 
 from archi.auth.cache import (
@@ -136,10 +136,10 @@ class GoCDBDowntimeSource:
     def cache_paths(self) -> tuple[str, ...]:
         return (self.records_path, self.sites_path, self.services_path)
 
-    def preflight(self, mode: str = "live") -> SourcePreflightResult:
+    def preflight(self, mode: str = "live") -> PreflightResult:
         path = resolve_repo_path(self.records_path, base=self.base)
         if not path.is_file():
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="cache_missing",
                 mode="cache",
@@ -149,7 +149,7 @@ class GoCDBDowntimeSource:
                 checked_at=_checked_at(),
             )
         records = self._records()
-        return SourcePreflightResult(
+        return PreflightResult(
             source_name=self.name,
             status="ok",
             mode="cache",
@@ -160,7 +160,7 @@ class GoCDBDowntimeSource:
             checked_at=_checked_at(),
         )
 
-    def run(self, run_id: str, *, mode: str = "cursor") -> SourceRun:
+    def run(self, run_id: str, *, mode: str = "cursor") -> ConnectorRun:
         records, skipped = self._records_with_skips()
         known_sites = _known_sites(self.sites_path, base=self.base)
         service_lookup = _service_lookup(self.services_path, base=self.base)
@@ -186,13 +186,13 @@ class GoCDBDowntimeSource:
             record_count=len(records),
             skipped_count=skipped,
         )
-        return SourceRun(
+        return ConnectorRun(
             facts=_facts(),
             completed_scope=(
                 mode in {"scope_complete", "reconcile"} and not skipped
             ),
             run_mode=mode,
-            health=SourceHealth(
+            health=ConnectorHealth(
                 status=status,
                 mode="cache",
                 record_count=len(records),

--- a/python/archi/sources/hypernews.py
+++ b/python/archi/sources/hypernews.py
@@ -97,15 +97,15 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterator
 
-from okg.substrate.library.sources.base import (
+from okg.deployment import (
     EdgeFact,
     NodeFact,
-    SourceHealth,
-    SourcePreflightResult,
-    SourceRun,
+    ConnectorHealth,
+    PreflightResult,
+    ConnectorRun,
 )
-from okg.substrate.library.sources.mutable_api_probe import MutableApiProbe
-from okg.substrate.sources.preflight import file_ref_preflight
+from okg.deployment import MutableApiProbe
+from okg.deployment import file_preflight
 
 from archi.auth.cache import load_json, resolve_repo_path
 from archi.auth.cookies import looks_like_login_page
@@ -265,9 +265,9 @@ class HyperNewsSource:
             if item is not None
         ]
 
-    def preflight(self, mode: str = "live") -> SourcePreflightResult:
+    def preflight(self, mode: str = "live") -> PreflightResult:
         if self._records is not None:
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="ok",
                 mode="fixture",
@@ -281,7 +281,7 @@ class HyperNewsSource:
             try:
                 records, _skipped = self._records_from_cache()
             except ValueError as exc:
-                return SourcePreflightResult(
+                return PreflightResult(
                     source_name=self.name,
                     status="endpoint_failed",
                     mode="cache",
@@ -293,7 +293,7 @@ class HyperNewsSource:
             if not records:
                 # Match run()'s refusal: an empty cache must not look
                 # healthy in preflight while run() rejects it.
-                return SourcePreflightResult(
+                return PreflightResult(
                     source_name=self.name,
                     status="endpoint_failed",
                     mode="cache",
@@ -303,7 +303,7 @@ class HyperNewsSource:
                     reason=self._empty_cache_reason(),
                     checked_at=_checked_at(),
                 )
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="ok",
                 mode="cache",
@@ -314,7 +314,7 @@ class HyperNewsSource:
                 reason="local HyperNews records cache present",
                 checked_at=_checked_at(),
             )
-        file_result = file_ref_preflight(
+        file_result = file_preflight(
             self.name,
             self.cookie_file_env,
             required=self.required,
@@ -326,8 +326,8 @@ class HyperNewsSource:
 
     def _endpoint_probe(
         self,
-        file_result: SourcePreflightResult,
-    ) -> SourcePreflightResult:
+        file_result: PreflightResult,
+    ) -> PreflightResult:
         import http.cookiejar
         import requests
 
@@ -338,7 +338,7 @@ class HyperNewsSource:
             session = requests.Session()
             session.cookies = jar
         except Exception as exc:  # noqa: BLE001
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="endpoint_failed",
                 mode="live",
@@ -357,7 +357,7 @@ class HyperNewsSource:
                 failures.append(f"{forum}: {type(exc).__name__}")
                 continue
             if looks_like_login_page(resp.text) or "auth.cern.ch" in resp.url:
-                return SourcePreflightResult(
+                return PreflightResult(
                     source_name=self.name,
                     status="auth_failed",
                     mode="live",
@@ -370,7 +370,7 @@ class HyperNewsSource:
             if resp.status_code >= 400:
                 failures.append(f"{forum}: HTTP {resp.status_code}")
                 continue
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="ok",
                 mode="live",
@@ -380,7 +380,7 @@ class HyperNewsSource:
                 reason="HyperNews forum listing reachable",
                 checked_at=_checked_at(),
             )
-        return SourcePreflightResult(
+        return PreflightResult(
             source_name=self.name,
             status="endpoint_failed",
             mode="live",
@@ -394,14 +394,14 @@ class HyperNewsSource:
             checked_at=_checked_at(),
         )
 
-    def run(self, run_id: str, *, mode: str = "cursor") -> SourceRun:
+    def run(self, run_id: str, *, mode: str = "cursor") -> ConnectorRun:
         preflight = self.preflight(mode="live")
         if preflight.status != "ok":
-            return SourceRun(
+            return ConnectorRun(
                 facts=[],
                 completed_scope=False,
                 run_mode=mode,
-                health=SourceHealth(
+                health=ConnectorHealth(
                     status=preflight.status,
                     mode=preflight.mode,
                     reason=preflight.reason,
@@ -426,11 +426,11 @@ class HyperNewsSource:
                     # forever); refuse instead of retracting everything.
                     # (Preflight reports the same refusal, so this is
                     # normally caught before reaching here.)
-                    return SourceRun(
+                    return ConnectorRun(
                         facts=[],
                         completed_scope=False,
                         run_mode=mode,
-                        health=SourceHealth(
+                        health=ConnectorHealth(
                             status="endpoint_failed",
                             mode="cache",
                             record_count=0,
@@ -449,11 +449,11 @@ class HyperNewsSource:
                 credential_refs = (self.cookie_file_env,)
                 outcome = self._fetch()
                 if not outcome.records:
-                    return SourceRun(
+                    return ConnectorRun(
                         facts=[],
                         completed_scope=False,
                         run_mode=mode,
-                        health=SourceHealth(
+                        health=ConnectorHealth(
                             status="endpoint_failed",
                             mode="live",
                             credential_refs=credential_refs,
@@ -561,13 +561,13 @@ class HyperNewsSource:
                         targets,
                     )
 
-        return SourceRun(
+        return ConnectorRun(
             facts=_facts(),
             completed_scope=(
                 mode in {"scope_complete", "reconcile"} and allow_scope
             ),
             run_mode=mode,
-            health=SourceHealth(
+            health=ConnectorHealth(
                 status=run_status,
                 mode=run_health_mode,
                 credential_refs=credential_refs,

--- a/python/archi/sources/indico.py
+++ b/python/archi/sources/indico.py
@@ -77,12 +77,12 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Iterator
 
-from okg.substrate.library.sources.base import (
+from okg.deployment import (
     EdgeFact,
     NodeFact,
-    SourceHealth,
-    SourcePreflightResult,
-    SourceRun,
+    ConnectorHealth,
+    PreflightResult,
+    ConnectorRun,
 )
 
 from archi.auth.cache import (
@@ -167,10 +167,10 @@ class IndicoSource:
     def cache_paths(self) -> tuple[str, ...]:
         return (self.records_path,)
 
-    def preflight(self, mode: str = "live") -> SourcePreflightResult:
+    def preflight(self, mode: str = "live") -> PreflightResult:
         path = resolve_repo_path(self.records_path, base=self.base)
         if not path.is_file():
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="cache_missing",
                 mode="cache",
@@ -180,7 +180,7 @@ class IndicoSource:
                 checked_at=_checked_at(),
             )
         records = self._records()
-        return SourcePreflightResult(
+        return PreflightResult(
             source_name=self.name,
             status="ok",
             mode="cache",
@@ -191,7 +191,7 @@ class IndicoSource:
             checked_at=_checked_at(),
         )
 
-    def run(self, run_id: str, *, mode: str = "cursor") -> SourceRun:
+    def run(self, run_id: str, *, mode: str = "cursor") -> ConnectorRun:
         records, skipped = self._records_with_skips()
         revision = {
             "run_id": run_id,
@@ -212,13 +212,13 @@ class IndicoSource:
             record_count=len(records),
             skipped_count=skipped,
         )
-        return SourceRun(
+        return ConnectorRun(
             facts=_facts(),
             completed_scope=(
                 mode in {"scope_complete", "reconcile"} and not skipped
             ),
             run_mode=mode,
-            health=SourceHealth(
+            health=ConnectorHealth(
                 status=status,
                 mode="cache",
                 record_count=len(records),

--- a/python/archi/sources/jira.py
+++ b/python/archi/sources/jira.py
@@ -170,12 +170,12 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Iterator, Sequence
 
-from okg.substrate.library.sources.base import (
+from okg.deployment import (
     EdgeFact,
     NodeFact,
-    SourceHealth,
-    SourcePreflightResult,
-    SourceRun,
+    ConnectorHealth,
+    PreflightResult,
+    ConnectorRun,
 )
 
 from archi.auth.cache import (
@@ -369,14 +369,14 @@ class JiraIssueSource:
             return {}
         return {self.credential_ref: self.credential_aliases}
 
-    def preflight(self, mode: str = "live") -> SourcePreflightResult:
+    def preflight(self, mode: str = "live") -> PreflightResult:
         path = resolve_repo_path(self.records_path, base=self.base)
         if not path.is_file():
             expected = _expected_count(self.meta_path, base=self.base)
             reason = "JIRA records cache file is missing"
             if expected is not None:
                 reason += f"; metadata reports {expected} records"
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="cache_missing",
                 mode="cache",
@@ -388,7 +388,7 @@ class JiraIssueSource:
                 checked_at=_checked_at(),
             )
         records = self._records()
-        return SourcePreflightResult(
+        return PreflightResult(
             source_name=self.name,
             status="ok",
             mode="cache",
@@ -401,14 +401,14 @@ class JiraIssueSource:
             checked_at=_checked_at(),
         )
 
-    def run(self, run_id: str, *, mode: str = "cursor") -> SourceRun:
+    def run(self, run_id: str, *, mode: str = "cursor") -> ConnectorRun:
         path = resolve_repo_path(self.records_path, base=self.base)
         if not path.is_file():
-            return SourceRun(
+            return ConnectorRun(
                 facts=(),
                 completed_scope=False,
                 run_mode=mode,
-                health=SourceHealth(
+                health=ConnectorHealth(
                     status="cache_missing",
                     mode="cache",
                     credential_refs=self._credential_refs,
@@ -508,11 +508,11 @@ class JiraIssueSource:
             # complete would retract every record it dropped. The
             # closed status vocabulary has no 'degraded', so report
             # endpoint_failed.
-            return SourceRun(
+            return ConnectorRun(
                 facts=_facts(),
                 completed_scope=False,
                 run_mode=mode,
-                health=SourceHealth(
+                health=ConnectorHealth(
                     status="endpoint_failed",
                     mode="cache",
                     credential_refs=self._credential_refs,
@@ -528,11 +528,11 @@ class JiraIssueSource:
                     checked_at=_checked_at(),
                 ),
             )
-        return SourceRun(
+        return ConnectorRun(
             facts=_facts(),
             completed_scope=(mode in {"scope_complete", "reconcile"}),
             run_mode=mode,
-            health=SourceHealth(
+            health=ConnectorHealth(
                 status="ok",
                 mode="cache",
                 credential_refs=self._credential_refs,

--- a/python/archi/sources/monit.py
+++ b/python/archi/sources/monit.py
@@ -41,11 +41,11 @@ see ``pact/changes/circleback-fixes/notes-live.md``):
   ingested record under ``missing_from_completed_scope``.
 - Any cache-read or live-query failure is ``endpoint_failed`` health
   with ``completed_scope=False``.
-- ``SourceHealth.status`` values come only from okg's closed
+- ``ConnectorHealth.status`` values come only from okg's closed
   ``PREFLIGHT_STATUSES`` vocabulary (``ok`` / ``skipped_optional`` /
   ``missing_credential`` / ``auth_failed`` / ``tls_failed`` /
   ``endpoint_failed`` / ``cache_missing`` / ``not_applicable`` / ...);
-  ``SourceHealth.__post_init__`` rejects anything else.
+  ``ConnectorHealth.__post_init__`` rejects anything else.
 - A *partial* OpenSearch response — ``timed_out: true``, failed shards,
   or a bucket-limited terms aggregation that dropped buckets
   (``sum_other_doc_count`` / ``doc_count_error_upper_bound`` > 0) —
@@ -307,13 +307,13 @@ from typing import Any, Callable, Iterable, Iterator
 
 import requests
 
-from okg.substrate.library.sources.base import (
+from okg.deployment import (
     EdgeFact,
     NodeFact,
     ProgressMarker,
-    SourceHealth,
-    SourcePreflightResult,
-    SourceRun,
+    ConnectorHealth,
+    PreflightResult,
+    ConnectorRun,
 )
 
 from archi.auth.cache import (
@@ -575,7 +575,7 @@ class MONITSAMSource:
     def cache_paths(self) -> tuple[str, ...]:
         return (self.records_path,)
 
-    def preflight(self, mode: str = "live") -> SourcePreflightResult:
+    def preflight(self, mode: str = "live") -> PreflightResult:
         return _monit_preflight(
             source_name=self.name,
             records_path=self.records_path,
@@ -593,7 +593,7 @@ class MONITSAMSource:
         mode: str = "cursor",
         cursor: Any = None,
         **_: Any,
-    ) -> SourceRun:
+    ) -> ConnectorRun:
         try:
             records, run_mode, revision, quality = self._load_records(run_id)
         except MissingMONITCredential as exc:
@@ -722,7 +722,7 @@ class MONITCondorSource:
     def cache_paths(self) -> tuple[str, ...]:
         return (self.records_path,)
 
-    def preflight(self, mode: str = "live") -> SourcePreflightResult:
+    def preflight(self, mode: str = "live") -> PreflightResult:
         return _monit_preflight(
             source_name=self.name,
             records_path=self.records_path,
@@ -740,7 +740,7 @@ class MONITCondorSource:
         mode: str = "cursor",
         cursor: Any = None,
         **_: Any,
-    ) -> SourceRun:
+    ) -> ConnectorRun:
         try:
             records, run_mode, revision, quality = self._load_records(run_id)
         except MissingMONITCredential as exc:
@@ -870,7 +870,7 @@ class MONITRucioTransferSource:
     def cache_paths(self) -> tuple[str, ...]:
         return (self.records_path,)
 
-    def preflight(self, mode: str = "live") -> SourcePreflightResult:
+    def preflight(self, mode: str = "live") -> PreflightResult:
         return _monit_preflight(
             source_name=self.name,
             records_path=self.records_path,
@@ -888,7 +888,7 @@ class MONITRucioTransferSource:
         mode: str = "cursor",
         cursor: Any = None,
         **_: Any,
-    ) -> SourceRun:
+    ) -> ConnectorRun:
         try:
             records, run_mode, revision, quality = self._load_records(run_id)
         except MissingMONITCredential as exc:
@@ -1039,7 +1039,7 @@ class MONITRucioDatasetSource:
     def cache_paths(self) -> tuple[str, ...]:
         return (self.records_path,)
 
-    def preflight(self, mode: str = "live") -> SourcePreflightResult:
+    def preflight(self, mode: str = "live") -> PreflightResult:
         return _monit_preflight(
             source_name=self.name,
             records_path=self.records_path,
@@ -1058,7 +1058,7 @@ class MONITRucioDatasetSource:
         cursor: Any = None,
         since_progress: dict[str, str] | None = None,
         **_: Any,
-    ) -> SourceRun:
+    ) -> ConnectorRun:
         path = resolve_repo_path(self.records_path, base=self.base)
         if not path.is_file():
             token = os.environ.get(self.token_env)
@@ -1098,11 +1098,11 @@ class MONITRucioDatasetSource:
                 .get("datasets", {})
             )
             if not first_datasets.get("buckets"):
-                return SourceRun(
+                return ConnectorRun(
                     facts=[],
                     completed_scope=False,
                     run_mode=mode,
-                    health=SourceHealth(
+                    health=ConnectorHealth(
                         status="skipped_optional",
                         mode="live",
                         credential_refs=(self.token_env,),
@@ -1127,11 +1127,11 @@ class MONITRucioDatasetSource:
                     first_page=first_page,
                 )
 
-            return SourceRun(
+            return ConnectorRun(
                 facts=_live(),
                 completed_scope=(mode in {"scope_complete", "reconcile"}),
                 run_mode=mode,
-                health=SourceHealth(
+                health=ConnectorHealth(
                     status="ok",
                     mode="live",
                     credential_refs=(self.token_env,),
@@ -1421,11 +1421,11 @@ def _monit_preflight(
     cache_loader: Callable[[], tuple[list[Any], _ResponseQuality]],
     cache_reason: str,
     base: str | None = None,
-) -> SourcePreflightResult:
+) -> PreflightResult:
     path = resolve_repo_path(records_path, base=base)
     if path.is_file():
         records, _ = cache_loader()
-        return SourcePreflightResult(
+        return PreflightResult(
             source_name=source_name,
             status="ok",
             mode="cache",
@@ -1437,7 +1437,7 @@ def _monit_preflight(
             checked_at=_checked_at(),
         )
     if os.environ.get(token_env):
-        return SourcePreflightResult(
+        return PreflightResult(
             source_name=source_name,
             status="ok",
             mode="live",
@@ -1447,7 +1447,7 @@ def _monit_preflight(
             reason="MONIT Grafana token present",
             checked_at=_checked_at(),
         )
-    return SourcePreflightResult(
+    return PreflightResult(
         source_name=source_name,
         status="missing_credential",
         mode="live",
@@ -1482,15 +1482,15 @@ def _missing_credential_run(
     mode: str,
     token_env: str,
     reason: str,
-) -> SourceRun:
+) -> ConnectorRun:
     # A missing configured credential must never claim completed_scope:
     # under missing_from_completed_scope semantics an empty-but-complete
     # run would retract every previously ingested record.
-    return SourceRun(
+    return ConnectorRun(
         facts=[],
         completed_scope=False,
         run_mode=mode,
-        health=SourceHealth(
+        health=ConnectorHealth(
             status="missing_credential",
             mode="live",
             credential_refs=(token_env,),
@@ -1506,13 +1506,13 @@ def _endpoint_failed_run(
     exc: Exception,
     *,
     endpoint: str,
-) -> SourceRun:
+) -> ConnectorRun:
     # Same discipline for failed reads: emit nothing and claim nothing.
-    return SourceRun(
+    return ConnectorRun(
         facts=[],
         completed_scope=False,
         run_mode=mode,
-        health=SourceHealth(
+        health=ConnectorHealth(
             status="endpoint_failed",
             mode="live",
             credential_refs=(token_env,),
@@ -1535,7 +1535,7 @@ def _source_run(
     ok_reason: str,
     empty_reason: str,
     quality: _ResponseQuality | None = None,
-) -> SourceRun:
+) -> ConnectorRun:
     partial = quality is not None and not quality.complete
     if partial:
         # HTTP 200 but the response itself is partial (timed out, shard
@@ -1562,11 +1562,11 @@ def _source_run(
         status = "ok"
         reason = ok_reason
         completed = mode in {"scope_complete", "reconcile"}
-    return SourceRun(
+    return ConnectorRun(
         facts=facts,
         completed_scope=completed,
         run_mode=mode,
-        health=SourceHealth(
+        health=ConnectorHealth(
             status=status,
             mode=run_mode,
             credential_refs=((token_env,) if run_mode == "live" else ()),

--- a/python/archi/sources/siteconf.py
+++ b/python/archi/sources/siteconf.py
@@ -76,15 +76,15 @@ from datetime import datetime, timezone
 from typing import Any, Iterator
 from urllib.parse import quote_plus
 
-from okg.substrate.library.sources.base import (
+from okg.deployment import (
     EdgeFact,
     NodeFact,
-    SourceHealth,
-    SourcePreflightResult,
-    SourceRun,
+    ConnectorHealth,
+    PreflightResult,
+    ConnectorRun,
 )
-from okg.substrate.library.sources.mutable_api_probe import MutableApiProbe
-from okg.substrate.sources.preflight import credential_env_preflight
+from okg.deployment import MutableApiProbe
+from okg.deployment import credential_preflight
 
 from archi.auth.cache import load_json
 
@@ -160,9 +160,9 @@ class SITECONFSource:
         )
         return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
-    def preflight(self, mode: str = "live") -> SourcePreflightResult:
+    def preflight(self, mode: str = "live") -> PreflightResult:
         if self._records is not None:
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="ok",
                 mode="fixture",
@@ -171,7 +171,7 @@ class SITECONFSource:
                 reason="in-memory SITECONF records supplied",
                 checked_at=_checked_at(),
             )
-        env_result = credential_env_preflight(
+        env_result = credential_preflight(
             self.name,
             self.token_env,
             aliases=self.aliases,
@@ -184,8 +184,8 @@ class SITECONFSource:
 
     def _token_probe(
         self,
-        env_result: SourcePreflightResult,
-    ) -> SourcePreflightResult:
+        env_result: PreflightResult,
+    ) -> PreflightResult:
         import requests
 
         token = _env_value(self.token_env, self.aliases)
@@ -196,7 +196,7 @@ class SITECONFSource:
                 timeout=20,
             )
         except Exception as exc:  # noqa: BLE001
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="endpoint_failed",
                 mode="live",
@@ -208,7 +208,7 @@ class SITECONFSource:
                 checked_at=_checked_at(),
             )
         if resp.status_code in {401, 403}:
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="auth_failed",
                 mode="live",
@@ -220,7 +220,7 @@ class SITECONFSource:
                 checked_at=_checked_at(),
             )
         if resp.status_code >= 400:
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="endpoint_failed",
                 mode="live",
@@ -237,8 +237,8 @@ class SITECONFSource:
 
     def _group_probe(
         self,
-        env_result: SourcePreflightResult,
-    ) -> SourcePreflightResult:
+        env_result: PreflightResult,
+    ) -> PreflightResult:
         """Probe group visibility, not just token validity.
 
         ``/api/v4/user`` accepts any live token; a token without group
@@ -261,7 +261,7 @@ class SITECONFSource:
                 timeout=20,
             )
         except Exception as exc:  # noqa: BLE001
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="endpoint_failed",
                 mode="live",
@@ -273,7 +273,7 @@ class SITECONFSource:
                 checked_at=_checked_at(),
             )
         if resp.status_code in {401, 403}:
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="auth_failed",
                 mode="live",
@@ -297,7 +297,7 @@ class SITECONFSource:
             or not isinstance(payload, list)
             or not payload
         ):
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="endpoint_failed",
                 mode="live",
@@ -312,7 +312,7 @@ class SITECONFSource:
                 ),
                 checked_at=_checked_at(),
             )
-        return SourcePreflightResult(
+        return PreflightResult(
             source_name=self.name,
             status="ok",
             mode="live",
@@ -324,14 +324,14 @@ class SITECONFSource:
             checked_at=_checked_at(),
         )
 
-    def run(self, run_id: str, *, mode: str = "cursor") -> SourceRun:
+    def run(self, run_id: str, *, mode: str = "cursor") -> ConnectorRun:
         preflight = self.preflight(mode="live")
         if preflight.status != "ok":
-            return SourceRun(
+            return ConnectorRun(
                 facts=[],
                 completed_scope=False,
                 run_mode=mode,
-                health=SourceHealth(
+                health=ConnectorHealth(
                     status=preflight.status,
                     mode=preflight.mode,
                     reason=preflight.reason,
@@ -349,11 +349,11 @@ class SITECONFSource:
                 # visibility) or a crawl that parsed zero site configs
                 # must never become a healthy completed scope over zero
                 # records — that would retract every site_config.
-                return SourceRun(
+                return ConnectorRun(
                     facts=[],
                     completed_scope=False,
                     run_mode=mode,
-                    health=SourceHealth(
+                    health=ConnectorHealth(
                         status="endpoint_failed",
                         mode="live",
                         credential_refs=(self.token_env,),
@@ -404,13 +404,13 @@ class SITECONFSource:
                 f"; max_projects={self.max_projects} truncated the "
                 "project list; no complete scope claimed"
             )
-        return SourceRun(
+        return ConnectorRun(
             facts=_facts(),
             completed_scope=(
                 mode in {"scope_complete", "reconcile"} and not truncated
             ),
             run_mode=mode,
-            health=SourceHealth(
+            health=ConnectorHealth(
                 status="ok",
                 mode="live" if self._records is None else "fixture",
                 credential_refs=(

--- a/python/archi/sources/twiki.py
+++ b/python/archi/sources/twiki.py
@@ -218,15 +218,15 @@ from urllib.parse import urlparse
 
 import requests
 
-from okg.substrate.library.sources.base import (
+from okg.deployment import (
     EdgeFact,
     NodeFact,
-    SourceHealth,
-    SourcePreflightResult,
-    SourceRun,
+    ConnectorHealth,
+    PreflightResult,
+    ConnectorRun,
 )
-from okg.substrate.library.sources.content_hash_probe import ContentHashProbe
-from okg.substrate.sources.preflight import file_ref_preflight
+from okg.deployment import ContentHashProbe
+from okg.deployment import file_preflight
 
 from archi.auth.cache import (
     cache_or_forced_live_change_probe,
@@ -423,9 +423,9 @@ class TwikiEOSSource:
                 out.append((f"aux:{raw}", path))
         return out
 
-    def preflight(self, mode: str = "live") -> SourcePreflightResult:
+    def preflight(self, mode: str = "live") -> PreflightResult:
         if self._records is not None:
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="ok",
                 mode="fixture",
@@ -460,7 +460,7 @@ class TwikiEOSSource:
                         f" ({len(walk.missing_seeds)} seeds missing from "
                         "the snapshot)"
                     )
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="ok",
                 mode="filesystem",
@@ -472,14 +472,14 @@ class TwikiEOSSource:
                 reason=reason,
                 checked_at=_checked_at(),
             )
-        return file_ref_preflight(
+        return file_preflight(
             self.name,
             self.eos_root_env,
             required=self.required,
             mode=mode,
         )
 
-    def run(self, run_id: str, *, mode: str = "cursor") -> SourceRun:
+    def run(self, run_id: str, *, mode: str = "cursor") -> ConnectorRun:
         missing_seeds: tuple[str, ...] = ()
         if self._records is not None:
             records = self._records
@@ -489,17 +489,17 @@ class TwikiEOSSource:
             # itself — one listing per run, not two.
             root = Path(self.eos_root).expanduser() if self.eos_root else None
             if root is None or not root.is_dir():
-                preflight = file_ref_preflight(
+                preflight = file_preflight(
                     self.name,
                     self.eos_root_env,
                     required=self.required,
                     mode="live",
                 )
-                return SourceRun(
+                return ConnectorRun(
                     facts=[],
                     completed_scope=False,
                     run_mode=mode,
-                    health=SourceHealth(
+                    health=ConnectorHealth(
                         status=preflight.status,
                         mode=preflight.mode,
                         reason=preflight.reason,
@@ -541,11 +541,11 @@ class TwikiEOSSource:
             total = len(self.seed_topics or ())
             samples = ", ".join(missing_seeds[:3])
             all_missing = len(missing_seeds) == total
-            return SourceRun(
+            return ConnectorRun(
                 facts=_facts(),
                 completed_scope=False,
                 run_mode=mode,
-                health=SourceHealth(
+                health=ConnectorHealth(
                     status="cache_missing" if all_missing else "endpoint_failed",
                     mode="filesystem",
                     credential_refs=(self.eos_root_env,),
@@ -558,11 +558,11 @@ class TwikiEOSSource:
                     ),
                 ),
             )
-        return SourceRun(
+        return ConnectorRun(
             facts=_facts(),
             completed_scope=(mode in {"scope_complete", "reconcile"}),
             run_mode=mode,
-            health=SourceHealth(
+            health=ConnectorHealth(
                 status="ok",
                 mode="filesystem" if self._records is None else "fixture",
                 credential_refs=(
@@ -783,9 +783,9 @@ class TwikiCrawlSource:
     def _credential_refs(self) -> tuple[str, ...]:
         return (self.cookie_file_env,) if self.cookie_file_env else ()
 
-    def preflight(self, mode: str = "live") -> SourcePreflightResult:
+    def preflight(self, mode: str = "live") -> PreflightResult:
         if not self.cookie_file_env:
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="ok",
                 mode="live",
@@ -799,7 +799,7 @@ class TwikiCrawlSource:
             )
         cookie_file = os.environ.get(self.cookie_file_env, "")
         if not cookie_file or not Path(cookie_file).is_file():
-            return SourcePreflightResult(
+            return PreflightResult(
                 source_name=self.name,
                 status="missing_credential",
                 mode="live",
@@ -817,7 +817,7 @@ class TwikiCrawlSource:
             else None
         )
         status = check_cookie_file(cookie_file, max_age=max_age)
-        return SourcePreflightResult(
+        return PreflightResult(
             source_name=self.name,
             status="ok" if status.fresh else "auth_failed",
             mode="live",
@@ -828,18 +828,18 @@ class TwikiCrawlSource:
             checked_at=_checked_at(),
         )
 
-    def run(self, run_id: str, *, mode: str = "cursor") -> SourceRun:
+    def run(self, run_id: str, *, mode: str = "cursor") -> ConnectorRun:
         session = self._session()
         if session is None:
             # A missing/unparseable cookie is an auth failure, not an
             # empty-but-complete crawl: with completed_scope=True the
             # registry's missing_from_completed_scope semantics would
             # retract every previously ingested topic.
-            return SourceRun(
+            return ConnectorRun(
                 facts=(),
                 completed_scope=False,
                 run_mode=mode,
-                health=SourceHealth(
+                health=ConnectorHealth(
                     status="auth_failed",
                     mode="live",
                     credential_refs=self._credential_refs(),
@@ -894,11 +894,11 @@ class TwikiCrawlSource:
             # topics' records); emit what succeeded and report the rest.
             samples = ", ".join(crawl.failed_urls[:3])
             trailer = f"; {truncation_note}" if truncation_note else ""
-            return SourceRun(
+            return ConnectorRun(
                 facts=_facts(),
                 completed_scope=False,
                 run_mode=mode,
-                health=SourceHealth(
+                health=ConnectorHealth(
                     status="endpoint_failed",
                     mode="live",
                     credential_refs=self._credential_refs(),
@@ -919,11 +919,11 @@ class TwikiCrawlSource:
             # not be claimed complete in any mode (the queued topics'
             # previously ingested records would be retracted under
             # missing_from_completed_scope).
-            return SourceRun(
+            return ConnectorRun(
                 facts=_facts(),
                 completed_scope=False,
                 run_mode=mode,
-                health=SourceHealth(
+                health=ConnectorHealth(
                     status="ok",
                     mode="live",
                     credential_refs=self._credential_refs(),
@@ -935,11 +935,11 @@ class TwikiCrawlSource:
                     ),
                 ),
             )
-        return SourceRun(
+        return ConnectorRun(
             facts=_facts(),
             completed_scope=(mode in {"scope_complete", "reconcile"}),
             run_mode=mode,
-            health=SourceHealth(
+            health=ConnectorHealth(
                 status="ok",
                 mode="live",
                 credential_refs=self._credential_refs(),

--- a/python/archi/sources/wmstats.py
+++ b/python/archi/sources/wmstats.py
@@ -64,11 +64,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Iterator
 
-from okg.substrate.library.sources.base import (
+from okg.deployment import (
     EdgeFact,
     NodeFact,
-    SourcePreflightResult,
-    SourceRun,
+    PreflightResult,
+    ConnectorRun,
 )
 
 from archi.auth.cache import (
@@ -131,7 +131,7 @@ class WMStatsWorkflowSource:
     def cache_paths(self) -> tuple[str, ...]:
         return (self.records_path,)
 
-    def preflight(self, mode: str = "live") -> SourcePreflightResult:
+    def preflight(self, mode: str = "live") -> PreflightResult:
         try:
             records = self._records()
         except FileNotFoundError:
@@ -145,7 +145,7 @@ class WMStatsWorkflowSource:
             base=self.base,
         )
 
-    def run(self, run_id: str, *, mode: str = "cursor") -> SourceRun:
+    def run(self, run_id: str, *, mode: str = "cursor") -> ConnectorRun:
         records, skipped = self._records_with_skips()
         revision = {
             "run_id": run_id,
@@ -156,7 +156,7 @@ class WMStatsWorkflowSource:
         def _facts() -> Iterator[Any]:
             yield from _facts_for_records(records, revision)
 
-        return SourceRun(
+        return ConnectorRun(
             facts=_facts(),
             completed_scope=(
                 mode in {"scope_complete", "reconcile"} and not skipped

--- a/python/tests/sources/test_cmssw.py
+++ b/python/tests/sources/test_cmssw.py
@@ -6,7 +6,7 @@ the W1 releases.map option, which now flows through the same emission
 """
 import json
 
-from okg.substrate.library.sources.base import EdgeFact, NodeFact
+from okg.deployment import EdgeFact, NodeFact
 
 from archi.sources.cmssw import CMSSWReleaseSource, parse_releases_map
 

--- a/python/tests/sources/test_conddb.py
+++ b/python/tests/sources/test_conddb.py
@@ -1,7 +1,7 @@
 """req.w2.sources-catalogs — CondDBGlobalTagSource emission, offline."""
 import json
 
-from okg.substrate.library.sources.base import EdgeFact, NodeFact
+from okg.deployment import EdgeFact, NodeFact
 
 from archi.sources.conddb import CondDBGlobalTagSource
 

--- a/python/tests/sources/test_cric.py
+++ b/python/tests/sources/test_cric.py
@@ -3,7 +3,7 @@ import json
 
 import pytest
 
-from okg.substrate.library.sources.base import EdgeFact, NodeFact
+from okg.deployment import EdgeFact, NodeFact
 
 from archi.sources.cric import CRICCoreSource, CRICSource
 

--- a/python/tests/sources/test_dbs.py
+++ b/python/tests/sources/test_dbs.py
@@ -1,7 +1,7 @@
 """req.w2.sources-catalogs — DBSDatasetSource emission, offline."""
 import json
 
-from okg.substrate.library.sources.base import EdgeFact, NodeFact
+from okg.deployment import EdgeFact, NodeFact
 
 from archi.sources.dbs import DBSDatasetSource
 

--- a/python/tests/sources/test_docs.py
+++ b/python/tests/sources/test_docs.py
@@ -6,9 +6,9 @@ from datetime import datetime, timezone
 
 import pytest
 
-from okg.substrate.library.sources.base import EdgeFact, NodeFact
-from okg.substrate.library.sources.content_hash_probe import ContentHashProbe
-from okg.substrate.library.sources.mutable_api_probe import MutableApiProbe
+from okg.deployment import EdgeFact, NodeFact
+from okg.deployment import ContentHashProbe
+from okg.deployment import MutableApiProbe
 
 import archi.sources.docs as docs_mod
 from archi.sources.docs import DocumentationSource, SSOCookieDocsSource

--- a/python/tests/sources/test_dqm.py
+++ b/python/tests/sources/test_dqm.py
@@ -1,7 +1,7 @@
 """req.w2.sources-catalogs — DQMSource emission, offline."""
 import json
 
-from okg.substrate.library.sources.base import EdgeFact, NodeFact
+from okg.deployment import EdgeFact, NodeFact
 
 from archi.sources.dqm import DQMSource
 

--- a/python/tests/sources/test_github_repos.py
+++ b/python/tests/sources/test_github_repos.py
@@ -1,5 +1,5 @@
 """req.w2.sources-catalogs — GitHubRepoSource emission, offline."""
-from okg.substrate.library.sources.base import EdgeFact, NodeFact
+from okg.deployment import EdgeFact, NodeFact
 
 from archi.sources.github_repos import DEFAULT_REPOS, GitHubRepoSource
 

--- a/python/tests/sources/test_gocdb.py
+++ b/python/tests/sources/test_gocdb.py
@@ -1,7 +1,7 @@
 """req.w2.sources-catalogs — GoCDBDowntimeSource emission, offline."""
 import json
 
-from okg.substrate.library.sources.base import EdgeFact, NodeFact
+from okg.deployment import EdgeFact, NodeFact
 
 from archi.sources.gocdb import GoCDBDowntimeSource
 

--- a/python/tests/sources/test_hypernews.py
+++ b/python/tests/sources/test_hypernews.py
@@ -2,10 +2,10 @@
 import hashlib
 import json
 
-from okg.substrate.library.sources.base import (
+from okg.deployment import (
     EdgeFact,
     NodeFact,
-    SourcePreflightResult,
+    PreflightResult,
 )
 
 from archi.sources.hypernews import HyperNewsSource
@@ -133,7 +133,7 @@ def _patch_http(monkeypatch, handler):
 
 
 def _ok_preflight(self, mode="live"):
-    return SourcePreflightResult(
+    return PreflightResult(
         source_name="hypernews", status="ok", mode="live"
     )
 

--- a/python/tests/sources/test_indico.py
+++ b/python/tests/sources/test_indico.py
@@ -2,7 +2,7 @@
 import hashlib
 import json
 
-from okg.substrate.library.sources.base import EdgeFact, NodeFact
+from okg.deployment import EdgeFact, NodeFact
 
 from archi.sources.indico import IndicoSource
 

--- a/python/tests/sources/test_jira.py
+++ b/python/tests/sources/test_jira.py
@@ -5,8 +5,8 @@ import time
 
 import pytest
 
-from okg.substrate.library.sources.base import EdgeFact, NodeFact
-from okg.substrate.library.sources.mutable_api_probe import MutableApiProbe
+from okg.deployment import EdgeFact, NodeFact
+from okg.deployment import MutableApiProbe
 
 from archi.sources.jira import (
     JiraIssueSource,

--- a/python/tests/sources/test_monit.py
+++ b/python/tests/sources/test_monit.py
@@ -11,12 +11,12 @@ import time
 
 import pytest
 
-from okg.substrate.library.sources.base import (
+from okg.deployment import (
     EdgeFact,
     NodeFact,
     ProgressMarker,
 )
-from okg.substrate.library.sources.mutable_api_probe import MutableApiProbe
+from okg.deployment import MutableApiProbe
 
 import archi.sources.monit as monit_mod
 from archi.sources.monit import (

--- a/python/tests/sources/test_siteconf.py
+++ b/python/tests/sources/test_siteconf.py
@@ -1,10 +1,10 @@
 """req.w2.sources-catalogs — SITECONFSource emission (fixture mode)."""
 import json
 
-from okg.substrate.library.sources.base import (
+from okg.deployment import (
     EdgeFact,
     NodeFact,
-    SourcePreflightResult,
+    PreflightResult,
 )
 
 from archi.sources.siteconf import SiteConfRecord, SITECONFSource
@@ -81,7 +81,7 @@ class _Resp:
 
 
 def _ok_preflight(self, mode="live"):
-    return SourcePreflightResult(
+    return PreflightResult(
         source_name="siteconf", status="ok", mode="live"
     )
 

--- a/python/tests/sources/test_twiki.py
+++ b/python/tests/sources/test_twiki.py
@@ -8,9 +8,9 @@ from datetime import datetime, timezone
 import pytest
 import requests
 
-from okg.substrate.library.sources.base import EdgeFact, NodeFact
-from okg.substrate.library.sources.content_hash_probe import ContentHashProbe
-from okg.substrate.library.sources.mutable_api_probe import MutableApiProbe
+from okg.deployment import EdgeFact, NodeFact
+from okg.deployment import ContentHashProbe
+from okg.deployment import MutableApiProbe
 
 import archi.sources.twiki as twiki_mod
 from archi.sources._twiki_parse import (

--- a/python/tests/sources/test_wmstats.py
+++ b/python/tests/sources/test_wmstats.py
@@ -1,7 +1,7 @@
 """req.w2.sources-catalogs — WMStatsWorkflowSource emission, offline."""
 import json
 
-from okg.substrate.library.sources.base import EdgeFact, NodeFact
+from okg.deployment import EdgeFact, NodeFact
 
 from archi.sources.wmstats import WMStatsWorkflowSource
 


### PR DESCRIPTION
**Stacked on #640** (now merged).

## What this changes

Archi's connectors now import from the public `okg.deployment` SDK instead of okg's private internals — with one exception that okg cannot yet support.

## Behavior before → after

**Before.** 12 names imported from five `okg.substrate.*` modules.

**After.** 11 come from the public SDK. `SourceRun` stays on substrate, because the SDK's replacement breaks ingest — see finding 1.

## Findings, worst first

1. **`ConnectorRun` cannot be returned to okg's runner, and I shipped it before finding that out.** The SDK's replacement for `SourceRun` drops `next_cursor`. okg's ingest runner reads that attribute unconditionally (`ingest/runner.py:3399`) and contains no reference to `ConnectorRun` anywhere. Every one of our connectors failed at ingest with `AttributeError: 'ConnectorRun' object has no attribute 'next_cursor'`; the source failed at stage `run`, publish continued as `deferred_incomplete`, and the generation came out at **187 nodes with `cmssw_release` absent entirely**. Backed out: `SourceRun` stays on substrate.
2. **I verified the wrong side of the boundary.** My earlier analysis confirmed *Archi* never reads the six dropped fields, across all 39 construction sites, and called it a proven drop-in. It never asked whether *okg's runner* reads them off the object we return.
3. **Unit tests cannot catch this** and stayed green — 339 passing across the broken commit. They exercise our connectors directly; the failure exists only through okg's runner. The live ingest was the only check that could find it.
4. **Everything else is safe and stands.** `NodeFact`, `EdgeFact`, `ProgressMarker`, `ContentHashProbe`, `MutableApiProbe`, `ConnectorHealth`, `PreflightResult`, `file_preflight`, `credential_preflight`, `http_preflight`, `redact` are all the *same objects* as the substrate names they replace, verified by identity. Import-path changes only.

## How I verified

Full live ingest on a fresh database against real GitHub, GitLab and cms-bot data: **2,601 nodes / 2,294 edges**, `cmssw_release` 2,414. The pre-migration baseline was 2,600 / 2,293 with 2,413 — the +1 is one new CMSSW release upstream since 2026-09-08. Suite **339 passed**; CI green.

## For okg

Finding 1 is an okg gap worth reporting on #1181: the public SDK declares a connector return type its own ingest runner cannot consume, so the connector SDK is not usable end to end. Sprint 11's closing summary records their installed connector example as having *"admitted two records but published no generation"* — the same shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Dhd8kXJLfAJjDDZHXaXds